### PR TITLE
add ch32x035

### DIFF
--- a/Core/ch32x035/core_riscv.c
+++ b/Core/ch32x035/core_riscv.c
@@ -1,0 +1,307 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : core_riscv.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : RISC-V Core Peripheral Access Layer Source File
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include <stdint.h>
+
+/* define compiler specific symbols */
+#if defined ( __CC_ARM   )
+  #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
+  #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
+
+#elif defined ( __ICCARM__ )
+  #define __ASM           __asm                                       /*!< asm keyword for IAR Compiler          */
+  #define __INLINE        inline                                      /*!< inline keyword for IAR Compiler. Only avaiable in High optimization mode! */
+
+#elif defined   (  __GNUC__  )
+  #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+
+#elif defined   (  __TASKING__  )
+  #define __ASM            __asm                                      /*!< asm keyword for TASKING Compiler      */
+  #define __INLINE         inline                                     /*!< inline keyword for TASKING Compiler   */
+
+#endif
+
+
+
+/*********************************************************************
+ * @fn      __get_MSTATUS
+ *
+ * @brief   Return the Machine Status Register
+ *
+ * @return  mstatus value
+ */
+uint32_t __get_MSTATUS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mstatus" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MSTATUS
+ *
+ * @brief   Set the Machine Status Register
+ *
+ * @param   value  - set mstatus value
+ *
+ * @return  none
+ */
+void __set_MSTATUS(uint32_t value)
+{
+  __ASM volatile ("csrw mstatus, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MISA
+ *
+ * @brief   Return the Machine ISA Register
+ *
+ * @return  misa value
+ */
+uint32_t __get_MISA(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "misa" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MISA
+ *
+ * @brief   Set the Machine ISA Register
+ *
+ * @param   value  - set misa value
+ *
+ * @return  none
+ */
+void __set_MISA(uint32_t value)
+{
+  __ASM volatile ("csrw misa, %0" : : "r" (value) );
+}
+
+
+/*********************************************************************
+ * @fn      __get_MTVEC
+ *
+ * @brief   Return the Machine Trap-Vector Base-Address Register
+ *
+ * @return  mtvec value
+ */
+uint32_t __get_MTVEC(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mtvec" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MTVEC
+ *
+ * @brief   Set the Machine Trap-Vector Base-Address Register
+ *
+ * @param   value  - set mtvec value
+ *
+ * @return  none
+ */
+void __set_MTVEC(uint32_t value)
+{
+  __ASM volatile ("csrw mtvec, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MSCRATCH
+ *
+ * @brief   Return the Machine Seratch Register
+ *
+ * @return  mscratch value
+ */
+uint32_t __get_MSCRATCH(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mscratch" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MSCRATCH
+ *
+ * @brief   Set the Machine Seratch Register
+ *
+ * @param   value  - set mscratch value
+ *
+ * @return  none
+ */
+void __set_MSCRATCH(uint32_t value)
+{
+  __ASM volatile ("csrw mscratch, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MEPC
+ *
+ * @brief   Return the Machine Exception Program Register
+ *
+ * @return  mepc value
+ */
+uint32_t __get_MEPC(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mepc" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MEPC
+ *
+ * @brief   Set the Machine Exception Program Register
+ *
+ * @return  mepc value
+ */
+void __set_MEPC(uint32_t value)
+{
+  __ASM volatile ("csrw mepc, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MCAUSE
+ *
+ * @brief   Return the Machine Cause Register
+ *
+ * @return  mcause value
+ */
+uint32_t __get_MCAUSE(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mcause" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MEPC
+ *
+ * @brief   Set the Machine Cause Register
+ *
+ * @return  mcause value
+ */
+void __set_MCAUSE(uint32_t value)
+{
+  __ASM volatile ("csrw mcause, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MTVAL
+ *
+ * @brief   Return the Machine Trap Value Register
+ *
+ * @return  mtval value
+ */
+uint32_t __get_MTVAL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mtval" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MTVAL
+ *
+ * @brief   Set the Machine Trap Value Register
+ *
+ * @return  mtval value
+ */
+void __set_MTVAL(uint32_t value)
+{
+  __ASM volatile ("csrw mtval, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MVENDORID
+ *
+ * @brief   Return Vendor ID Register
+ *
+ * @return  mvendorid value
+ */
+uint32_t __get_MVENDORID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mvendorid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_MARCHID
+ *
+ * @brief   Return Machine Architecture ID Register
+ *
+ * @return  marchid value
+ */
+uint32_t __get_MARCHID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "marchid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_MIMPID
+ *
+ * @brief   Return Machine Implementation ID Register
+ *
+ * @return  mimpid value
+ */
+uint32_t __get_MIMPID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mimpid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_MHARTID
+ *
+ * @brief   Return Hart ID Register
+ *
+ * @return  mhartid value
+ */
+uint32_t __get_MHARTID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mhartid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_SP
+ *
+ * @brief   Return SP Register
+ *
+ * @return  SP value
+ */
+uint32_t __get_SP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "mv %0," "sp" : "=r"(result) : );
+  return (result);
+}
+

--- a/Core/ch32x035/core_riscv.h
+++ b/Core/ch32x035/core_riscv.h
@@ -1,0 +1,569 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : core_riscv.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : RISC-V Core Peripheral Access Layer Header File for CH32X035
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CORE_RISCV_H__
+#define __CORE_RISCV_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* IO definitions */
+#ifdef __cplusplus
+  #define     __I     volatile                /* defines 'read only' permissions */
+#else
+  #define     __I     volatile const          /* defines 'read only' permissions */
+#endif
+#define     __O     volatile                  /* defines 'write only' permissions */
+#define     __IO    volatile                  /* defines 'read / write' permissions */
+
+/* Standard Peripheral Library old types (maintained for legacy purpose) */
+typedef __I uint64_t vuc64;  /* Read Only */
+typedef __I uint32_t vuc32;  /* Read Only */
+typedef __I uint16_t vuc16;  /* Read Only */
+typedef __I uint8_t  vuc8;   /* Read Only */
+
+typedef const uint64_t uc64; /* Read Only */
+typedef const uint32_t uc32; /* Read Only */
+typedef const uint16_t uc16; /* Read Only */
+typedef const uint8_t  uc8;  /* Read Only */
+
+typedef __I int64_t vsc64;   /* Read Only */
+typedef __I int32_t vsc32;   /* Read Only */
+typedef __I int16_t vsc16;   /* Read Only */
+typedef __I int8_t  vsc8;    /* Read Only */
+
+typedef const int64_t sc64;  /* Read Only */
+typedef const int32_t sc32;  /* Read Only */
+typedef const int16_t sc16;  /* Read Only */
+typedef const int8_t  sc8;   /* Read Only */
+
+typedef __IO uint64_t  vu64;
+typedef __IO uint32_t  vu32;
+typedef __IO uint16_t  vu16;
+typedef __IO uint8_t   vu8;
+
+typedef uint64_t  u64;
+typedef uint32_t  u32;
+typedef uint16_t  u16;
+typedef uint8_t   u8;
+
+typedef __IO int64_t  vs64;
+typedef __IO int32_t  vs32;
+typedef __IO int16_t  vs16;
+typedef __IO int8_t   vs8;
+
+typedef int64_t  s64;
+typedef int32_t  s32;
+typedef int16_t  s16;
+typedef int8_t   s8;
+
+typedef enum {NoREADY = 0, READY = !NoREADY} ErrorStatus;
+
+typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
+
+typedef enum {RESET = 0, SET = !RESET} FlagStatus, ITStatus;
+
+#define   RV_STATIC_INLINE  static  inline
+
+/* memory mapped structure for Program Fast Interrupt Controller (PFIC) */
+typedef struct{
+  __I  uint32_t ISR[8];
+  __I  uint32_t IPR[8];
+  __IO uint32_t ITHRESDR;
+  __IO uint32_t RESERVED;
+  __IO uint32_t CFGR;
+  __I  uint32_t GISR;
+  __IO uint8_t VTFIDR[4];
+  uint8_t RESERVED0[12];
+  __IO uint32_t VTFADDR[4];
+  uint8_t RESERVED1[0x90];
+  __O  uint32_t IENR[8];
+  uint8_t RESERVED2[0x60];
+  __O  uint32_t IRER[8];
+  uint8_t RESERVED3[0x60];
+  __O  uint32_t IPSR[8];
+  uint8_t RESERVED4[0x60];
+  __O  uint32_t IPRR[8];
+  uint8_t RESERVED5[0x60];
+  __IO uint32_t IACTR[8];
+  uint8_t RESERVED6[0xE0];
+  __IO uint8_t IPRIOR[256];
+  uint8_t RESERVED7[0x810];
+  __IO uint32_t SCTLR;
+}PFIC_Type;
+
+/* memory mapped structure for SysTick */
+typedef struct
+{
+    __IO u32 CTLR;
+    __IO u32 SR;
+    __IO u64 CNT;
+    __IO u64 CMP;
+}SysTick_Type;
+
+
+#define PFIC            ((PFIC_Type *) 0xE000E000 )
+#define NVIC            PFIC
+#define NVIC_KEY1       ((uint32_t)0xFA050000)
+#define	NVIC_KEY2	    ((uint32_t)0xBCAF0000)
+#define	NVIC_KEY3	    ((uint32_t)0xBEEF0000)
+#define SysTick         ((SysTick_Type *) 0xE000F000)
+
+
+/*********************************************************************
+ * @fn      __enable_irq
+ *
+ * @brief   Enable Global Interrupt
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void __enable_irq()
+{
+  __asm volatile ("csrw 0x800, %0" : : "r" (0x6088) );
+}
+
+/*********************************************************************
+ * @fn      __disable_irq
+ *
+ * @brief   Disable Global Interrupt
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void __disable_irq()
+{
+  __asm volatile ("csrw 0x800, %0" : : "r" (0x6000) );
+}
+
+/*********************************************************************
+ * @fn      __NOP
+ *
+ * @brief   nop
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void __NOP()
+{
+  __asm volatile ("nop");
+}
+
+/*********************************************************************
+ * @fn      NVIC_EnableIRQ
+ *
+ * @brief   Enable Interrupt
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  NVIC->IENR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn      NVIC_DisableIRQ
+ *
+ * @brief   Disable Interrupt
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  NVIC->IRER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn       NVIC_GetStatusIRQ
+ *
+ * @brief   Get Interrupt Enable State
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  1 - Interrupt Pending Enable
+ *          0 - Interrupt Pending Disable
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE uint32_t NVIC_GetStatusIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t) ((NVIC->ISR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+}
+
+/*********************************************************************
+ * @fn      NVIC_GetPendingIRQ
+ *
+ * @brief   Get Interrupt Pending State
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  1 - Interrupt Pending Enable
+ *          0 - Interrupt Pending Disable
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t) ((NVIC->IPR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+}
+
+/*********************************************************************
+ * @fn      NVIC_SetPendingIRQ
+ *
+ * @brief   Set Interrupt Pending
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->IPSR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn      NVIC_ClearPendingIRQ
+ *
+ * @brief   Clear Interrupt Pending
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->IPRR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn      NVIC_GetActive
+ *
+ * @brief   Get Interrupt Active State
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  1 - Interrupt Active
+ *          0 - Interrupt No Active
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE uint32_t NVIC_GetActive(IRQn_Type IRQn)
+{
+  return((uint32_t)((NVIC->IACTR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+}
+
+/*********************************************************************
+ * @fn      NVIC_SetPriority
+ *
+ * @brief   Set Interrupt Priority
+ *
+ * @param   IRQn - Interrupt Numbers
+ *                  priority: bit7 - pre-emption priority
+ *                  bit6-bit5 - subpriority
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint8_t priority)
+{
+  NVIC->IPRIOR[(uint32_t)(IRQn)] = priority;
+}
+
+/*********************************************************************
+ * @fn      __WFI
+ *
+ * @brief   Wait for Interrupt
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFI(void)
+{
+  NVIC->SCTLR &= ~(1<<3);	// wfi
+  asm volatile ("wfi");
+}
+
+/*********************************************************************
+ * @fn       _SEV
+ *
+ * @brief   Set Event
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void _SEV(void)
+{
+  uint32_t t;
+
+  t = NVIC->SCTLR;
+  NVIC->SCTLR |= (1<<3)|(1<<5);
+  NVIC->SCTLR = (NVIC->SCTLR & ~(1<<5)) | ( t & (1<<5));
+}
+
+/*********************************************************************
+ * @fn       _WFE
+ *
+ * @brief   Wait for Events
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void _WFE(void)
+{
+  NVIC->SCTLR |= (1<<3);
+  asm volatile ("wfi");
+}
+
+/*********************************************************************
+ * @fn       __WFE
+ *
+ * @brief   Wait for Events
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFE(void)
+{
+  _SEV();
+  _WFE();
+  _WFE();
+}
+
+/*********************************************************************
+ * @fn      SetVTFIRQ
+ *
+ * @brief   Set VTF Interrupt
+ *
+ * @param   addr - VTF interrupt service function base address.
+ *                  IRQn - Interrupt Numbers
+ *                  num - VTF Interrupt Numbers
+ *                  NewState -  DISABLE or ENABLE
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void SetVTFIRQ(uint32_t addr, IRQn_Type IRQn, uint8_t num, FunctionalState NewState){
+  if(num > 3)  return ;
+
+  if (NewState != DISABLE)
+  {
+      NVIC->VTFIDR[num] = IRQn;
+      NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)|0x1);
+  }
+  else{
+      NVIC->VTFIDR[num] = IRQn;
+      NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)&(~0x1));
+  }
+}
+
+/*********************************************************************
+ * @fn      NVIC_SystemReset
+ *
+ * @brief   Initiate a system reset request
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void NVIC_SystemReset(void)
+{
+  NVIC->CFGR = NVIC_KEY3|(1<<7);
+}
+
+/*********************************************************************
+ *  @fn      __AMOADD_W
+ *
+ *  @brief   Atomic Add with 32bit value
+ *           Atomically ADD 32bit value with value in memory using amoadd.d.
+ *           addr - Address pointer to data, address need to be 4byte aligned
+ *           value - value to be ADDed
+ *
+ * @return  return memory value + add value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE int32_t __AMOADD_W(volatile int32_t *addr, int32_t value)
+{
+    int32_t result;
+
+    __asm volatile ("amoadd.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/*********************************************************************
+ * @fn      __AMOAND_W
+ *
+ * @brief  Atomic And with 32bit value
+ *        Atomically AND 32bit value with value in memory using amoand.d.
+ *        addr - Address pointer to data, address need to be 4byte aligned
+ *        value - value to be ANDed
+ *
+ * @return  return memory value & and value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE int32_t __AMOAND_W(volatile int32_t *addr, int32_t value)
+{
+    int32_t result;
+
+    __asm volatile ("amoand.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/*********************************************************************
+ * @fn         __AMOMAX_W
+ *
+ * @brief      Atomic signed MAX with 32bit value
+ * @details   Atomically signed max compare 32bit value with value in memory using amomax.d.
+ *            addr - Address pointer to data, address need to be 4byte aligned
+ *            value - value to be compared
+ *
+ * @return the bigger value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE int32_t __AMOMAX_W(volatile int32_t *addr, int32_t value)
+{
+    int32_t result;
+
+    __asm volatile ("amomax.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/*********************************************************************
+ * @fn        __AMOMAXU_W
+ *
+ * @brief  Atomic unsigned MAX with 32bit value
+ *         Atomically unsigned max compare 32bit value with value in memory using amomaxu.d.
+ *         addr - Address pointer to data, address need to be 4byte aligned
+ *         value - value to be compared
+ *
+ * @return  return the bigger value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE uint32_t __AMOMAXU_W(volatile uint32_t *addr, uint32_t value)
+{
+    uint32_t result;
+
+    __asm volatile ("amomaxu.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/*********************************************************************
+ * @fn      __AMOMIN_W
+ *
+ * @brief  Atomic signed MIN with 32bit value
+ *         Atomically signed min compare 32bit value with value in memory using amomin.d.
+ *         addr - Address pointer to data, address need to be 4byte aligned
+ *         value - value to be compared
+ *
+ * @return  the smaller value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE int32_t __AMOMIN_W(volatile int32_t *addr, int32_t value)
+{
+    int32_t result;
+
+    __asm volatile ("amomin.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/*********************************************************************
+ * @fn      __AMOMINU_W
+ *
+ * @brief   Atomic unsigned MIN with 32bit value
+ *          Atomically unsigned min compare 32bit value with value in memory using amominu.d.
+ *          addr - Address pointer to data, address need to be 4byte aligned
+ *          value - value to be compared
+ *
+ * @return the smaller value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE uint32_t __AMOMINU_W(volatile uint32_t *addr, uint32_t value)
+{
+    uint32_t result;
+
+    __asm volatile ("amominu.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/*********************************************************************
+ * @fn        __AMOOR_W
+ *
+ * @brief      Atomic OR with 32bit value
+ * @details    Atomically OR 32bit value with value in memory using amoor.d.
+ *             addr - Address pointer to data, address need to be 4byte aligned
+ *             value - value to be ORed
+ *
+ * @return  return memory value | and value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE int32_t __AMOOR_W(volatile int32_t *addr, int32_t value)
+{
+    int32_t result;
+
+    __asm volatile ("amoor.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/*********************************************************************
+ * @fn       __AMOSWAP_W
+ *
+ * @brief    Atomically swap new 32bit value into memory using amoswap.d.
+ *           addr - Address pointer to data, address need to be 4byte aligned
+ *           newval - New value to be stored into the address
+ *
+ * @return    return the original value in memory
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE uint32_t __AMOSWAP_W(volatile uint32_t *addr, uint32_t newval)
+{
+    uint32_t result;
+
+    __asm volatile ("amoswap.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(newval) : "memory");
+    return result;
+}
+
+/*********************************************************************
+ * @fn      __AMOXOR_W
+ *
+ * @brief    Atomic XOR with 32bit value
+ * @details  Atomically XOR 32bit value with value in memory using amoxor.d.
+ *           addr - Address pointer to data, address need to be 4byte aligned
+ *           value - value to be XORed
+ *
+ * @return  return memory value ^ and value
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE int32_t __AMOXOR_W(volatile int32_t *addr, int32_t value)
+{
+    int32_t result;
+
+    __asm volatile ("amoxor.w %0, %2, %1" : \
+            "=r"(result), "+A"(*addr) : "r"(value) : "memory");
+    return *addr;
+}
+
+/* Core_Exported_Functions */  
+extern uint32_t __get_MSTATUS(void);
+extern void __set_MSTATUS(uint32_t value);
+extern uint32_t __get_MISA(void);
+extern void __set_MISA(uint32_t value);
+extern uint32_t __get_MTVEC(void);
+extern void __set_MTVEC(uint32_t value);
+extern uint32_t __get_MSCRATCH(void);
+extern void __set_MSCRATCH(uint32_t value);
+extern uint32_t __get_MEPC(void);
+extern void __set_MEPC(uint32_t value);
+extern uint32_t __get_MCAUSE(void);
+extern void __set_MCAUSE(uint32_t value);
+extern uint32_t __get_MTVAL(void);
+extern void __set_MTVAL(uint32_t value);
+extern uint32_t __get_MVENDORID(void);
+extern uint32_t __get_MARCHID(void);
+extern uint32_t __get_MIMPID(void);
+extern uint32_t __get_MHARTID(void);
+extern uint32_t __get_SP(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+
+
+
+

--- a/Debug/ch32x035/debug.c
+++ b/Debug/ch32x035/debug.c
@@ -1,0 +1,192 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : debug.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for UART
+ *                      Printf , Delay functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "debug.h"
+
+static uint8_t  p_us = 0;
+static uint16_t p_ms = 0;
+/*********************************************************************
+ * @fn      Delay_Init
+ *
+ * @brief   Initializes Delay Funcation.
+ *
+ * @return  none
+ */
+void Delay_Init(void)
+{
+    p_us = SystemCoreClock / 8000000;
+    p_ms = (uint16_t)p_us * 1000;
+}
+
+/*********************************************************************
+ * @fn      Delay_Us
+ *
+ * @brief   Microsecond Delay Time.
+ *
+ * @param   n - Microsecond number.
+ *
+ * @return  None
+ */
+void Delay_Us(uint32_t n)
+{
+    uint32_t i;
+
+    SysTick->SR &= ~(1 << 0);
+    i = (uint32_t)n * p_us;
+
+    SysTick->CMP = i;
+    SysTick->CTLR |= (1 << 4);
+    SysTick->CTLR |= (1 << 5) | (1 << 0);
+
+    while((SysTick->SR & (1 << 0)) != (1 << 0));
+    SysTick->CTLR &= ~(1 << 0);
+}
+
+/*********************************************************************
+ * @fn      Delay_Ms
+ *
+ * @brief   Millisecond Delay Time.
+ *
+ * @param   n - Millisecond number.
+ *
+ * @return  None
+ */
+void Delay_Ms(uint32_t n)
+{
+    uint32_t i;
+
+    SysTick->SR &= ~(1 << 0);
+    i = (uint32_t)n * p_ms;
+
+    SysTick->CMP = i;
+    SysTick->CTLR |= (1 << 4);
+    SysTick->CTLR |= (1 << 5) | (1 << 0);
+
+    while((SysTick->SR & (1 << 0)) != (1 << 0));
+    SysTick->CTLR &= ~(1 << 0);
+}
+
+/*********************************************************************
+ * @fn      USART_Printf_Init
+ *
+ * @brief   Initializes the USARTx peripheral.
+ *
+ * @param   baudrate - USART communication baud rate.
+ *
+ * @return  None
+ */
+void USART_Printf_Init(uint32_t baudrate)
+{
+    GPIO_InitTypeDef  GPIO_InitStructure;
+    USART_InitTypeDef USART_InitStructure;
+
+#if(DEBUG == DEBUG_UART1)
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1 | RCC_APB2Periph_GPIOB, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_10;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
+    GPIO_Init(GPIOB, &GPIO_InitStructure);
+
+#elif(DEBUG == DEBUG_UART2)
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, ENABLE);
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_2;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
+    GPIO_Init(GPIOA, &GPIO_InitStructure);
+
+#elif(DEBUG == DEBUG_UART3)
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART3, ENABLE);
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_3;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
+    GPIO_Init(GPIOB, &GPIO_InitStructure);
+
+#endif
+
+    USART_InitStructure.USART_BaudRate = baudrate;
+    USART_InitStructure.USART_WordLength = USART_WordLength_8b;
+    USART_InitStructure.USART_StopBits = USART_StopBits_1;
+    USART_InitStructure.USART_Parity = USART_Parity_No;
+    USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+    USART_InitStructure.USART_Mode = USART_Mode_Tx;
+
+#if(DEBUG == DEBUG_UART1)
+    USART_Init(USART1, &USART_InitStructure);
+    USART_Cmd(USART1, ENABLE);
+
+#elif(DEBUG == DEBUG_UART2)
+    USART_Init(USART2, &USART_InitStructure);
+    USART_Cmd(USART2, ENABLE);
+
+#elif(DEBUG == DEBUG_UART3)
+    USART_Init(USART3, &USART_InitStructure);
+    USART_Cmd(USART3, ENABLE);
+
+#endif
+}
+
+/*********************************************************************
+ * @fn      _write
+ *
+ * @brief   Support Printf Function
+ *
+ * @param   *buf - UART send Data.
+ *          size - Data length
+ *
+ * @return  size - Data length
+ */
+__attribute__((used))
+int _write(int fd, char *buf, int size)
+{
+    int i;
+
+    for(i = 0; i < size; i++){
+#if(DEBUG == DEBUG_UART1)
+        while(USART_GetFlagStatus(USART1, USART_FLAG_TC) == RESET);
+        USART_SendData(USART1, *buf++);
+#elif(DEBUG == DEBUG_UART2)
+        while(USART_GetFlagStatus(USART2, USART_FLAG_TC) == RESET);
+        USART_SendData(USART2, *buf++);
+#elif(DEBUG == DEBUG_UART3)
+        while(USART_GetFlagStatus(USART3, USART_FLAG_TC) == RESET);
+        USART_SendData(USART3, *buf++);
+#endif
+    }
+
+    return size;
+}
+
+/*********************************************************************
+ * @fn      _sbrk
+ *
+ * @brief   Change the spatial position of data segment.
+ *
+ * @return  size - Data length
+ */
+__attribute__((used))
+void *_sbrk(ptrdiff_t incr)
+{
+    extern char _end[];
+    extern char _heap_end[];
+    static char *curbrk = _end;
+
+    if ((curbrk + incr < _end) || (curbrk + incr > _heap_end))
+    return NULL - 1;
+
+    curbrk += incr;
+    return curbrk - incr;
+}

--- a/Debug/ch32x035/debug.h
+++ b/Debug/ch32x035/debug.h
@@ -1,0 +1,48 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : debug.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for UART
+ *                      Printf , Delay functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __DEBUG_H
+#define __DEBUG_H
+
+#include "stdio.h"
+#include "ch32x035.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* UART Printf Definition */
+#define DEBUG_UART1    1
+#define DEBUG_UART2    2
+#define DEBUG_UART3    3
+
+/* DEBUG UATR Definition */
+#ifndef DEBUG
+#define DEBUG   DEBUG_UART2
+#endif
+
+void Delay_Init(void);
+void Delay_Us(uint32_t n);
+void Delay_Ms(uint32_t n);
+void USART_Printf_Init(uint32_t baudrate);
+
+#if(DEBUG)
+  #define PRINT(format, ...)    printf(format, ##__VA_ARGS__)
+#else
+  #define PRINT(X...)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035.h
+++ b/Peripheral/ch32x035/inc/ch32x035.h
@@ -1,0 +1,2779 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : CH32X035 Device Peripheral Access Layer Header File.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_H
+#define __CH32X035_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define __MPU_PRESENT             0                   /* Other CH32 devices does not provide an MPU */
+#define __Vendor_SysTickConfig    0                   /* Set to 1 if different SysTick Config is used */
+
+#define HSI_VALUE              ((uint32_t)48000000) /* Value of the Internal oscillator in Hz */
+
+/* Standard Peripheral Library version number */
+#define __STDPERIPH_VERSION_MAIN   (0x01) /* [15:8] main version */
+#define __STDPERIPH_VERSION_SUB    (0x00) /* [7:0] sub version */
+#define __STDPERIPH_VERSION        ((__STDPERIPH_VERSION_MAIN << 8)\
+                                    |(__STDPERIPH_VERSION_SUB << 0))
+
+
+/* Interrupt Number Definition, according to the selected device */
+typedef enum IRQn
+{
+    /******  RISC-V Processor Exceptions Numbers *******************************************************/
+    NonMaskableInt_IRQn = 2,   /* 2 Non Maskable Interrupt                             */
+    EXC_IRQn = 3,              /* 3 Exception Interrupt                                */
+    Ecall_M_Mode_IRQn = 5,     /* 5 Ecall M Mode Interrupt                             */
+    Ecall_U_Mode_IRQn = 8,     /* 8 Ecall U Mode Interrupt                             */
+    Break_Point_IRQn = 9,      /* 9 Break Point Interrupt                              */
+    SysTicK_IRQn = 12,         /* 12 System timer Interrupt                            */
+    Software_IRQn = 14,        /* 14 software Interrupt                                */
+
+    /******  RISC-V specific Interrupt Numbers *********************************************************/
+    WWDG_IRQn = 16,            /* Window WatchDog Interrupt                            */
+    PVD_IRQn = 17,             /* PVD through EXTI Line detection Interrupt            */
+    FLASH_IRQn = 18,           /* FLASH global Interrupt                               */
+    EXTI7_0_IRQn = 20,         /* External Line[7:0] Interrupts                        */
+    AWU_IRQn = 21,             /* AWU global Interrupt                                 */
+    DMA1_Channel1_IRQn = 22,   /* DMA1 Channel 1 global Interrupt                      */
+    DMA1_Channel2_IRQn = 23,   /* DMA1 Channel 2 global Interrupt                      */
+    DMA1_Channel3_IRQn = 24,   /* DMA1 Channel 3 global Interrupt                      */
+    DMA1_Channel4_IRQn = 25,   /* DMA1 Channel 4 global Interrupt                      */
+    DMA1_Channel5_IRQn = 26,   /* DMA1 Channel 5 global Interrupt                      */
+    DMA1_Channel6_IRQn = 27,   /* DMA1 Channel 6 global Interrupt                      */
+    DMA1_Channel7_IRQn = 28,   /* DMA1 Channel 7 global Interrupt                      */
+    ADC1_IRQn = 29,            /* ADC1 global Interrupt                                */
+    I2C1_EV_IRQn = 30,         /* I2C1 Event Interrupt                                 */
+    I2C1_ER_IRQn = 31,         /* I2C1 Error Interrupt                                 */
+    USART1_IRQn = 32,          /* USART1 global Interrupt                              */
+    SPI1_IRQn = 33,            /* SPI1 global Interrupt                                */
+    TIM1_BRK_IRQn = 34,        /* TIM1 Break Interrupt                                 */
+    TIM1_UP_IRQn = 35,         /* TIM1 Update Interrupt                                */
+    TIM1_TRG_COM_IRQn = 36,    /* TIM1 Trigger and Commutation Interrupt               */
+    TIM1_CC_IRQn = 37,         /* TIM1 Capture Compare Interrupt                       */
+    TIM2_UP_IRQn = 38,         /* TIM2 Update Interrupt                                */
+    USART2_IRQn = 39,          /* USART2 global Interrupt                              */
+    EXTI15_8_IRQn = 40,        /* External Line[15:8] Interrupts                       */
+    EXTI25_16_IRQn = 41,       /* External Line[25:16] Interrupts                      */
+    USART3_IRQn = 42,          /* USART3 global Interrupt                              */
+    USART4_IRQn = 43,          /* USART4 global Interrupt                              */
+    DMA1_Channel8_IRQn = 44,   /* DMA1 Channel 8 global Interrupt                      */
+    USBFS_IRQn = 45,           /* USBFS Host/Device global Interrupt                   */
+    USBFSWakeUp_IRQn = 46,     /* USBFS Host/Device WakeUp Interrupt                   */
+    PIOC_IRQn = 47,            /* PIOC global Interrupt                                */
+    OPA_IRQn = 48,             /* OPA global Interrupt                                 */
+    USBPD_IRQn = 49,           /* USBPD global Interrupt                               */
+    USBPDWakeUp_IRQn = 50,     /* USBPD WakeUp Interrupt                               */
+    TIM2_CC_IRQn = 51,         /* TIM2 Capture Compare Interrupt                       */
+    TIM2_TRG_COM_IRQn = 52,    /* TIM2 Trigger and Commutation Interrupt               */
+    TIM2_BRK_IRQn = 53,        /* TIM2 Break Interrupt                                 */
+    TIM3_IRQn = 54,            /* TIM3 global Interrupt                                */
+} IRQn_Type;
+
+#define HardFault_IRQn    EXC_IRQn
+
+#include <stdint.h>
+#include "core_riscv.h"
+#include "system_ch32x035.h"
+
+/* Standard Peripheral Library old definitions (maintained for legacy purpose) */
+#define HSI_Value             HSI_VALUE
+
+/* Analog to Digital Converter */
+typedef struct
+{
+    __IO uint32_t STATR;
+    __IO uint32_t CTLR1;
+    __IO uint32_t CTLR2;
+    __IO uint32_t SAMPTR1;
+    __IO uint32_t SAMPTR2;
+    __IO uint32_t IOFR1;
+    __IO uint32_t IOFR2;
+    __IO uint32_t IOFR3;
+    __IO uint32_t IOFR4;
+    __IO uint32_t WDHTR;
+    __IO uint32_t WDLTR;
+    __IO uint32_t RSQR1;
+    __IO uint32_t RSQR2;
+    __IO uint32_t RSQR3;
+    __IO uint32_t ISQR;
+    __IO uint32_t IDATAR1;
+    __IO uint32_t IDATAR2;
+    __IO uint32_t IDATAR3;
+    __IO uint32_t IDATAR4;
+    __IO uint32_t RDATAR;
+    __IO uint32_t CTLR3;
+    __IO uint32_t WDTR1;
+    __IO uint32_t WDTR2;
+    __IO uint32_t WDTR3;
+} ADC_TypeDef;
+
+/* DMA Channel Controller */
+typedef struct
+{
+    __IO uint32_t CFGR;
+    __IO uint32_t CNTR;
+    __IO uint32_t PADDR;
+    __IO uint32_t MADDR;
+} DMA_Channel_TypeDef;
+
+/* DMA Controller */
+typedef struct
+{
+    __IO uint32_t INTFR;
+    __IO uint32_t INTFCR;
+} DMA_TypeDef;
+
+/* External Interrupt/Event Controller */
+typedef struct
+{
+    __IO uint32_t INTENR;
+    __IO uint32_t EVENR;
+    __IO uint32_t RTENR;
+    __IO uint32_t FTENR;
+    __IO uint32_t SWIEVR;
+    __IO uint32_t INTFR;
+} EXTI_TypeDef;
+
+/* FLASH Registers */
+typedef struct
+{
+    __IO uint32_t ACTLR;
+    __IO uint32_t KEYR;
+    __IO uint32_t OBKEYR;
+    __IO uint32_t STATR;
+    __IO uint32_t CTLR;
+    __IO uint32_t ADDR;
+    uint32_t      RESERVED;
+    __IO uint32_t OBR;
+    __IO uint32_t WPR;
+    __IO uint32_t MODEKEYR;
+    __IO uint32_t BOOT_MODEKEYR;
+} FLASH_TypeDef;
+
+/* Option Bytes Registers */
+typedef struct
+{
+    __IO uint16_t RDPR;
+    __IO uint16_t USER;
+    __IO uint16_t Data0;
+    __IO uint16_t Data1;
+    __IO uint16_t WRPR0;
+    __IO uint16_t WRPR1;
+    __IO uint16_t WRPR2;
+    __IO uint16_t WRPR3;
+} OB_TypeDef;
+
+/* General Purpose I/O */
+typedef struct
+{
+    __IO uint32_t CFGLR;
+    __IO uint32_t CFGHR;
+    __IO uint32_t INDR;
+    __IO uint32_t OUTDR;
+    __IO uint32_t BSHR;
+    __IO uint32_t BCR;
+    __IO uint32_t LCKR;
+    __IO uint32_t CFGXR;
+    __IO uint32_t BSXR;
+} GPIO_TypeDef;
+
+/* Alternate Function I/O */
+typedef struct
+{
+    uint32_t      RESERVED0;
+    __IO uint32_t PCFR1;
+    __IO uint32_t EXTICR[2];
+    uint32_t      RESERVED1;
+    uint32_t      RESERVED2;
+    __IO uint32_t CTLR;
+} AFIO_TypeDef;
+
+/* Inter Integrated Circuit Interface */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t OADDR1;
+    uint16_t      RESERVED2;
+    __IO uint16_t OADDR2;
+    uint16_t      RESERVED3;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED4;
+    __IO uint16_t STAR1;
+    uint16_t      RESERVED5;
+    __IO uint16_t STAR2;
+    uint16_t      RESERVED6;
+    __IO uint16_t CKCFGR;
+    uint16_t      RESERVED7;
+} I2C_TypeDef;
+
+/* Independent WatchDog */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t PSCR;
+    __IO uint32_t RLDR;
+    __IO uint32_t STATR;
+} IWDG_TypeDef;
+
+/* Power Control */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CSR;
+} PWR_TypeDef;
+
+/* Reset and Clock Control */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CFGR0;
+    __IO uint32_t RESERVED0;
+    __IO uint32_t APB2PRSTR;
+    __IO uint32_t APB1PRSTR;
+    __IO uint32_t AHBPCENR;
+    __IO uint32_t APB2PCENR;
+    __IO uint32_t APB1PCENR;
+    __IO uint32_t RESERVED1;
+    __IO uint32_t RSTSCKR;
+    __IO uint32_t AHBRSTR;
+} RCC_TypeDef;
+
+/* Serial Peripheral Interface */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t STATR;
+    uint16_t      RESERVED2;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED3;
+    __IO uint16_t CRCR;
+    uint16_t      RESERVED4;
+    __IO uint16_t RCRCR;
+    uint16_t      RESERVED5;
+    __IO uint16_t TCRCR;
+    uint16_t      RESERVED6;
+    uint32_t      RESERVED7;
+    uint32_t      RESERVED8;
+    __IO uint16_t HSCR;
+    uint16_t      RESERVED9;
+} SPI_TypeDef;
+
+/* TIM */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t SMCFGR;
+    uint16_t      RESERVED2;
+    __IO uint16_t DMAINTENR;
+    uint16_t      RESERVED3;
+    __IO uint16_t INTFR;
+    uint16_t      RESERVED4;
+    __IO uint16_t SWEVGR;
+    uint16_t      RESERVED5;
+    __IO uint16_t CHCTLR1;
+    uint16_t      RESERVED6;
+    __IO uint16_t CHCTLR2;
+    uint16_t      RESERVED7;
+    __IO uint16_t CCER;
+    uint16_t      RESERVED8;
+    __IO uint16_t CNT;
+    uint16_t      RESERVED9;
+    __IO uint16_t PSC;
+    uint16_t      RESERVED10;
+    __IO uint16_t ATRLR;
+    uint16_t      RESERVED11;
+    __IO uint16_t RPTCR;
+    uint16_t      RESERVED12;
+    __IO uint16_t CH1CVR;
+    uint16_t      RESERVED13;
+    __IO uint16_t CH2CVR;
+    uint16_t      RESERVED14;
+    __IO uint16_t CH3CVR;
+    uint16_t      RESERVED15;
+    __IO uint16_t CH4CVR;
+    uint16_t      RESERVED16;
+    __IO uint16_t BDTR;
+    uint16_t      RESERVED17;
+    __IO uint16_t DMACFGR;
+    uint16_t      RESERVED18;
+    __IO uint16_t DMAADR;
+    uint16_t      RESERVED19;
+    __IO uint16_t SPEC;
+    uint16_t      RESERVED20;
+} TIM_TypeDef;
+
+/* Universal Synchronous Asynchronous Receiver Transmitter */
+typedef struct
+{
+    __IO uint16_t STATR;
+    uint16_t      RESERVED0;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED1;
+    __IO uint16_t BRR;
+    uint16_t      RESERVED2;
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED3;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED4;
+    __IO uint16_t CTLR3;
+    uint16_t      RESERVED5;
+    __IO uint16_t GPR;
+    uint16_t      RESERVED6;
+} USART_TypeDef;
+
+/* Window WatchDog */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CFGR;
+    __IO uint32_t STATR;
+} WWDG_TypeDef;
+
+/* OPA Registers */
+typedef struct
+{
+    __IO uint16_t CFGR1;
+    __IO uint16_t CFGR2;
+    __IO uint32_t CTLR1;
+    __IO uint32_t CTLR2;
+    __IO uint32_t OPAKEY;
+    __IO uint32_t CMPKEY;
+    __IO uint32_t POLLKEY;
+} OPA_TypeDef;
+
+/* AWU Registers */
+typedef struct
+{
+    __IO uint32_t CSR;
+    __IO uint32_t WR;
+    __IO uint32_t PSC;
+} AWU_TypeDef;
+
+/* PD Registers */
+
+typedef struct
+{
+    union
+    {
+        __IO uint32_t USBPD_CONFIG;
+        struct
+        {
+            __IO uint16_t CONFIG;
+            __IO uint16_t BMC_CLK_CNT;
+        };
+    };
+    union
+    {
+        __IO uint32_t USBPD_CONTROL;
+        struct
+        {
+            union
+            {
+                __IO uint16_t R16_CONTROL;
+                struct
+                {
+                    __IO uint8_t  CONTROL;
+                    __IO uint8_t  TX_SEL;
+                };
+            };
+            __IO uint16_t BMC_TX_SZ;
+        };
+    };
+    union
+    {
+        __IO uint32_t USBPD_STATUS;
+        struct
+        {
+            union
+            {
+                __IO uint16_t R16_STATUS;
+                struct
+                {
+                    __IO uint8_t  DATA_BUF;
+                    __IO uint8_t  STATUS;
+                };
+            };
+            __IO uint16_t BMC_BYTE_CNT;
+        };
+    };
+    union
+    {
+        __IO uint32_t USBPD_PORT;
+        struct
+        {
+            __IO uint16_t PORT_CC1;
+            __IO uint16_t PORT_CC2;
+        };
+    };
+    union
+    {
+        __IO uint32_t USBPD_DMA;
+        struct
+        {
+            __IO uint16_t DMA;
+            __IO uint16_t RESERVED;
+        };
+    };
+} USBPD_TypeDef;
+
+/* USBFS Registers */
+typedef struct
+{
+    __IO uint8_t  BASE_CTRL;
+    __IO uint8_t  UDEV_CTRL;
+    __IO uint8_t  INT_EN;
+    __IO uint8_t  DEV_ADDR;
+    uint8_t       RESERVED0;
+    __IO uint8_t  MIS_ST;
+    __IO uint8_t  INT_FG;
+    __IO uint8_t  INT_ST;
+    __IO uint32_t RX_LEN;
+    __IO uint8_t  UEP4_1_MOD;
+    __IO uint8_t  UEP2_3_MOD;
+    __IO uint8_t  UEP567_MOD;
+    uint8_t       RESERVED1;
+    __IO uint32_t UEP0_DMA;
+    __IO uint32_t UEP1_DMA;
+    __IO uint32_t UEP2_DMA;
+    __IO uint32_t UEP3_DMA;
+    union{
+        __IO uint32_t  UEP0_CTRL;
+        struct{
+            __IO uint16_t  UEP0_TX_LEN;
+            __IO uint16_t  UEP0_CTRL_H;
+        };
+    };
+    union{
+        __IO uint32_t  UEP1_CTRL;
+        struct{
+            __IO uint16_t  UEP1_TX_LEN;
+            __IO uint16_t  UEP1_CTRL_H;
+        };
+    };
+    union{
+        __IO uint32_t  UEP2_CTRL;
+        struct{
+            __IO uint16_t  UEP2_TX_LEN;
+            __IO uint16_t  UEP2_CTRL_H;
+        };
+    };
+    union{
+        __IO uint32_t  UEP3_CTRL;
+        struct{
+            __IO uint16_t  UEP3_TX_LEN;
+            __IO uint16_t  UEP3_CTRL_H;
+        };
+    };
+    union{
+        __IO uint32_t  UEP4_CTRL;
+        struct{
+            __IO uint16_t  UEP4_TX_LEN;
+            __IO uint16_t  UEP4_CTRL_H;
+        };
+    };
+    uint32_t      RESERVED2;
+    uint32_t      RESERVED3;
+    uint32_t      RESERVED4;
+    uint32_t      RESERVED5;
+    uint32_t      RESERVED6;
+    uint32_t      RESERVED7;
+    uint32_t      RESERVED8;
+    uint32_t      RESERVED9;
+    __IO uint32_t UEP5_DMA;
+    __IO uint32_t UEP6_DMA;
+    __IO uint32_t UEP7_DMA;
+    uint32_t      RESERVED10;
+    union{
+        __IO uint32_t  UEP5_CTRL;
+        struct{
+            __IO uint16_t  UEP5_TX_LEN;
+            __IO uint16_t  UEP5_CTRL_H;
+        };
+    };
+    union{
+        __IO uint32_t  UEP6_CTRL;
+        struct{
+            __IO uint16_t  UEP6_TX_LEN;
+            __IO uint16_t  UEP6_CTRL_H;
+        };
+    };
+    union{
+        __IO uint32_t  UEP7_CTRL;
+        struct{
+            __IO uint16_t  UEP7_TX_LEN;
+            __IO uint16_t  UEP7_CTRL_H;
+        };
+    };
+    __IO uint32_t UEPX_MOD;
+} USBFSD_TypeDef;
+
+typedef struct
+{
+    __IO uint8_t   BASE_CTRL;
+    __IO uint8_t   HOST_CTRL;
+    __IO uint8_t   INT_EN;
+    __IO uint8_t   DEV_ADDR;
+    uint8_t        RESERVED0;
+    __IO uint8_t   MIS_ST;
+    __IO uint8_t   INT_FG;
+    __IO uint8_t   INT_ST;
+    __IO uint16_t  RX_LEN;
+    uint16_t       RESERVED1;
+    uint8_t        RESERVED2;
+    __IO uint8_t   HOST_EP_MOD;
+    uint16_t       RESERVED3;
+    uint32_t       RESERVED4;
+    uint32_t       RESERVED5;
+    __IO uint16_t  HOST_RX_DMA;
+    uint16_t       RESERVED6;
+    __IO uint16_t  HOST_TX_DMA;
+    uint16_t       RESERVED7;
+    uint32_t       RESERVED8;
+    uint16_t       RESERVED9;
+    __IO uint8_t   HOST_SETUP;
+    uint8_t        RESERVED10;
+    __IO uint8_t   HOST_EP_PID;
+    uint8_t        RESERVED11;
+    __IO uint8_t   HOST_RX_CTRL;
+    uint8_t        RESERVED12;
+    __IO uint8_t   HOST_TX_LEN;
+    uint8_t        RESERVED13;
+    __IO uint8_t   HOST_TX_CTRL;
+    uint8_t        RESERVED14;
+} USBFSH_TypeDef;
+
+/* Peripheral memory map */
+#define FLASH_BASE                              ((uint32_t)0x08000000) /* FLASH base address in the alias region */
+#define SRAM_BASE                               ((uint32_t)0x20000000) /* SRAM base address in the alias region */
+#define PERIPH_BASE                             ((uint32_t)0x40000000) /* Peripheral base address in the alias region */
+
+#define APB1PERIPH_BASE                         (PERIPH_BASE)
+#define APB2PERIPH_BASE                         (PERIPH_BASE + 0x10000)
+#define AHBPERIPH_BASE                          (PERIPH_BASE + 0x20000)
+
+#define TIM2_BASE                               (APB1PERIPH_BASE + 0x0000)
+#define TIM3_BASE                               (APB1PERIPH_BASE + 0x0400)
+#define WWDG_BASE                               (APB1PERIPH_BASE + 0x2C00)
+#define IWDG_BASE                               (APB1PERIPH_BASE + 0x3000)
+#define USART2_BASE                             (APB1PERIPH_BASE + 0x4400)
+#define USART3_BASE                             (APB1PERIPH_BASE + 0x4800)
+#define USART4_BASE                             (APB1PERIPH_BASE + 0x4C00)
+#define I2C1_BASE                               (APB1PERIPH_BASE + 0x5400)
+#define PWR_BASE                                (APB1PERIPH_BASE + 0x7000)
+
+#define AFIO_BASE                               (APB2PERIPH_BASE + 0x0000)
+#define EXTI_BASE                               (APB2PERIPH_BASE + 0x0400)
+#define GPIOA_BASE                              (APB2PERIPH_BASE + 0x0800)
+#define GPIOB_BASE                              (APB2PERIPH_BASE + 0x0C00)
+#define GPIOC_BASE                              (APB2PERIPH_BASE + 0x1000)
+#define ADC1_BASE                               (APB2PERIPH_BASE + 0x2400)
+#define TIM1_BASE                               (APB2PERIPH_BASE + 0x2C00)
+#define SPI1_BASE                               (APB2PERIPH_BASE + 0x3000)
+#define USART1_BASE                             (APB2PERIPH_BASE + 0x3800)
+
+#define DMA1_BASE                               (AHBPERIPH_BASE + 0x0000)
+#define DMA1_Channel1_BASE                      (AHBPERIPH_BASE + 0x0008)
+#define DMA1_Channel2_BASE                      (AHBPERIPH_BASE + 0x001C)
+#define DMA1_Channel3_BASE                      (AHBPERIPH_BASE + 0x0030)
+#define DMA1_Channel4_BASE                      (AHBPERIPH_BASE + 0x0044)
+#define DMA1_Channel5_BASE                      (AHBPERIPH_BASE + 0x0058)
+#define DMA1_Channel6_BASE                      (AHBPERIPH_BASE + 0x006C)
+#define DMA1_Channel7_BASE                      (AHBPERIPH_BASE + 0x0080)
+#define DMA1_Channel8_BASE                      (AHBPERIPH_BASE + 0x0094)
+#define RCC_BASE                                (AHBPERIPH_BASE + 0x1000)
+#define FLASH_R_BASE                            (AHBPERIPH_BASE + 0x2000)
+#define USBFS_BASE                              (AHBPERIPH_BASE + 0x3400)
+#define OPA_BASE                                (AHBPERIPH_BASE + 0x6000)
+#define AWU_BASE                                (AHBPERIPH_BASE + 0x6400)
+#define PIOC_BASE                               (AHBPERIPH_BASE + 0x6C00)
+#define USBPD_BASE                              (AHBPERIPH_BASE + 0x7000)
+
+#define OB_BASE                                 ((uint32_t)0x1FFFF800)
+
+/* Peripheral declaration */
+#define TIM2                                    ((TIM_TypeDef *)TIM2_BASE)
+#define TIM3                                    ((TIM_TypeDef *)TIM3_BASE)
+#define WWDG                                    ((WWDG_TypeDef *)WWDG_BASE)
+#define IWDG                                    ((IWDG_TypeDef *)IWDG_BASE)
+#define USART2                                  ((USART_TypeDef *)USART2_BASE)
+#define USART3                                  ((USART_TypeDef *)USART3_BASE)
+#define USART4                                  ((USART_TypeDef *)USART4_BASE)
+#define I2C1                                    ((I2C_TypeDef *)I2C1_BASE)
+#define PWR                                     ((PWR_TypeDef *)PWR_BASE)
+
+#define AFIO                                    ((AFIO_TypeDef *)AFIO_BASE)
+#define EXTI                                    ((EXTI_TypeDef *)EXTI_BASE)
+#define GPIOA                                   ((GPIO_TypeDef *)GPIOA_BASE)
+#define GPIOB                                   ((GPIO_TypeDef *)GPIOB_BASE)
+#define GPIOC                                   ((GPIO_TypeDef *)GPIOC_BASE)
+#define ADC1                                    ((ADC_TypeDef *)ADC1_BASE)
+#define TKey1                                   ((ADC_TypeDef *)ADC1_BASE)
+#define TIM1                                    ((TIM_TypeDef *)TIM1_BASE)
+#define SPI1                                    ((SPI_TypeDef *)SPI1_BASE)
+#define USART1                                  ((USART_TypeDef *)USART1_BASE)
+
+#define DMA1                                    ((DMA_TypeDef *)DMA1_BASE)
+#define DMA1_Channel1                           ((DMA_Channel_TypeDef *)DMA1_Channel1_BASE)
+#define DMA1_Channel2                           ((DMA_Channel_TypeDef *)DMA1_Channel2_BASE)
+#define DMA1_Channel3                           ((DMA_Channel_TypeDef *)DMA1_Channel3_BASE)
+#define DMA1_Channel4                           ((DMA_Channel_TypeDef *)DMA1_Channel4_BASE)
+#define DMA1_Channel5                           ((DMA_Channel_TypeDef *)DMA1_Channel5_BASE)
+#define DMA1_Channel6                           ((DMA_Channel_TypeDef *)DMA1_Channel6_BASE)
+#define DMA1_Channel7                           ((DMA_Channel_TypeDef *)DMA1_Channel7_BASE)
+#define DMA1_Channel8                           ((DMA_Channel_TypeDef *)DMA1_Channel8_BASE)
+#define RCC                                     ((RCC_TypeDef *)RCC_BASE)
+#define FLASH                                   ((FLASH_TypeDef *)FLASH_R_BASE)
+#define USBFSD                                  ((USBFSD_TypeDef *)USBFS_BASE)
+#define USBFSH                                  ((USBFSH_TypeDef *)USBFS_BASE)
+#define OPA                                     ((OPA_TypeDef *)OPA_BASE)
+#define AWU                                     ((AWU_TypeDef *)AWU_BASE)
+#define USBPD                                   ((USBPD_TypeDef *)USBPD_BASE)
+
+#define OB                                      ((OB_TypeDef *)OB_BASE)
+
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                        Analog to Digital Converter                         */
+/******************************************************************************/
+
+/********************  Bit definition for ADC_STATR register  ********************/
+#define ADC_AWD                                 ((uint8_t)0x01) /* Analog watchdog flag */
+#define ADC_EOC                                 ((uint8_t)0x02) /* End of conversion */
+#define ADC_JEOC                                ((uint8_t)0x04) /* Injected channel end of conversion */
+#define ADC_JSTRT                               ((uint8_t)0x08) /* Injected channel Start flag */
+#define ADC_STRT                                ((uint8_t)0x10) /* Regular channel Start flag */
+
+/*******************  Bit definition for ADC_CTLR1 register  ********************/
+#define ADC_AWDCH                               ((uint32_t)0x0000001F) /* AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define ADC_AWDCH_0                             ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_AWDCH_1                             ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_AWDCH_2                             ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_AWDCH_3                             ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_AWDCH_4                             ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_EOCIE                               ((uint32_t)0x00000020) /* Interrupt enable for EOC */
+#define ADC_AWDIE                               ((uint32_t)0x00000040) /* Analog Watchdog interrupt enable */
+#define ADC_JEOCIE                              ((uint32_t)0x00000080) /* Interrupt enable for injected channels */
+#define ADC_SCAN                                ((uint32_t)0x00000100) /* Scan mode */
+#define ADC_AWDSGL                              ((uint32_t)0x00000200) /* Enable the watchdog on a single channel in scan mode */
+#define ADC_JAUTO                               ((uint32_t)0x00000400) /* Automatic injected group conversion */
+#define ADC_DISCEN                              ((uint32_t)0x00000800) /* Discontinuous mode on regular channels */
+#define ADC_JDISCEN                             ((uint32_t)0x00001000) /* Discontinuous mode on injected channels */
+
+#define ADC_DISCNUM                             ((uint32_t)0x0000E000) /* DISCNUM[2:0] bits (Discontinuous mode channel count) */
+#define ADC_DISCNUM_0                           ((uint32_t)0x00002000) /* Bit 0 */
+#define ADC_DISCNUM_1                           ((uint32_t)0x00004000) /* Bit 1 */
+#define ADC_DISCNUM_2                           ((uint32_t)0x00008000) /* Bit 2 */
+
+#define ADC_DUALMOD                             ((uint32_t)0x000F0000) /* DUALMOD[3:0] bits (Dual mode selection) */
+#define ADC_DUALMOD_0                           ((uint32_t)0x00010000) /* Bit 0 */
+#define ADC_DUALMOD_1                           ((uint32_t)0x00020000) /* Bit 1 */
+#define ADC_DUALMOD_2                           ((uint32_t)0x00040000) /* Bit 2 */
+#define ADC_DUALMOD_3                           ((uint32_t)0x00080000) /* Bit 3 */
+
+#define ADC_JAWDEN                              ((uint32_t)0x00400000) /* Analog watchdog enable on injected channels */
+#define ADC_AWDEN                               ((uint32_t)0x00800000) /* Analog watchdog enable on regular channels */
+
+/*******************  Bit definition for ADC_CTLR2 register  ********************/
+#define ADC_ADON                                ((uint32_t)0x00000001) /* A/D Converter ON / OFF */
+#define ADC_CONT                                ((uint32_t)0x00000002) /* Continuous Conversion */
+#define ADC_CAL                                 ((uint32_t)0x00000004) /* A/D Calibration */
+#define ADC_RSTCAL                              ((uint32_t)0x00000008) /* Reset Calibration */
+#define ADC_DMA                                 ((uint32_t)0x00000100) /* Direct Memory access mode */
+#define ADC_ALIGN                               ((uint32_t)0x00000800) /* Data Alignment */
+
+#define ADC_JEXTSEL                             ((uint32_t)0x00007000) /* JEXTSEL[2:0] bits (External event select for injected group) */
+#define ADC_JEXTSEL_0                           ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_JEXTSEL_1                           ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_JEXTSEL_2                           ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_JEXTTRIG                            ((uint32_t)0x00008000) /* External Trigger Conversion mode for injected channels */
+
+#define ADC_EXTSEL                              ((uint32_t)0x000E0000) /* EXTSEL[2:0] bits (External Event Select for regular group) */
+#define ADC_EXTSEL_0                            ((uint32_t)0x00020000) /* Bit 0 */
+#define ADC_EXTSEL_1                            ((uint32_t)0x00040000) /* Bit 1 */
+#define ADC_EXTSEL_2                            ((uint32_t)0x00080000) /* Bit 2 */
+
+#define ADC_EXTTRIG                             ((uint32_t)0x00100000) /* External Trigger Conversion mode for regular channels */
+#define ADC_JSWSTART                            ((uint32_t)0x00200000) /* Start Conversion of injected channels */
+#define ADC_SWSTART                             ((uint32_t)0x00400000) /* Start Conversion of regular channels */
+#define ADC_TSVREFE                             ((uint32_t)0x00800000) /* Temperature Sensor and VREFINT Enable */
+
+/******************  Bit definition for ADC_SAMPTR1 register  *******************/
+#define ADC_SMP10                               ((uint32_t)0x00000007) /* SMP10[2:0] bits (Channel 10 Sample time selection) */
+#define ADC_SMP10_0                             ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SMP10_1                             ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SMP10_2                             ((uint32_t)0x00000004) /* Bit 2 */
+
+#define ADC_SMP11                               ((uint32_t)0x00000038) /* SMP11[2:0] bits (Channel 11 Sample time selection) */
+#define ADC_SMP11_0                             ((uint32_t)0x00000008) /* Bit 0 */
+#define ADC_SMP11_1                             ((uint32_t)0x00000010) /* Bit 1 */
+#define ADC_SMP11_2                             ((uint32_t)0x00000020) /* Bit 2 */
+
+#define ADC_SMP12                               ((uint32_t)0x000001C0) /* SMP12[2:0] bits (Channel 12 Sample time selection) */
+#define ADC_SMP12_0                             ((uint32_t)0x00000040) /* Bit 0 */
+#define ADC_SMP12_1                             ((uint32_t)0x00000080) /* Bit 1 */
+#define ADC_SMP12_2                             ((uint32_t)0x00000100) /* Bit 2 */
+
+#define ADC_SMP13                               ((uint32_t)0x00000E00) /* SMP13[2:0] bits (Channel 13 Sample time selection) */
+#define ADC_SMP13_0                             ((uint32_t)0x00000200) /* Bit 0 */
+#define ADC_SMP13_1                             ((uint32_t)0x00000400) /* Bit 1 */
+#define ADC_SMP13_2                             ((uint32_t)0x00000800) /* Bit 2 */
+
+#define ADC_SMP14                               ((uint32_t)0x00007000) /* SMP14[2:0] bits (Channel 14 Sample time selection) */
+#define ADC_SMP14_0                             ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_SMP14_1                             ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_SMP14_2                             ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_SMP15                               ((uint32_t)0x00038000) /* SMP15[2:0] bits (Channel 15 Sample time selection) */
+#define ADC_SMP15_0                             ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SMP15_1                             ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SMP15_2                             ((uint32_t)0x00020000) /* Bit 2 */
+
+#define ADC_SMP16                               ((uint32_t)0x001C0000) /* SMP16[2:0] bits (Channel 16 Sample time selection) */
+#define ADC_SMP16_0                             ((uint32_t)0x00040000) /* Bit 0 */
+#define ADC_SMP16_1                             ((uint32_t)0x00080000) /* Bit 1 */
+#define ADC_SMP16_2                             ((uint32_t)0x00100000) /* Bit 2 */
+
+#define ADC_SMP17                               ((uint32_t)0x00E00000) /* SMP17[2:0] bits (Channel 17 Sample time selection) */
+#define ADC_SMP17_0                             ((uint32_t)0x00200000) /* Bit 0 */
+#define ADC_SMP17_1                             ((uint32_t)0x00400000) /* Bit 1 */
+#define ADC_SMP17_2                             ((uint32_t)0x00800000) /* Bit 2 */
+
+/******************  Bit definition for ADC_SAMPTR2 register  *******************/
+#define ADC_SMP0                                ((uint32_t)0x00000007) /* SMP0[2:0] bits (Channel 0 Sample time selection) */
+#define ADC_SMP0_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SMP0_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SMP0_2                              ((uint32_t)0x00000004) /* Bit 2 */
+
+#define ADC_SMP1                                ((uint32_t)0x00000038) /* SMP1[2:0] bits (Channel 1 Sample time selection) */
+#define ADC_SMP1_0                              ((uint32_t)0x00000008) /* Bit 0 */
+#define ADC_SMP1_1                              ((uint32_t)0x00000010) /* Bit 1 */
+#define ADC_SMP1_2                              ((uint32_t)0x00000020) /* Bit 2 */
+
+#define ADC_SMP2                                ((uint32_t)0x000001C0) /* SMP2[2:0] bits (Channel 2 Sample time selection) */
+#define ADC_SMP2_0                              ((uint32_t)0x00000040) /* Bit 0 */
+#define ADC_SMP2_1                              ((uint32_t)0x00000080) /* Bit 1 */
+#define ADC_SMP2_2                              ((uint32_t)0x00000100) /* Bit 2 */
+
+#define ADC_SMP3                                ((uint32_t)0x00000E00) /* SMP3[2:0] bits (Channel 3 Sample time selection) */
+#define ADC_SMP3_0                              ((uint32_t)0x00000200) /* Bit 0 */
+#define ADC_SMP3_1                              ((uint32_t)0x00000400) /* Bit 1 */
+#define ADC_SMP3_2                              ((uint32_t)0x00000800) /* Bit 2 */
+
+#define ADC_SMP4                                ((uint32_t)0x00007000) /* SMP4[2:0] bits (Channel 4 Sample time selection) */
+#define ADC_SMP4_0                              ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_SMP4_1                              ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_SMP4_2                              ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_SMP5                                ((uint32_t)0x00038000) /* SMP5[2:0] bits (Channel 5 Sample time selection) */
+#define ADC_SMP5_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SMP5_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SMP5_2                              ((uint32_t)0x00020000) /* Bit 2 */
+
+#define ADC_SMP6                                ((uint32_t)0x001C0000) /* SMP6[2:0] bits (Channel 6 Sample time selection) */
+#define ADC_SMP6_0                              ((uint32_t)0x00040000) /* Bit 0 */
+#define ADC_SMP6_1                              ((uint32_t)0x00080000) /* Bit 1 */
+#define ADC_SMP6_2                              ((uint32_t)0x00100000) /* Bit 2 */
+
+#define ADC_SMP7                                ((uint32_t)0x00E00000) /* SMP7[2:0] bits (Channel 7 Sample time selection) */
+#define ADC_SMP7_0                              ((uint32_t)0x00200000) /* Bit 0 */
+#define ADC_SMP7_1                              ((uint32_t)0x00400000) /* Bit 1 */
+#define ADC_SMP7_2                              ((uint32_t)0x00800000) /* Bit 2 */
+
+#define ADC_SMP8                                ((uint32_t)0x07000000) /* SMP8[2:0] bits (Channel 8 Sample time selection) */
+#define ADC_SMP8_0                              ((uint32_t)0x01000000) /* Bit 0 */
+#define ADC_SMP8_1                              ((uint32_t)0x02000000) /* Bit 1 */
+#define ADC_SMP8_2                              ((uint32_t)0x04000000) /* Bit 2 */
+
+#define ADC_SMP9                                ((uint32_t)0x38000000) /* SMP9[2:0] bits (Channel 9 Sample time selection) */
+#define ADC_SMP9_0                              ((uint32_t)0x08000000) /* Bit 0 */
+#define ADC_SMP9_1                              ((uint32_t)0x10000000) /* Bit 1 */
+#define ADC_SMP9_2                              ((uint32_t)0x20000000) /* Bit 2 */
+
+/******************  Bit definition for ADC_IOFR1 register  *******************/
+#define ADC_JOFFSET1                            ((uint16_t)0x0FFF) /* Data offset for injected channel 1 */
+
+/******************  Bit definition for ADC_IOFR2 register  *******************/
+#define ADC_JOFFSET2                            ((uint16_t)0x0FFF) /* Data offset for injected channel 2 */
+
+/******************  Bit definition for ADC_IOFR3 register  *******************/
+#define ADC_JOFFSET3                            ((uint16_t)0x0FFF) /* Data offset for injected channel 3 */
+
+/******************  Bit definition for ADC_IOFR4 register  *******************/
+#define ADC_JOFFSET4                            ((uint16_t)0x0FFF) /* Data offset for injected channel 4 */
+
+/*******************  Bit definition for ADC_WDHTR register  ********************/
+#define ADC_HT                                  ((uint16_t)0x0FFF) /* Analog watchdog high threshold */
+
+/*******************  Bit definition for ADC_WDLTR register  ********************/
+#define ADC_LT                                  ((uint16_t)0x0FFF) /* Analog watchdog low threshold */
+
+/*******************  Bit definition for ADC_RSQR1 register  *******************/
+#define ADC_SQ13                                ((uint32_t)0x0000001F) /* SQ13[4:0] bits (13th conversion in regular sequence) */
+#define ADC_SQ13_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ13_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ13_2                              ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ13_3                              ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ13_4                              ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ14                                ((uint32_t)0x000003E0) /* SQ14[4:0] bits (14th conversion in regular sequence) */
+#define ADC_SQ14_0                              ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ14_1                              ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ14_2                              ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ14_3                              ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ14_4                              ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ15                                ((uint32_t)0x00007C00) /* SQ15[4:0] bits (15th conversion in regular sequence) */
+#define ADC_SQ15_0                              ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ15_1                              ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ15_2                              ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ15_3                              ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ15_4                              ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ16                                ((uint32_t)0x000F8000) /* SQ16[4:0] bits (16th conversion in regular sequence) */
+#define ADC_SQ16_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ16_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ16_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ16_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ16_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_L                                   ((uint32_t)0x00F00000) /* L[3:0] bits (Regular channel sequence length) */
+#define ADC_L_0                                 ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_L_1                                 ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_L_2                                 ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_L_3                                 ((uint32_t)0x00800000) /* Bit 3 */
+
+/*******************  Bit definition for ADC_RSQR2 register  *******************/
+#define ADC_SQ7                                 ((uint32_t)0x0000001F) /* SQ7[4:0] bits (7th conversion in regular sequence) */
+#define ADC_SQ7_0                               ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ7_1                               ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ7_2                               ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ7_3                               ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ7_4                               ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ8                                 ((uint32_t)0x000003E0) /* SQ8[4:0] bits (8th conversion in regular sequence) */
+#define ADC_SQ8_0                               ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ8_1                               ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ8_2                               ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ8_3                               ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ8_4                               ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ9                                 ((uint32_t)0x00007C00) /* SQ9[4:0] bits (9th conversion in regular sequence) */
+#define ADC_SQ9_0                               ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ9_1                               ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ9_2                               ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ9_3                               ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ9_4                               ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ10                                ((uint32_t)0x000F8000) /* SQ10[4:0] bits (10th conversion in regular sequence) */
+#define ADC_SQ10_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ10_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ10_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ10_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ10_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_SQ11                                ((uint32_t)0x01F00000) /* SQ11[4:0] bits (11th conversion in regular sequence) */
+#define ADC_SQ11_0                              ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_SQ11_1                              ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_SQ11_2                              ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_SQ11_3                              ((uint32_t)0x00800000) /* Bit 3 */
+#define ADC_SQ11_4                              ((uint32_t)0x01000000) /* Bit 4 */
+
+#define ADC_SQ12                                ((uint32_t)0x3E000000) /* SQ12[4:0] bits (12th conversion in regular sequence) */
+#define ADC_SQ12_0                              ((uint32_t)0x02000000) /* Bit 0 */
+#define ADC_SQ12_1                              ((uint32_t)0x04000000) /* Bit 1 */
+#define ADC_SQ12_2                              ((uint32_t)0x08000000) /* Bit 2 */
+#define ADC_SQ12_3                              ((uint32_t)0x10000000) /* Bit 3 */
+#define ADC_SQ12_4                              ((uint32_t)0x20000000) /* Bit 4 */
+
+/*******************  Bit definition for ADC_RSQR3 register  *******************/
+#define ADC_SQ1                                 ((uint32_t)0x0000001F) /* SQ1[4:0] bits (1st conversion in regular sequence) */
+#define ADC_SQ1_0                               ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ1_1                               ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ1_2                               ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ1_3                               ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ1_4                               ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ2                                 ((uint32_t)0x000003E0) /* SQ2[4:0] bits (2nd conversion in regular sequence) */
+#define ADC_SQ2_0                               ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ2_1                               ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ2_2                               ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ2_3                               ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ2_4                               ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ3                                 ((uint32_t)0x00007C00) /* SQ3[4:0] bits (3rd conversion in regular sequence) */
+#define ADC_SQ3_0                               ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ3_1                               ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ3_2                               ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ3_3                               ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ3_4                               ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ4                                 ((uint32_t)0x000F8000) /* SQ4[4:0] bits (4th conversion in regular sequence) */
+#define ADC_SQ4_0                               ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ4_1                               ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ4_2                               ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ4_3                               ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ4_4                               ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_SQ5                                 ((uint32_t)0x01F00000) /* SQ5[4:0] bits (5th conversion in regular sequence) */
+#define ADC_SQ5_0                               ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_SQ5_1                               ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_SQ5_2                               ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_SQ5_3                               ((uint32_t)0x00800000) /* Bit 3 */
+#define ADC_SQ5_4                               ((uint32_t)0x01000000) /* Bit 4 */
+
+#define ADC_SQ6                                 ((uint32_t)0x3E000000) /* SQ6[4:0] bits (6th conversion in regular sequence) */
+#define ADC_SQ6_0                               ((uint32_t)0x02000000) /* Bit 0 */
+#define ADC_SQ6_1                               ((uint32_t)0x04000000) /* Bit 1 */
+#define ADC_SQ6_2                               ((uint32_t)0x08000000) /* Bit 2 */
+#define ADC_SQ6_3                               ((uint32_t)0x10000000) /* Bit 3 */
+#define ADC_SQ6_4                               ((uint32_t)0x20000000) /* Bit 4 */
+
+/*******************  Bit definition for ADC_ISQR register  *******************/
+#define ADC_JSQ1                                ((uint32_t)0x0000001F) /* JSQ1[4:0] bits (1st conversion in injected sequence) */
+#define ADC_JSQ1_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_JSQ1_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_JSQ1_2                              ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_JSQ1_3                              ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_JSQ1_4                              ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_JSQ2                                ((uint32_t)0x000003E0) /* JSQ2[4:0] bits (2nd conversion in injected sequence) */
+#define ADC_JSQ2_0                              ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_JSQ2_1                              ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_JSQ2_2                              ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_JSQ2_3                              ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_JSQ2_4                              ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_JSQ3                                ((uint32_t)0x00007C00) /* JSQ3[4:0] bits (3rd conversion in injected sequence) */
+#define ADC_JSQ3_0                              ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_JSQ3_1                              ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_JSQ3_2                              ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_JSQ3_3                              ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_JSQ3_4                              ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_JSQ4                                ((uint32_t)0x000F8000) /* JSQ4[4:0] bits (4th conversion in injected sequence) */
+#define ADC_JSQ4_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_JSQ4_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_JSQ4_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_JSQ4_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_JSQ4_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_JL                                  ((uint32_t)0x00300000) /* JL[1:0] bits (Injected Sequence length) */
+#define ADC_JL_0                                ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_JL_1                                ((uint32_t)0x00200000) /* Bit 1 */
+
+/*******************  Bit definition for ADC_IDATAR1 register  *******************/
+#define ADC_IDATAR1_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR2 register  *******************/
+#define ADC_IDATAR2_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR3 register  *******************/
+#define ADC_IDATAR3_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR4 register  *******************/
+#define ADC_IDATAR4_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/********************  Bit definition for ADC_RDATAR register  ********************/
+#define ADC_RDATAR_DATA                         ((uint32_t)0x0000FFFF) /* Regular data */
+#define ADC_RDATAR_ADC2DATA                     ((uint32_t)0xFFFF0000) /* ADC2 data */
+
+/******************************************************************************/
+/*                             DMA Controller                                 */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_INTFR register  ********************/
+#define DMA_GIF1                                ((uint32_t)0x00000001) /* Channel 1 Global interrupt flag */
+#define DMA_TCIF1                               ((uint32_t)0x00000002) /* Channel 1 Transfer Complete flag */
+#define DMA_HTIF1                               ((uint32_t)0x00000004) /* Channel 1 Half Transfer flag */
+#define DMA_TEIF1                               ((uint32_t)0x00000008) /* Channel 1 Transfer Error flag */
+#define DMA_GIF2                                ((uint32_t)0x00000010) /* Channel 2 Global interrupt flag */
+#define DMA_TCIF2                               ((uint32_t)0x00000020) /* Channel 2 Transfer Complete flag */
+#define DMA_HTIF2                               ((uint32_t)0x00000040) /* Channel 2 Half Transfer flag */
+#define DMA_TEIF2                               ((uint32_t)0x00000080) /* Channel 2 Transfer Error flag */
+#define DMA_GIF3                                ((uint32_t)0x00000100) /* Channel 3 Global interrupt flag */
+#define DMA_TCIF3                               ((uint32_t)0x00000200) /* Channel 3 Transfer Complete flag */
+#define DMA_HTIF3                               ((uint32_t)0x00000400) /* Channel 3 Half Transfer flag */
+#define DMA_TEIF3                               ((uint32_t)0x00000800) /* Channel 3 Transfer Error flag */
+#define DMA_GIF4                                ((uint32_t)0x00001000) /* Channel 4 Global interrupt flag */
+#define DMA_TCIF4                               ((uint32_t)0x00002000) /* Channel 4 Transfer Complete flag */
+#define DMA_HTIF4                               ((uint32_t)0x00004000) /* Channel 4 Half Transfer flag */
+#define DMA_TEIF4                               ((uint32_t)0x00008000) /* Channel 4 Transfer Error flag */
+#define DMA_GIF5                                ((uint32_t)0x00010000) /* Channel 5 Global interrupt flag */
+#define DMA_TCIF5                               ((uint32_t)0x00020000) /* Channel 5 Transfer Complete flag */
+#define DMA_HTIF5                               ((uint32_t)0x00040000) /* Channel 5 Half Transfer flag */
+#define DMA_TEIF5                               ((uint32_t)0x00080000) /* Channel 5 Transfer Error flag */
+#define DMA_GIF6                                ((uint32_t)0x00100000) /* Channel 6 Global interrupt flag */
+#define DMA_TCIF6                               ((uint32_t)0x00200000) /* Channel 6 Transfer Complete flag */
+#define DMA_HTIF6                               ((uint32_t)0x00400000) /* Channel 6 Half Transfer flag */
+#define DMA_TEIF6                               ((uint32_t)0x00800000) /* Channel 6 Transfer Error flag */
+#define DMA_GIF7                                ((uint32_t)0x01000000) /* Channel 7 Global interrupt flag */
+#define DMA_TCIF7                               ((uint32_t)0x02000000) /* Channel 7 Transfer Complete flag */
+#define DMA_HTIF7                               ((uint32_t)0x04000000) /* Channel 7 Half Transfer flag */
+#define DMA_TEIF7                               ((uint32_t)0x08000000) /* Channel 7 Transfer Error flag */
+#define DMA_GIF8                                ((uint32_t)0x10000000) /* Channel 8 Global interrupt flag */
+#define DMA_TCIF8                               ((uint32_t)0x20000000) /* Channel 8 Transfer Complete flag */
+#define DMA_HTIF8                               ((uint32_t)0x40000000) /* Channel 8 Half Transfer flag */
+#define DMA_TEIF8                               ((uint32_t)0x80000000) /* Channel 8 Transfer Error flag */
+
+/*******************  Bit definition for DMA_INTFCR register  *******************/
+#define DMA_CGIF1                               ((uint32_t)0x00000001) /* Channel 1 Global interrupt clear */
+#define DMA_CTCIF1                              ((uint32_t)0x00000002) /* Channel 1 Transfer Complete clear */
+#define DMA_CHTIF1                              ((uint32_t)0x00000004) /* Channel 1 Half Transfer clear */
+#define DMA_CTEIF1                              ((uint32_t)0x00000008) /* Channel 1 Transfer Error clear */
+#define DMA_CGIF2                               ((uint32_t)0x00000010) /* Channel 2 Global interrupt clear */
+#define DMA_CTCIF2                              ((uint32_t)0x00000020) /* Channel 2 Transfer Complete clear */
+#define DMA_CHTIF2                              ((uint32_t)0x00000040) /* Channel 2 Half Transfer clear */
+#define DMA_CTEIF2                              ((uint32_t)0x00000080) /* Channel 2 Transfer Error clear */
+#define DMA_CGIF3                               ((uint32_t)0x00000100) /* Channel 3 Global interrupt clear */
+#define DMA_CTCIF3                              ((uint32_t)0x00000200) /* Channel 3 Transfer Complete clear */
+#define DMA_CHTIF3                              ((uint32_t)0x00000400) /* Channel 3 Half Transfer clear */
+#define DMA_CTEIF3                              ((uint32_t)0x00000800) /* Channel 3 Transfer Error clear */
+#define DMA_CGIF4                               ((uint32_t)0x00001000) /* Channel 4 Global interrupt clear */
+#define DMA_CTCIF4                              ((uint32_t)0x00002000) /* Channel 4 Transfer Complete clear */
+#define DMA_CHTIF4                              ((uint32_t)0x00004000) /* Channel 4 Half Transfer clear */
+#define DMA_CTEIF4                              ((uint32_t)0x00008000) /* Channel 4 Transfer Error clear */
+#define DMA_CGIF5                               ((uint32_t)0x00010000) /* Channel 5 Global interrupt clear */
+#define DMA_CTCIF5                              ((uint32_t)0x00020000) /* Channel 5 Transfer Complete clear */
+#define DMA_CHTIF5                              ((uint32_t)0x00040000) /* Channel 5 Half Transfer clear */
+#define DMA_CTEIF5                              ((uint32_t)0x00080000) /* Channel 5 Transfer Error clear */
+#define DMA_CGIF6                               ((uint32_t)0x00100000) /* Channel 6 Global interrupt clear */
+#define DMA_CTCIF6                              ((uint32_t)0x00200000) /* Channel 6 Transfer Complete clear */
+#define DMA_CHTIF6                              ((uint32_t)0x00400000) /* Channel 6 Half Transfer clear */
+#define DMA_CTEIF6                              ((uint32_t)0x00800000) /* Channel 6 Transfer Error clear */
+#define DMA_CGIF7                               ((uint32_t)0x01000000) /* Channel 7 Global interrupt clear */
+#define DMA_CTCIF7                              ((uint32_t)0x02000000) /* Channel 7 Transfer Complete clear */
+#define DMA_CHTIF7                              ((uint32_t)0x04000000) /* Channel 7 Half Transfer clear */
+#define DMA_CTEIF7                              ((uint32_t)0x08000000) /* Channel 7 Transfer Error clear */
+#define DMA_CGIF8                               ((uint32_t)0x10000000) /* Channel 8 Global interrupt clear */
+#define DMA_CTCIF8                              ((uint32_t)0x20000000) /* Channel 8 Transfer Complete clear */
+#define DMA_CHTIF8                              ((uint32_t)0x40000000) /* Channel 8 Half Transfer clear */
+#define DMA_CTEIF8                              ((uint32_t)0x80000000) /* Channel 8 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CFGR1 register  *******************/
+#define DMA_CFGR1_EN                            ((uint16_t)0x0001) /* Channel enable*/
+#define DMA_CFGR1_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR1_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR1_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR1_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR1_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR1_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR1_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR1_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR1_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR1_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR1_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR1_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR1_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR1_PL                            ((uint16_t)0x3000) /* PL[1:0] bits(Channel Priority level) */
+#define DMA_CFGR1_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR1_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR1_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR2 register  *******************/
+#define DMA_CFGR2_EN                            ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR2_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR2_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR2_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR2_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR2_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR2_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR2_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR2_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR2_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR2_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR2_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR2_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR2_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR2_PL                            ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR2_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR2_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR2_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR3 register  *******************/
+#define DMA_CFGR3_EN                            ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR3_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR3_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR3_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR3_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR3_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR3_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR3_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR3_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR3_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR3_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR3_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR3_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR3_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR3_PL                            ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR3_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR3_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR3_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFG4 register  *******************/
+#define DMA_CFG4_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG4_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG4_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG4_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG4_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG4_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG4_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG4_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG4_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG4_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG4_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG4_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG4_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG4_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG4_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG4_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG4_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG4_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode */
+
+/******************  Bit definition for DMA_CFG5 register  *******************/
+#define DMA_CFG5_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG5_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG5_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG5_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG5_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG5_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG5_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG5_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG5_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG5_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG5_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG5_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG5_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG5_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG5_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG5_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG5_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG5_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/*******************  Bit definition for DMA_CFG6 register  *******************/
+#define DMA_CFG6_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG6_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG6_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG6_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG6_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG6_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG6_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG6_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG6_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG6_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG6_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG6_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG6_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG6_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG6_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG6_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG6_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG6_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFG7 register  *******************/
+#define DMA_CFG7_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG7_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG7_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG7_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG7_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG7_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG7_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG7_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG7_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG7_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG7_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG7_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG7_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG7_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG7_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG7_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG7_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG7_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/*******************  Bit definition for DMA_CFG8 register  *******************/
+#define DMA_CFG8_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG8_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG8_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG8_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG8_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG8_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG8_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG8_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG8_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG8_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG8_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG8_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG8_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG8_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG8_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG8_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG8_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG8_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/******************  Bit definition for DMA_CNTR1 register  ******************/
+#define DMA_CNTR1_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR2 register  ******************/
+#define DMA_CNTR2_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR3 register  ******************/
+#define DMA_CNTR3_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR4 register  ******************/
+#define DMA_CNTR4_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR5 register  ******************/
+#define DMA_CNTR5_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR6 register  ******************/
+#define DMA_CNTR6_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR7 register  ******************/
+#define DMA_CNTR7_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR8 register  ******************/
+#define DMA_CNTR8_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_PADDR1 register  *******************/
+#define DMA_PADDR1_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR2 register  *******************/
+#define DMA_PADDR2_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR3 register  *******************/
+#define DMA_PADDR3_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR4 register  *******************/
+#define DMA_PADDR4_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR5 register  *******************/
+#define DMA_PADDR5_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR6 register  *******************/
+#define DMA_PADDR6_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR7 register  *******************/
+#define DMA_PADDR7_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR8 register  *******************/
+#define DMA_PADDR8_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_MADDR1 register  *******************/
+#define DMA_MADDR1_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR2 register  *******************/
+#define DMA_MADDR2_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR3 register  *******************/
+#define DMA_MADDR3_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR4 register  *******************/
+#define DMA_MADDR4_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR5 register  *******************/
+#define DMA_MADDR5_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR6 register  *******************/
+#define DMA_MADDR6_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR7 register  *******************/
+#define DMA_MADDR7_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR8 register  *******************/
+#define DMA_MADDR8_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************************************************************************/
+/*                    External Interrupt/Event Controller                     */
+/******************************************************************************/
+
+/*******************  Bit definition for EXTI_INTENR register  *******************/
+#define EXTI_INTENR_MR0                         ((uint32_t)0x00000001) /* Interrupt Mask on line 0 */
+#define EXTI_INTENR_MR1                         ((uint32_t)0x00000002) /* Interrupt Mask on line 1 */
+#define EXTI_INTENR_MR2                         ((uint32_t)0x00000004) /* Interrupt Mask on line 2 */
+#define EXTI_INTENR_MR3                         ((uint32_t)0x00000008) /* Interrupt Mask on line 3 */
+#define EXTI_INTENR_MR4                         ((uint32_t)0x00000010) /* Interrupt Mask on line 4 */
+#define EXTI_INTENR_MR5                         ((uint32_t)0x00000020) /* Interrupt Mask on line 5 */
+#define EXTI_INTENR_MR6                         ((uint32_t)0x00000040) /* Interrupt Mask on line 6 */
+#define EXTI_INTENR_MR7                         ((uint32_t)0x00000080) /* Interrupt Mask on line 7 */
+#define EXTI_INTENR_MR8                         ((uint32_t)0x00000100) /* Interrupt Mask on line 8 */
+#define EXTI_INTENR_MR9                         ((uint32_t)0x00000200) /* Interrupt Mask on line 9 */
+#define EXTI_INTENR_MR10                        ((uint32_t)0x00000400) /* Interrupt Mask on line 10 */
+#define EXTI_INTENR_MR11                        ((uint32_t)0x00000800) /* Interrupt Mask on line 11 */
+#define EXTI_INTENR_MR12                        ((uint32_t)0x00001000) /* Interrupt Mask on line 12 */
+#define EXTI_INTENR_MR13                        ((uint32_t)0x00002000) /* Interrupt Mask on line 13 */
+#define EXTI_INTENR_MR14                        ((uint32_t)0x00004000) /* Interrupt Mask on line 14 */
+#define EXTI_INTENR_MR15                        ((uint32_t)0x00008000) /* Interrupt Mask on line 15 */
+#define EXTI_INTENR_MR16                        ((uint32_t)0x00010000) /* Interrupt Mask on line 16 */
+#define EXTI_INTENR_MR17                        ((uint32_t)0x00020000) /* Interrupt Mask on line 17 */
+#define EXTI_INTENR_MR18                        ((uint32_t)0x00040000) /* Interrupt Mask on line 18 */
+#define EXTI_INTENR_MR19                        ((uint32_t)0x00080000) /* Interrupt Mask on line 19 */
+#define EXTI_INTENR_MR20                        ((uint32_t)0x00100000) /* Interrupt Mask on line 20 */
+#define EXTI_INTENR_MR21                        ((uint32_t)0x00200000) /* Interrupt Mask on line 21 */
+#define EXTI_INTENR_MR22                        ((uint32_t)0x00400000) /* Interrupt Mask on line 22 */
+#define EXTI_INTENR_MR23                        ((uint32_t)0x00800000) /* Interrupt Mask on line 23 */
+#define EXTI_INTENR_MR24                        ((uint32_t)0x01000000) /* Interrupt Mask on line 24 */
+#define EXTI_INTENR_MR25                        ((uint32_t)0x02000000) /* Interrupt Mask on line 25 */
+#define EXTI_INTENR_MR26                        ((uint32_t)0x04000000) /* Interrupt Mask on line 26 */
+#define EXTI_INTENR_MR27                        ((uint32_t)0x08000000) /* Interrupt Mask on line 27 */
+#define EXTI_INTENR_MR28                        ((uint32_t)0x10000000) /* Interrupt Mask on line 28 */
+#define EXTI_INTENR_MR29                        ((uint32_t)0x20000000) /* Interrupt Mask on line 29 */
+
+/*******************  Bit definition for EXTI_EVENR register  *******************/
+#define EXTI_EVENR_MR0                          ((uint32_t)0x00000001) /* Event Mask on line 0 */
+#define EXTI_EVENR_MR1                          ((uint32_t)0x00000002) /* Event Mask on line 1 */
+#define EXTI_EVENR_MR2                          ((uint32_t)0x00000004) /* Event Mask on line 2 */
+#define EXTI_EVENR_MR3                          ((uint32_t)0x00000008) /* Event Mask on line 3 */
+#define EXTI_EVENR_MR4                          ((uint32_t)0x00000010) /* Event Mask on line 4 */
+#define EXTI_EVENR_MR5                          ((uint32_t)0x00000020) /* Event Mask on line 5 */
+#define EXTI_EVENR_MR6                          ((uint32_t)0x00000040) /* Event Mask on line 6 */
+#define EXTI_EVENR_MR7                          ((uint32_t)0x00000080) /* Event Mask on line 7 */
+#define EXTI_EVENR_MR8                          ((uint32_t)0x00000100) /* Event Mask on line 8 */
+#define EXTI_EVENR_MR9                          ((uint32_t)0x00000200) /* Event Mask on line 9 */
+#define EXTI_EVENR_MR10                         ((uint32_t)0x00000400) /* Event Mask on line 10 */
+#define EXTI_EVENR_MR11                         ((uint32_t)0x00000800) /* Event Mask on line 11 */
+#define EXTI_EVENR_MR12                         ((uint32_t)0x00001000) /* Event Mask on line 12 */
+#define EXTI_EVENR_MR13                         ((uint32_t)0x00002000) /* Event Mask on line 13 */
+#define EXTI_EVENR_MR14                         ((uint32_t)0x00004000) /* Event Mask on line 14 */
+#define EXTI_EVENR_MR15                         ((uint32_t)0x00008000) /* Event Mask on line 15 */
+#define EXTI_EVENR_MR16                         ((uint32_t)0x00010000) /* Event Mask on line 16 */
+#define EXTI_EVENR_MR17                         ((uint32_t)0x00020000) /* Event Mask on line 17 */
+#define EXTI_EVENR_MR18                         ((uint32_t)0x00040000) /* Event Mask on line 18 */
+#define EXTI_EVENR_MR19                         ((uint32_t)0x00080000) /* Event Mask on line 19 */
+#define EXTI_EVENR_MR20                         ((uint32_t)0x00100000) /* Event Mask on line 20 */
+#define EXTI_EVENR_MR21                         ((uint32_t)0x00200000) /* Event Mask on line 21 */
+#define EXTI_EVENR_MR22                         ((uint32_t)0x00400000) /* Event Mask on line 22 */
+#define EXTI_EVENR_MR23                         ((uint32_t)0x00800000) /* Event Mask on line 23 */
+#define EXTI_EVENR_MR24                         ((uint32_t)0x01000000) /* Event Mask on line 24 */
+#define EXTI_EVENR_MR25                         ((uint32_t)0x02000000) /* Event Mask on line 25 */
+#define EXTI_EVENR_MR26                         ((uint32_t)0x04000000) /* Event Mask on line 26 */
+#define EXTI_EVENR_MR27                         ((uint32_t)0x08000000) /* Event Mask on line 27 */
+#define EXTI_EVENR_MR28                         ((uint32_t)0x10000000) /* Event Mask on line 28 */
+#define EXTI_EVENR_MR29                         ((uint32_t)0x20000000) /* Event Mask on line 29 */
+
+/******************  Bit definition for EXTI_RTENR register  *******************/
+#define EXTI_RTENR_TR0                          ((uint32_t)0x00000001) /* Rising trigger event configuration bit of line 0 */
+#define EXTI_RTENR_TR1                          ((uint32_t)0x00000002) /* Rising trigger event configuration bit of line 1 */
+#define EXTI_RTENR_TR2                          ((uint32_t)0x00000004) /* Rising trigger event configuration bit of line 2 */
+#define EXTI_RTENR_TR3                          ((uint32_t)0x00000008) /* Rising trigger event configuration bit of line 3 */
+#define EXTI_RTENR_TR4                          ((uint32_t)0x00000010) /* Rising trigger event configuration bit of line 4 */
+#define EXTI_RTENR_TR5                          ((uint32_t)0x00000020) /* Rising trigger event configuration bit of line 5 */
+#define EXTI_RTENR_TR6                          ((uint32_t)0x00000040) /* Rising trigger event configuration bit of line 6 */
+#define EXTI_RTENR_TR7                          ((uint32_t)0x00000080) /* Rising trigger event configuration bit of line 7 */
+#define EXTI_RTENR_TR8                          ((uint32_t)0x00000100) /* Rising trigger event configuration bit of line 8 */
+#define EXTI_RTENR_TR9                          ((uint32_t)0x00000200) /* Rising trigger event configuration bit of line 9 */
+#define EXTI_RTENR_TR10                         ((uint32_t)0x00000400) /* Rising trigger event configuration bit of line 10 */
+#define EXTI_RTENR_TR11                         ((uint32_t)0x00000800) /* Rising trigger event configuration bit of line 11 */
+#define EXTI_RTENR_TR12                         ((uint32_t)0x00001000) /* Rising trigger event configuration bit of line 12 */
+#define EXTI_RTENR_TR13                         ((uint32_t)0x00002000) /* Rising trigger event configuration bit of line 13 */
+#define EXTI_RTENR_TR14                         ((uint32_t)0x00004000) /* Rising trigger event configuration bit of line 14 */
+#define EXTI_RTENR_TR15                         ((uint32_t)0x00008000) /* Rising trigger event configuration bit of line 15 */
+#define EXTI_RTENR_TR16                         ((uint32_t)0x00010000) /* Rising trigger event configuration bit of line 16 */
+#define EXTI_RTENR_TR17                         ((uint32_t)0x00020000) /* Rising trigger event configuration bit of line 17 */
+#define EXTI_RTENR_TR18                         ((uint32_t)0x00040000) /* Rising trigger event configuration bit of line 18 */
+#define EXTI_RTENR_TR19                         ((uint32_t)0x00080000) /* Rising trigger event configuration bit of line 19 */
+#define EXTI_RTENR_TR20                         ((uint32_t)0x00100000) /* Rising trigger event configuration bit of line 20 */
+#define EXTI_RTENR_TR21                         ((uint32_t)0x00200000) /* Rising trigger event configuration bit of line 21 */
+#define EXTI_RTENR_TR22                         ((uint32_t)0x00400000) /* Rising trigger event configuration bit of line 22 */
+#define EXTI_RTENR_TR23                         ((uint32_t)0x00800000) /* Rising trigger event configuration bit of line 23 */
+#define EXTI_RTENR_TR24                         ((uint32_t)0x01000000) /* Rising trigger event configuration bit of line 24 */
+#define EXTI_RTENR_TR25                         ((uint32_t)0x02000000) /* Rising trigger event configuration bit of line 25 */
+#define EXTI_RTENR_TR26                         ((uint32_t)0x04000000) /* Rising trigger event configuration bit of line 26 */
+#define EXTI_RTENR_TR27                         ((uint32_t)0x08000000) /* Rising trigger event configuration bit of line 27 */
+#define EXTI_RTENR_TR28                         ((uint32_t)0x10000000) /* Rising trigger event configuration bit of line 28 */
+#define EXTI_RTENR_TR29                         ((uint32_t)0x20000000) /* Rising trigger event configuration bit of line 29 */
+
+/******************  Bit definition for EXTI_FTENR register  *******************/
+#define EXTI_FTENR_TR0                          ((uint32_t)0x00000001) /* Falling trigger event configuration bit of line 0 */
+#define EXTI_FTENR_TR1                          ((uint32_t)0x00000002) /* Falling trigger event configuration bit of line 1 */
+#define EXTI_FTENR_TR2                          ((uint32_t)0x00000004) /* Falling trigger event configuration bit of line 2 */
+#define EXTI_FTENR_TR3                          ((uint32_t)0x00000008) /* Falling trigger event configuration bit of line 3 */
+#define EXTI_FTENR_TR4                          ((uint32_t)0x00000010) /* Falling trigger event configuration bit of line 4 */
+#define EXTI_FTENR_TR5                          ((uint32_t)0x00000020) /* Falling trigger event configuration bit of line 5 */
+#define EXTI_FTENR_TR6                          ((uint32_t)0x00000040) /* Falling trigger event configuration bit of line 6 */
+#define EXTI_FTENR_TR7                          ((uint32_t)0x00000080) /* Falling trigger event configuration bit of line 7 */
+#define EXTI_FTENR_TR8                          ((uint32_t)0x00000100) /* Falling trigger event configuration bit of line 8 */
+#define EXTI_FTENR_TR9                          ((uint32_t)0x00000200) /* Falling trigger event configuration bit of line 9 */
+#define EXTI_FTENR_TR10                         ((uint32_t)0x00000400) /* Falling trigger event configuration bit of line 10 */
+#define EXTI_FTENR_TR11                         ((uint32_t)0x00000800) /* Falling trigger event configuration bit of line 11 */
+#define EXTI_FTENR_TR12                         ((uint32_t)0x00001000) /* Falling trigger event configuration bit of line 12 */
+#define EXTI_FTENR_TR13                         ((uint32_t)0x00002000) /* Falling trigger event configuration bit of line 13 */
+#define EXTI_FTENR_TR14                         ((uint32_t)0x00004000) /* Falling trigger event configuration bit of line 14 */
+#define EXTI_FTENR_TR15                         ((uint32_t)0x00008000) /* Falling trigger event configuration bit of line 15 */
+#define EXTI_FTENR_TR16                         ((uint32_t)0x00010000) /* Falling trigger event configuration bit of line 16 */
+#define EXTI_FTENR_TR17                         ((uint32_t)0x00020000) /* Falling trigger event configuration bit of line 17 */
+#define EXTI_FTENR_TR18                         ((uint32_t)0x00040000) /* Falling trigger event configuration bit of line 18 */
+#define EXTI_FTENR_TR19                         ((uint32_t)0x00080000) /* Falling trigger event configuration bit of line 19 */
+#define EXTI_FTENR_TR20                         ((uint32_t)0x00100000) /* Falling trigger event configuration bit of line 20 */
+#define EXTI_FTENR_TR21                         ((uint32_t)0x00200000) /* Falling trigger event configuration bit of line 21 */
+#define EXTI_FTENR_TR22                         ((uint32_t)0x00400000) /* Falling trigger event configuration bit of line 22 */
+#define EXTI_FTENR_TR23                         ((uint32_t)0x00800000) /* Falling trigger event configuration bit of line 23 */
+#define EXTI_FTENR_TR24                         ((uint32_t)0x01000000) /* Falling trigger event configuration bit of line 24 */
+#define EXTI_FTENR_TR25                         ((uint32_t)0x02000000) /* Falling trigger event configuration bit of line 25 */
+#define EXTI_FTENR_TR26                         ((uint32_t)0x04000000) /* Falling trigger event configuration bit of line 26 */
+#define EXTI_FTENR_TR27                         ((uint32_t)0x08000000) /* Falling trigger event configuration bit of line 27 */
+#define EXTI_FTENR_TR28                         ((uint32_t)0x10000000) /* Falling trigger event configuration bit of line 28 */
+#define EXTI_FTENR_TR29                         ((uint32_t)0x20000000) /* Falling trigger event configuration bit of line 29 */
+
+/******************  Bit definition for EXTI_SWIEVR register  ******************/
+#define EXTI_SWIEVR_SWIEVR0                     ((uint32_t)0x00000001) /* Software Interrupt on line 0 */
+#define EXTI_SWIEVR_SWIEVR1                     ((uint32_t)0x00000002) /* Software Interrupt on line 1 */
+#define EXTI_SWIEVR_SWIEVR2                     ((uint32_t)0x00000004) /* Software Interrupt on line 2 */
+#define EXTI_SWIEVR_SWIEVR3                     ((uint32_t)0x00000008) /* Software Interrupt on line 3 */
+#define EXTI_SWIEVR_SWIEVR4                     ((uint32_t)0x00000010) /* Software Interrupt on line 4 */
+#define EXTI_SWIEVR_SWIEVR5                     ((uint32_t)0x00000020) /* Software Interrupt on line 5 */
+#define EXTI_SWIEVR_SWIEVR6                     ((uint32_t)0x00000040) /* Software Interrupt on line 6 */
+#define EXTI_SWIEVR_SWIEVR7                     ((uint32_t)0x00000080) /* Software Interrupt on line 7 */
+#define EXTI_SWIEVR_SWIEVR8                     ((uint32_t)0x00000100) /* Software Interrupt on line 8 */
+#define EXTI_SWIEVR_SWIEVR9                     ((uint32_t)0x00000200) /* Software Interrupt on line 9 */
+#define EXTI_SWIEVR_SWIEVR10                    ((uint32_t)0x00000400) /* Software Interrupt on line 10 */
+#define EXTI_SWIEVR_SWIEVR11                    ((uint32_t)0x00000800) /* Software Interrupt on line 11 */
+#define EXTI_SWIEVR_SWIEVR12                    ((uint32_t)0x00001000) /* Software Interrupt on line 12 */
+#define EXTI_SWIEVR_SWIEVR13                    ((uint32_t)0x00002000) /* Software Interrupt on line 13 */
+#define EXTI_SWIEVR_SWIEVR14                    ((uint32_t)0x00004000) /* Software Interrupt on line 14 */
+#define EXTI_SWIEVR_SWIEVR15                    ((uint32_t)0x00008000) /* Software Interrupt on line 15 */
+#define EXTI_SWIEVR_SWIEVR16                    ((uint32_t)0x00010000) /* Software Interrupt on line 16 */
+#define EXTI_SWIEVR_SWIEVR17                    ((uint32_t)0x00020000) /* Software Interrupt on line 17 */
+#define EXTI_SWIEVR_SWIEVR18                    ((uint32_t)0x00040000) /* Software Interrupt on line 18 */
+#define EXTI_SWIEVR_SWIEVR19                    ((uint32_t)0x00080000) /* Software Interrupt on line 19 */
+#define EXTI_SWIEVR_SWIEVR20                    ((uint32_t)0x00100000) /* Software Interrupt on line 20 */
+#define EXTI_SWIEVR_SWIEVR21                    ((uint32_t)0x00200000) /* Software Interrupt on line 21 */
+#define EXTI_SWIEVR_SWIEVR22                    ((uint32_t)0x00400000) /* Software Interrupt on line 22 */
+#define EXTI_SWIEVR_SWIEVR23                    ((uint32_t)0x00800000) /* Software Interrupt on line 23 */
+#define EXTI_SWIEVR_SWIEVR24                    ((uint32_t)0x01000000) /* Software Interrupt on line 24 */
+#define EXTI_SWIEVR_SWIEVR25                    ((uint32_t)0x02000000) /* Software Interrupt on line 25 */
+#define EXTI_SWIEVR_SWIEVR26                    ((uint32_t)0x04000000) /* Software Interrupt on line 26 */
+#define EXTI_SWIEVR_SWIEVR27                    ((uint32_t)0x08000000) /* Software Interrupt on line 27 */
+#define EXTI_SWIEVR_SWIEVR28                    ((uint32_t)0x10000000) /* Software Interrupt on line 28 */
+#define EXTI_SWIEVR_SWIEVR29                    ((uint32_t)0x20000000) /* Software Interrupt on line 29 */
+
+/*******************  Bit definition for EXTI_INTFR register  ********************/
+#define EXTI_INTF_INTF0                         ((uint32_t)0x00000001) /* Pending bit for line 0 */
+#define EXTI_INTF_INTF1                         ((uint32_t)0x00000002) /* Pending bit for line 1 */
+#define EXTI_INTF_INTF2                         ((uint32_t)0x00000004) /* Pending bit for line 2 */
+#define EXTI_INTF_INTF3                         ((uint32_t)0x00000008) /* Pending bit for line 3 */
+#define EXTI_INTF_INTF4                         ((uint32_t)0x00000010) /* Pending bit for line 4 */
+#define EXTI_INTF_INTF5                         ((uint32_t)0x00000020) /* Pending bit for line 5 */
+#define EXTI_INTF_INTF6                         ((uint32_t)0x00000040) /* Pending bit for line 6 */
+#define EXTI_INTF_INTF7                         ((uint32_t)0x00000080) /* Pending bit for line 7 */
+#define EXTI_INTF_INTF8                         ((uint32_t)0x00000100) /* Pending bit for line 8 */
+#define EXTI_INTF_INTF9                         ((uint32_t)0x00000200) /* Pending bit for line 9 */
+#define EXTI_INTF_INTF10                        ((uint32_t)0x00000400) /* Pending bit for line 10 */
+#define EXTI_INTF_INTF11                        ((uint32_t)0x00000800) /* Pending bit for line 11 */
+#define EXTI_INTF_INTF12                        ((uint32_t)0x00001000) /* Pending bit for line 12 */
+#define EXTI_INTF_INTF13                        ((uint32_t)0x00002000) /* Pending bit for line 13 */
+#define EXTI_INTF_INTF14                        ((uint32_t)0x00004000) /* Pending bit for line 14 */
+#define EXTI_INTF_INTF15                        ((uint32_t)0x00008000) /* Pending bit for line 15 */
+#define EXTI_INTF_INTF16                        ((uint32_t)0x00010000) /* Pending bit for line 16 */
+#define EXTI_INTF_INTF17                        ((uint32_t)0x00020000) /* Pending bit for line 17 */
+#define EXTI_INTF_INTF18                        ((uint32_t)0x00040000) /* Pending bit for line 18 */
+#define EXTI_INTF_INTF19                        ((uint32_t)0x00080000) /* Pending bit for line 19 */
+#define EXTI_INTF_INTF20                        ((uint32_t)0x00100000) /* Pending bit for line 20 */
+#define EXTI_INTF_INTF21                        ((uint32_t)0x00200000) /* Pending bit for line 21 */
+#define EXTI_INTF_INTF22                        ((uint32_t)0x00400000) /* Pending bit for line 22 */
+#define EXTI_INTF_INTF23                        ((uint32_t)0x00800000) /* Pending bit for line 23 */
+#define EXTI_INTF_INTF24                        ((uint32_t)0x01000000) /* Pending bit for line 24 */
+#define EXTI_INTF_INTF25                        ((uint32_t)0x02000000) /* Pending bit for line 25 */
+#define EXTI_INTF_INTF26                        ((uint32_t)0x04000000) /* Pending bit for line 26 */
+#define EXTI_INTF_INTF27                        ((uint32_t)0x08000000) /* Pending bit for line 27 */
+#define EXTI_INTF_INTF28                        ((uint32_t)0x10000000) /* Pending bit for line 28 */
+#define EXTI_INTF_INTF29                        ((uint32_t)0x20000000) /* Pending bit for line 29 */
+
+/******************************************************************************/
+/*                      FLASH and Option Bytes Registers                      */
+/******************************************************************************/
+
+/*******************  Bit definition for FLASH_ACTLR register  ******************/
+#define FLASH_ACTLR_LATENCY                     ((uint8_t)0x03) /* LATENCY[2:0] bits (Latency) */
+#define FLASH_ACTLR_LATENCY_0                   ((uint8_t)0x00) /* Bit 0 */
+#define FLASH_ACTLR_LATENCY_1                   ((uint8_t)0x01) /* Bit 0 */
+#define FLASH_ACTLR_LATENCY_2                   ((uint8_t)0x02) /* Bit 1 */
+
+/******************  Bit definition for FLASH_KEYR register  ******************/
+#define FLASH_KEYR_FKEYR                        ((uint32_t)0xFFFFFFFF) /* FPEC Key */
+
+/*****************  Bit definition for FLASH_OBKEYR register  ****************/
+#define FLASH_OBKEYR_OBKEYR                     ((uint32_t)0xFFFFFFFF) /* Option Byte Key */
+
+/******************  Bit definition for FLASH_STATR register  *******************/
+#define FLASH_STATR_BSY                         ((uint8_t)0x01) /* Busy */
+#define FLASH_STATR_PGERR                       ((uint8_t)0x04) /* Programming Error */
+#define FLASH_STATR_WRPRTERR                    ((uint8_t)0x10) /* Write Protection Error */
+#define FLASH_STATR_EOP                         ((uint8_t)0x20) /* End of operation */
+
+/*******************  Bit definition for FLASH_CTLR register  *******************/
+#define FLASH_CTLR_PG                           ((uint32_t)0x00000001) /* Programming */
+#define FLASH_CTLR_PER                          ((uint32_t)0x00000002) /* Sector Erase 4K */
+#define FLASH_CTLR_MER                          ((uint32_t)0x00000004) /* Mass Erase */
+#define FLASH_CTLR_OPTPG                        ((uint32_t)0x00000010) /* Option Byte Programming */
+#define FLASH_CTLR_OPTER                        ((uint32_t)0x00000020) /* Option Byte Erase */
+#define FLASH_CTLR_STRT                         ((uint32_t)0x00000040) /* Start */
+#define FLASH_CTLR_LOCK                         ((uint32_t)0x00000080) /* Lock */
+#define FLASH_CTLR_OPTWRE                       ((uint32_t)0x00000200) /* Option Bytes Write Enable */
+#define FLASH_CTLR_ERRIE                        ((uint32_t)0x00000400) /* Error Interrupt Enable */
+#define FLASH_CTLR_EOPIE                        ((uint32_t)0x00001000) /* End of operation interrupt enable */
+#define FLASH_CTLR_FAST_LOCK                    ((uint32_t)0x00008000) /* Fast Lock */
+#define FLASH_CTLR_PAGE_PG                      ((uint32_t)0x00010000) /* Page Programming 256Byte */
+#define FLASH_CTLR_PAGE_ER                      ((uint32_t)0x00020000) /* Page Erase 256Byte */
+#define FLASH_CTLR_PAGE_BER32                   ((uint32_t)0x00040000) /* Block Erase 32K */
+#define FLASH_CTLR_PAGE_BER64                   ((uint32_t)0x00080000) /* Block Erase 64K */
+#define FLASH_CTLR_PG_STRT                      ((uint32_t)0x00200000) /* Page Programming Start */
+
+/*******************  Bit definition for FLASH_ADDR register  *******************/
+#define FLASH_ADDR_FAR                          ((uint32_t)0xFFFFFFFF) /* Flash Address */
+
+/******************  Bit definition for FLASH_OBR register  *******************/
+#define FLASH_OBR_OPTERR                        ((uint16_t)0x0001) /* Option Byte Error */
+#define FLASH_OBR_RDPRT                         ((uint16_t)0x0002) /* Read protection */
+
+#define FLASH_OBR_USER                          ((uint16_t)0x03FC) /* User Option Bytes */
+#define FLASH_OBR_WDG_SW                        ((uint16_t)0x0004) /* WDG_SW */
+#define FLASH_OBR_nRST_STOP                     ((uint16_t)0x0008) /* nRST_STOP */
+#define FLASH_OBR_nRST_STDBY                    ((uint16_t)0x0010) /* nRST_STDBY */
+#define FLASH_OBR_BFB2                          ((uint16_t)0x0020) /* BFB2 */
+
+/******************  Bit definition for FLASH_WPR register  ******************/
+#define FLASH_WPR_WRP                           ((uint32_t)0xFFFFFFFF) /* Write Protect */
+
+/******************  Bit definition for FLASH_RDPR register  *******************/
+#define FLASH_RDPR_RDPR                         ((uint32_t)0x000000FF) /* Read protection option byte */
+#define FLASH_RDPR_nRDPR                        ((uint32_t)0x0000FF00) /* Read protection complemented option byte */
+
+/******************  Bit definition for FLASH_USER register  ******************/
+#define FLASH_USER_USER                         ((uint32_t)0x00FF0000) /* User option byte */
+#define FLASH_USER_nUSER                        ((uint32_t)0xFF000000) /* User complemented option byte */
+
+/******************  Bit definition for FLASH_Data0 register  *****************/
+#define FLASH_Data0_Data0                       ((uint32_t)0x000000FF) /* User data storage option byte */
+#define FLASH_Data0_nData0                      ((uint32_t)0x0000FF00) /* User data storage complemented option byte */
+
+/******************  Bit definition for FLASH_Data1 register  *****************/
+#define FLASH_Data1_Data1                       ((uint32_t)0x00FF0000) /* User data storage option byte */
+#define FLASH_Data1_nData1                      ((uint32_t)0xFF000000) /* User data storage complemented option byte */
+
+/******************  Bit definition for FLASH_WRPR0 register  ******************/
+#define FLASH_WRPR0_WRPR0                       ((uint32_t)0x000000FF) /* Flash memory write protection option bytes */
+#define FLASH_WRPR0_nWRPR0                      ((uint32_t)0x0000FF00) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR1 register  ******************/
+#define FLASH_WRPR1_WRPR1                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
+#define FLASH_WRPR1_nWRPR1                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR2 register  ******************/
+#define FLASH_WRPR2_WRPR2                       ((uint32_t)0x000000FF) /* Flash memory write protection option bytes */
+#define FLASH_WRPR2_nWRPR2                      ((uint32_t)0x0000FF00) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR3 register  ******************/
+#define FLASH_WRPR3_WRPR3                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
+#define FLASH_WRPR3_nWRPR3                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
+
+/******************************************************************************/
+/*                General Purpose and Alternate Function I/O                  */
+/******************************************************************************/
+
+/*******************  Bit definition for GPIO_CFGLR register  *******************/
+#define GPIO_CFGLR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
+
+#define GPIO_CFGLR_MODE0                        ((uint32_t)0x00000003) /* MODE0[1:0] bits (Port x mode bits, pin 0) */
+#define GPIO_CFGLR_MODE0_0                      ((uint32_t)0x00000001) /* Bit 0 */
+#define GPIO_CFGLR_MODE0_1                      ((uint32_t)0x00000002) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE1                        ((uint32_t)0x00000030) /* MODE1[1:0] bits (Port x mode bits, pin 1) */
+#define GPIO_CFGLR_MODE1_0                      ((uint32_t)0x00000010) /* Bit 0 */
+#define GPIO_CFGLR_MODE1_1                      ((uint32_t)0x00000020) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE2                        ((uint32_t)0x00000300) /* MODE2[1:0] bits (Port x mode bits, pin 2) */
+#define GPIO_CFGLR_MODE2_0                      ((uint32_t)0x00000100) /* Bit 0 */
+#define GPIO_CFGLR_MODE2_1                      ((uint32_t)0x00000200) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE3                        ((uint32_t)0x00003000) /* MODE3[1:0] bits (Port x mode bits, pin 3) */
+#define GPIO_CFGLR_MODE3_0                      ((uint32_t)0x00001000) /* Bit 0 */
+#define GPIO_CFGLR_MODE3_1                      ((uint32_t)0x00002000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE4                        ((uint32_t)0x00030000) /* MODE4[1:0] bits (Port x mode bits, pin 4) */
+#define GPIO_CFGLR_MODE4_0                      ((uint32_t)0x00010000) /* Bit 0 */
+#define GPIO_CFGLR_MODE4_1                      ((uint32_t)0x00020000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE5                        ((uint32_t)0x00300000) /* MODE5[1:0] bits (Port x mode bits, pin 5) */
+#define GPIO_CFGLR_MODE5_0                      ((uint32_t)0x00100000) /* Bit 0 */
+#define GPIO_CFGLR_MODE5_1                      ((uint32_t)0x00200000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE6                        ((uint32_t)0x03000000) /* MODE6[1:0] bits (Port x mode bits, pin 6) */
+#define GPIO_CFGLR_MODE6_0                      ((uint32_t)0x01000000) /* Bit 0 */
+#define GPIO_CFGLR_MODE6_1                      ((uint32_t)0x02000000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE7                        ((uint32_t)0x30000000) /* MODE7[1:0] bits (Port x mode bits, pin 7) */
+#define GPIO_CFGLR_MODE7_0                      ((uint32_t)0x10000000) /* Bit 0 */
+#define GPIO_CFGLR_MODE7_1                      ((uint32_t)0x20000000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
+
+#define GPIO_CFGLR_CNF0                         ((uint32_t)0x0000000C) /* CNF0[1:0] bits (Port x configuration bits, pin 0) */
+#define GPIO_CFGLR_CNF0_0                       ((uint32_t)0x00000004) /* Bit 0 */
+#define GPIO_CFGLR_CNF0_1                       ((uint32_t)0x00000008) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF1                         ((uint32_t)0x000000C0) /* CNF1[1:0] bits (Port x configuration bits, pin 1) */
+#define GPIO_CFGLR_CNF1_0                       ((uint32_t)0x00000040) /* Bit 0 */
+#define GPIO_CFGLR_CNF1_1                       ((uint32_t)0x00000080) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF2                         ((uint32_t)0x00000C00) /* CNF2[1:0] bits (Port x configuration bits, pin 2) */
+#define GPIO_CFGLR_CNF2_0                       ((uint32_t)0x00000400) /* Bit 0 */
+#define GPIO_CFGLR_CNF2_1                       ((uint32_t)0x00000800) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF3                         ((uint32_t)0x0000C000) /* CNF3[1:0] bits (Port x configuration bits, pin 3) */
+#define GPIO_CFGLR_CNF3_0                       ((uint32_t)0x00004000) /* Bit 0 */
+#define GPIO_CFGLR_CNF3_1                       ((uint32_t)0x00008000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF4                         ((uint32_t)0x000C0000) /* CNF4[1:0] bits (Port x configuration bits, pin 4) */
+#define GPIO_CFGLR_CNF4_0                       ((uint32_t)0x00040000) /* Bit 0 */
+#define GPIO_CFGLR_CNF4_1                       ((uint32_t)0x00080000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF5                         ((uint32_t)0x00C00000) /* CNF5[1:0] bits (Port x configuration bits, pin 5) */
+#define GPIO_CFGLR_CNF5_0                       ((uint32_t)0x00400000) /* Bit 0 */
+#define GPIO_CFGLR_CNF5_1                       ((uint32_t)0x00800000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF6                         ((uint32_t)0x0C000000) /* CNF6[1:0] bits (Port x configuration bits, pin 6) */
+#define GPIO_CFGLR_CNF6_0                       ((uint32_t)0x04000000) /* Bit 0 */
+#define GPIO_CFGLR_CNF6_1                       ((uint32_t)0x08000000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF7                         ((uint32_t)0xC0000000) /* CNF7[1:0] bits (Port x configuration bits, pin 7) */
+#define GPIO_CFGLR_CNF7_0                       ((uint32_t)0x40000000) /* Bit 0 */
+#define GPIO_CFGLR_CNF7_1                       ((uint32_t)0x80000000) /* Bit 1 */
+
+/*******************  Bit definition for GPIO_CFGHR register  *******************/
+#define GPIO_CFGHR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
+
+#define GPIO_CFGHR_MODE8                        ((uint32_t)0x00000003) /* MODE8[1:0] bits (Port x mode bits, pin 8) */
+#define GPIO_CFGHR_MODE8_0                      ((uint32_t)0x00000001) /* Bit 0 */
+#define GPIO_CFGHR_MODE8_1                      ((uint32_t)0x00000002) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE9                        ((uint32_t)0x00000030) /* MODE9[1:0] bits (Port x mode bits, pin 9) */
+#define GPIO_CFGHR_MODE9_0                      ((uint32_t)0x00000010) /* Bit 0 */
+#define GPIO_CFGHR_MODE9_1                      ((uint32_t)0x00000020) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE10                       ((uint32_t)0x00000300) /* MODE10[1:0] bits (Port x mode bits, pin 10) */
+#define GPIO_CFGHR_MODE10_0                     ((uint32_t)0x00000100) /* Bit 0 */
+#define GPIO_CFGHR_MODE10_1                     ((uint32_t)0x00000200) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE11                       ((uint32_t)0x00003000) /* MODE11[1:0] bits (Port x mode bits, pin 11) */
+#define GPIO_CFGHR_MODE11_0                     ((uint32_t)0x00001000) /* Bit 0 */
+#define GPIO_CFGHR_MODE11_1                     ((uint32_t)0x00002000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE12                       ((uint32_t)0x00030000) /* MODE12[1:0] bits (Port x mode bits, pin 12) */
+#define GPIO_CFGHR_MODE12_0                     ((uint32_t)0x00010000) /* Bit 0 */
+#define GPIO_CFGHR_MODE12_1                     ((uint32_t)0x00020000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE13                       ((uint32_t)0x00300000) /* MODE13[1:0] bits (Port x mode bits, pin 13) */
+#define GPIO_CFGHR_MODE13_0                     ((uint32_t)0x00100000) /* Bit 0 */
+#define GPIO_CFGHR_MODE13_1                     ((uint32_t)0x00200000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE14                       ((uint32_t)0x03000000) /* MODE14[1:0] bits (Port x mode bits, pin 14) */
+#define GPIO_CFGHR_MODE14_0                     ((uint32_t)0x01000000) /* Bit 0 */
+#define GPIO_CFGHR_MODE14_1                     ((uint32_t)0x02000000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE15                       ((uint32_t)0x30000000) /* MODE15[1:0] bits (Port x mode bits, pin 15) */
+#define GPIO_CFGHR_MODE15_0                     ((uint32_t)0x10000000) /* Bit 0 */
+#define GPIO_CFGHR_MODE15_1                     ((uint32_t)0x20000000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
+
+#define GPIO_CFGHR_CNF8                         ((uint32_t)0x0000000C) /* CNF8[1:0] bits (Port x configuration bits, pin 8) */
+#define GPIO_CFGHR_CNF8_0                       ((uint32_t)0x00000004) /* Bit 0 */
+#define GPIO_CFGHR_CNF8_1                       ((uint32_t)0x00000008) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF9                         ((uint32_t)0x000000C0) /* CNF9[1:0] bits (Port x configuration bits, pin 9) */
+#define GPIO_CFGHR_CNF9_0                       ((uint32_t)0x00000040) /* Bit 0 */
+#define GPIO_CFGHR_CNF9_1                       ((uint32_t)0x00000080) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF10                        ((uint32_t)0x00000C00) /* CNF10[1:0] bits (Port x configuration bits, pin 10) */
+#define GPIO_CFGHR_CNF10_0                      ((uint32_t)0x00000400) /* Bit 0 */
+#define GPIO_CFGHR_CNF10_1                      ((uint32_t)0x00000800) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF11                        ((uint32_t)0x0000C000) /* CNF11[1:0] bits (Port x configuration bits, pin 11) */
+#define GPIO_CFGHR_CNF11_0                      ((uint32_t)0x00004000) /* Bit 0 */
+#define GPIO_CFGHR_CNF11_1                      ((uint32_t)0x00008000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF12                        ((uint32_t)0x000C0000) /* CNF12[1:0] bits (Port x configuration bits, pin 12) */
+#define GPIO_CFGHR_CNF12_0                      ((uint32_t)0x00040000) /* Bit 0 */
+#define GPIO_CFGHR_CNF12_1                      ((uint32_t)0x00080000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF13                        ((uint32_t)0x00C00000) /* CNF13[1:0] bits (Port x configuration bits, pin 13) */
+#define GPIO_CFGHR_CNF13_0                      ((uint32_t)0x00400000) /* Bit 0 */
+#define GPIO_CFGHR_CNF13_1                      ((uint32_t)0x00800000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF14                        ((uint32_t)0x0C000000) /* CNF14[1:0] bits (Port x configuration bits, pin 14) */
+#define GPIO_CFGHR_CNF14_0                      ((uint32_t)0x04000000) /* Bit 0 */
+#define GPIO_CFGHR_CNF14_1                      ((uint32_t)0x08000000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF15                        ((uint32_t)0xC0000000) /* CNF15[1:0] bits (Port x configuration bits, pin 15) */
+#define GPIO_CFGHR_CNF15_0                      ((uint32_t)0x40000000) /* Bit 0 */
+#define GPIO_CFGHR_CNF15_1                      ((uint32_t)0x80000000) /* Bit 1 */
+
+/*******************  Bit definition for GPIO_INDR register  *******************/
+#define GPIO_INDR_IDR0                          ((uint16_t)0x0001) /* Port input data, bit 0 */
+#define GPIO_INDR_IDR1                          ((uint16_t)0x0002) /* Port input data, bit 1 */
+#define GPIO_INDR_IDR2                          ((uint16_t)0x0004) /* Port input data, bit 2 */
+#define GPIO_INDR_IDR3                          ((uint16_t)0x0008) /* Port input data, bit 3 */
+#define GPIO_INDR_IDR4                          ((uint16_t)0x0010) /* Port input data, bit 4 */
+#define GPIO_INDR_IDR5                          ((uint16_t)0x0020) /* Port input data, bit 5 */
+#define GPIO_INDR_IDR6                          ((uint16_t)0x0040) /* Port input data, bit 6 */
+#define GPIO_INDR_IDR7                          ((uint16_t)0x0080) /* Port input data, bit 7 */
+#define GPIO_INDR_IDR8                          ((uint16_t)0x0100) /* Port input data, bit 8 */
+#define GPIO_INDR_IDR9                          ((uint16_t)0x0200) /* Port input data, bit 9 */
+#define GPIO_INDR_IDR10                         ((uint16_t)0x0400) /* Port input data, bit 10 */
+#define GPIO_INDR_IDR11                         ((uint16_t)0x0800) /* Port input data, bit 11 */
+#define GPIO_INDR_IDR12                         ((uint16_t)0x1000) /* Port input data, bit 12 */
+#define GPIO_INDR_IDR13                         ((uint16_t)0x2000) /* Port input data, bit 13 */
+#define GPIO_INDR_IDR14                         ((uint16_t)0x4000) /* Port input data, bit 14 */
+#define GPIO_INDR_IDR15                         ((uint16_t)0x8000) /* Port input data, bit 15 */
+
+/*******************  Bit definition for GPIO_OUTDR register  *******************/
+#define GPIO_OUTDR_ODR0                         ((uint16_t)0x0001) /* Port output data, bit 0 */
+#define GPIO_OUTDR_ODR1                         ((uint16_t)0x0002) /* Port output data, bit 1 */
+#define GPIO_OUTDR_ODR2                         ((uint16_t)0x0004) /* Port output data, bit 2 */
+#define GPIO_OUTDR_ODR3                         ((uint16_t)0x0008) /* Port output data, bit 3 */
+#define GPIO_OUTDR_ODR4                         ((uint16_t)0x0010) /* Port output data, bit 4 */
+#define GPIO_OUTDR_ODR5                         ((uint16_t)0x0020) /* Port output data, bit 5 */
+#define GPIO_OUTDR_ODR6                         ((uint16_t)0x0040) /* Port output data, bit 6 */
+#define GPIO_OUTDR_ODR7                         ((uint16_t)0x0080) /* Port output data, bit 7 */
+#define GPIO_OUTDR_ODR8                         ((uint16_t)0x0100) /* Port output data, bit 8 */
+#define GPIO_OUTDR_ODR9                         ((uint16_t)0x0200) /* Port output data, bit 9 */
+#define GPIO_OUTDR_ODR10                        ((uint16_t)0x0400) /* Port output data, bit 10 */
+#define GPIO_OUTDR_ODR11                        ((uint16_t)0x0800) /* Port output data, bit 11 */
+#define GPIO_OUTDR_ODR12                        ((uint16_t)0x1000) /* Port output data, bit 12 */
+#define GPIO_OUTDR_ODR13                        ((uint16_t)0x2000) /* Port output data, bit 13 */
+#define GPIO_OUTDR_ODR14                        ((uint16_t)0x4000) /* Port output data, bit 14 */
+#define GPIO_OUTDR_ODR15                        ((uint16_t)0x8000) /* Port output data, bit 15 */
+
+/******************  Bit definition for GPIO_BSHR register  *******************/
+#define GPIO_BSHR_BS0                           ((uint32_t)0x00000001) /* Port x Set bit 0 */
+#define GPIO_BSHR_BS1                           ((uint32_t)0x00000002) /* Port x Set bit 1 */
+#define GPIO_BSHR_BS2                           ((uint32_t)0x00000004) /* Port x Set bit 2 */
+#define GPIO_BSHR_BS3                           ((uint32_t)0x00000008) /* Port x Set bit 3 */
+#define GPIO_BSHR_BS4                           ((uint32_t)0x00000010) /* Port x Set bit 4 */
+#define GPIO_BSHR_BS5                           ((uint32_t)0x00000020) /* Port x Set bit 5 */
+#define GPIO_BSHR_BS6                           ((uint32_t)0x00000040) /* Port x Set bit 6 */
+#define GPIO_BSHR_BS7                           ((uint32_t)0x00000080) /* Port x Set bit 7 */
+#define GPIO_BSHR_BS8                           ((uint32_t)0x00000100) /* Port x Set bit 8 */
+#define GPIO_BSHR_BS9                           ((uint32_t)0x00000200) /* Port x Set bit 9 */
+#define GPIO_BSHR_BS10                          ((uint32_t)0x00000400) /* Port x Set bit 10 */
+#define GPIO_BSHR_BS11                          ((uint32_t)0x00000800) /* Port x Set bit 11 */
+#define GPIO_BSHR_BS12                          ((uint32_t)0x00001000) /* Port x Set bit 12 */
+#define GPIO_BSHR_BS13                          ((uint32_t)0x00002000) /* Port x Set bit 13 */
+#define GPIO_BSHR_BS14                          ((uint32_t)0x00004000) /* Port x Set bit 14 */
+#define GPIO_BSHR_BS15                          ((uint32_t)0x00008000) /* Port x Set bit 15 */
+
+#define GPIO_BSHR_BR0                           ((uint32_t)0x00010000) /* Port x Reset bit 0 */
+#define GPIO_BSHR_BR1                           ((uint32_t)0x00020000) /* Port x Reset bit 1 */
+#define GPIO_BSHR_BR2                           ((uint32_t)0x00040000) /* Port x Reset bit 2 */
+#define GPIO_BSHR_BR3                           ((uint32_t)0x00080000) /* Port x Reset bit 3 */
+#define GPIO_BSHR_BR4                           ((uint32_t)0x00100000) /* Port x Reset bit 4 */
+#define GPIO_BSHR_BR5                           ((uint32_t)0x00200000) /* Port x Reset bit 5 */
+#define GPIO_BSHR_BR6                           ((uint32_t)0x00400000) /* Port x Reset bit 6 */
+#define GPIO_BSHR_BR7                           ((uint32_t)0x00800000) /* Port x Reset bit 7 */
+#define GPIO_BSHR_BR8                           ((uint32_t)0x01000000) /* Port x Reset bit 8 */
+#define GPIO_BSHR_BR9                           ((uint32_t)0x02000000) /* Port x Reset bit 9 */
+#define GPIO_BSHR_BR10                          ((uint32_t)0x04000000) /* Port x Reset bit 10 */
+#define GPIO_BSHR_BR11                          ((uint32_t)0x08000000) /* Port x Reset bit 11 */
+#define GPIO_BSHR_BR12                          ((uint32_t)0x10000000) /* Port x Reset bit 12 */
+#define GPIO_BSHR_BR13                          ((uint32_t)0x20000000) /* Port x Reset bit 13 */
+#define GPIO_BSHR_BR14                          ((uint32_t)0x40000000) /* Port x Reset bit 14 */
+#define GPIO_BSHR_BR15                          ((uint32_t)0x80000000) /* Port x Reset bit 15 */
+
+/*******************  Bit definition for GPIO_BCR register  *******************/
+#define GPIO_BCR_BR0                            ((uint16_t)0x0001) /* Port x Reset bit 0 */
+#define GPIO_BCR_BR1                            ((uint16_t)0x0002) /* Port x Reset bit 1 */
+#define GPIO_BCR_BR2                            ((uint16_t)0x0004) /* Port x Reset bit 2 */
+#define GPIO_BCR_BR3                            ((uint16_t)0x0008) /* Port x Reset bit 3 */
+#define GPIO_BCR_BR4                            ((uint16_t)0x0010) /* Port x Reset bit 4 */
+#define GPIO_BCR_BR5                            ((uint16_t)0x0020) /* Port x Reset bit 5 */
+#define GPIO_BCR_BR6                            ((uint16_t)0x0040) /* Port x Reset bit 6 */
+#define GPIO_BCR_BR7                            ((uint16_t)0x0080) /* Port x Reset bit 7 */
+#define GPIO_BCR_BR8                            ((uint16_t)0x0100) /* Port x Reset bit 8 */
+#define GPIO_BCR_BR9                            ((uint16_t)0x0200) /* Port x Reset bit 9 */
+#define GPIO_BCR_BR10                           ((uint16_t)0x0400) /* Port x Reset bit 10 */
+#define GPIO_BCR_BR11                           ((uint16_t)0x0800) /* Port x Reset bit 11 */
+#define GPIO_BCR_BR12                           ((uint16_t)0x1000) /* Port x Reset bit 12 */
+#define GPIO_BCR_BR13                           ((uint16_t)0x2000) /* Port x Reset bit 13 */
+#define GPIO_BCR_BR14                           ((uint16_t)0x4000) /* Port x Reset bit 14 */
+#define GPIO_BCR_BR15                           ((uint16_t)0x8000) /* Port x Reset bit 15 */
+
+/******************  Bit definition for GPIO_LCKR register  *******************/
+#define GPIO_LCK0                               ((uint32_t)0x00000001) /* Port x Lock bit 0 */
+#define GPIO_LCK1                               ((uint32_t)0x00000002) /* Port x Lock bit 1 */
+#define GPIO_LCK2                               ((uint32_t)0x00000004) /* Port x Lock bit 2 */
+#define GPIO_LCK3                               ((uint32_t)0x00000008) /* Port x Lock bit 3 */
+#define GPIO_LCK4                               ((uint32_t)0x00000010) /* Port x Lock bit 4 */
+#define GPIO_LCK5                               ((uint32_t)0x00000020) /* Port x Lock bit 5 */
+#define GPIO_LCK6                               ((uint32_t)0x00000040) /* Port x Lock bit 6 */
+#define GPIO_LCK7                               ((uint32_t)0x00000080) /* Port x Lock bit 7 */
+#define GPIO_LCK8                               ((uint32_t)0x00000100) /* Port x Lock bit 8 */
+#define GPIO_LCK9                               ((uint32_t)0x00000200) /* Port x Lock bit 9 */
+#define GPIO_LCK10                              ((uint32_t)0x00000400) /* Port x Lock bit 10 */
+#define GPIO_LCK11                              ((uint32_t)0x00000800) /* Port x Lock bit 11 */
+#define GPIO_LCK12                              ((uint32_t)0x00001000) /* Port x Lock bit 12 */
+#define GPIO_LCK13                              ((uint32_t)0x00002000) /* Port x Lock bit 13 */
+#define GPIO_LCK14                              ((uint32_t)0x00004000) /* Port x Lock bit 14 */
+#define GPIO_LCK15                              ((uint32_t)0x00008000) /* Port x Lock bit 15 */
+#define GPIO_LCKK                               ((uint32_t)0x00010000) /* Lock key */
+
+/******************  Bit definition for AFIO_PCFR1register  *******************/
+#define AFIO_PCFR1_SPI1_REMAP                   ((uint32_t)0x00000001) /* SPI1 remapping */
+#define AFIO_PCFR1_I2C1_REMAP                   ((uint32_t)0x00000002) /* I2C1 remapping */
+#define AFIO_PCFR1_USART1_REMAP                 ((uint32_t)0x00000004) /* USART1 remapping */
+#define AFIO_PCFR1_USART2_REMAP                 ((uint32_t)0x00000008) /* USART2 remapping */
+
+#define AFIO_PCFR1_USART3_REMAP                 ((uint32_t)0x00000030) /* USART3_REMAP[1:0] bits (USART3 remapping) */
+#define AFIO_PCFR1_USART3_REMAP_0               ((uint32_t)0x00000010) /* Bit 0 */
+#define AFIO_PCFR1_USART3_REMAP_1               ((uint32_t)0x00000020) /* Bit 1 */
+
+#define AFIO_PCFR1_USART3_REMAP_NOREMAP         ((uint32_t)0x00000000) /* No remap (TX/PB10, RX/PB11, CK/PB12, CTS/PB13, RTS/PB14) */
+#define AFIO_PCFR1_USART3_REMAP_PARTIALREMAP    ((uint32_t)0x00000010) /* Partial remap (TX/PC10, RX/PC11, CK/PC12, CTS/PB13, RTS/PB14) */
+#define AFIO_PCFR1_USART3_REMAP_FULLREMAP       ((uint32_t)0x00000030) /* Full remap (TX/PD8, RX/PD9, CK/PD10, CTS/PD11, RTS/PD12) */
+
+#define AFIO_PCFR1_TIM1_REMAP                   ((uint32_t)0x000000C0) /* TIM1_REMAP[1:0] bits (TIM1 remapping) */
+#define AFIO_PCFR1_TIM1_REMAP_0                 ((uint32_t)0x00000040) /* Bit 0 */
+#define AFIO_PCFR1_TIM1_REMAP_1                 ((uint32_t)0x00000080) /* Bit 1 */
+
+#define AFIO_PCFR1_TIM1_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (ETR/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BKIN/PB12, CH1N/PB13, CH2N/PB14, CH3N/PB15) */
+#define AFIO_PCFR1_TIM1_REMAP_PARTIALREMAP      ((uint32_t)0x00000040) /* Partial remap (ETR/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BKIN/PA6, CH1N/PA7, CH2N/PB0, CH3N/PB1) */
+#define AFIO_PCFR1_TIM1_REMAP_FULLREMAP         ((uint32_t)0x000000C0) /* Full remap (ETR/PE7, CH1/PE9, CH2/PE11, CH3/PE13, CH4/PE14, BKIN/PE15, CH1N/PE8, CH2N/PE10, CH3N/PE12) */
+
+#define AFIO_PCFR1_TIM2_REMAP                   ((uint32_t)0x00000300) /* TIM2_REMAP[1:0] bits (TIM2 remapping) */
+#define AFIO_PCFR1_TIM2_REMAP_0                 ((uint32_t)0x00000100) /* Bit 0 */
+#define AFIO_PCFR1_TIM2_REMAP_1                 ((uint32_t)0x00000200) /* Bit 1 */
+
+#define AFIO_PCFR1_TIM2_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (CH1/ETR/PA0, CH2/PA1, CH3/PA2, CH4/PA3) */
+#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP1     ((uint32_t)0x00000100) /* Partial remap (CH1/ETR/PA15, CH2/PB3, CH3/PA2, CH4/PA3) */
+#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP2     ((uint32_t)0x00000200) /* Partial remap (CH1/ETR/PA0, CH2/PA1, CH3/PB10, CH4/PB11) */
+#define AFIO_PCFR1_TIM2_REMAP_FULLREMAP         ((uint32_t)0x00000300) /* Full remap (CH1/ETR/PA15, CH2/PB3, CH3/PB10, CH4/PB11) */
+
+#define AFIO_PCFR1_TIM3_REMAP                   ((uint32_t)0x00000C00) /* TIM3_REMAP[1:0] bits (TIM3 remapping) */
+#define AFIO_PCFR1_TIM3_REMAP_0                 ((uint32_t)0x00000400) /* Bit 0 */
+#define AFIO_PCFR1_TIM3_REMAP_1                 ((uint32_t)0x00000800) /* Bit 1 */
+
+#define AFIO_PCFR1_TIM3_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (CH1/PA6, CH2/PA7, CH3/PB0, CH4/PB1) */
+#define AFIO_PCFR1_TIM3_REMAP_PARTIALREMAP      ((uint32_t)0x00000800) /* Partial remap (CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1) */
+#define AFIO_PCFR1_TIM3_REMAP_FULLREMAP         ((uint32_t)0x00000C00) /* Full remap (CH1/PC6, CH2/PC7, CH3/PC8, CH4/PC9) */
+
+#define AFIO_PCFR1_SWJ_CFG                      ((uint32_t)0x07000000) /* SWJ_CFG[2:0] bits (Serial Wire JTAG configuration) */
+#define AFIO_PCFR1_SWJ_CFG_0                    ((uint32_t)0x01000000) /* Bit 0 */
+#define AFIO_PCFR1_SWJ_CFG_1                    ((uint32_t)0x02000000) /* Bit 1 */
+#define AFIO_PCFR1_SWJ_CFG_2                    ((uint32_t)0x04000000) /* Bit 2 */
+
+#define AFIO_PCFR1_SWJ_CFG_RESET                ((uint32_t)0x00000000) /* Full SWJ (JTAG-DP + SW-DP) : Reset State */
+#define AFIO_PCFR1_SWJ_CFG_DISABLE              ((uint32_t)0x04000000) /* JTAG-DP Disabled and SW-DP Disabled */
+
+/*****************  Bit definition for AFIO_EXTICR1 register  *****************/
+#define AFIO_EXTICR1_EXTI0                      ((uint16_t)0x000F) /* EXTI 0 configuration */
+#define AFIO_EXTICR1_EXTI1                      ((uint16_t)0x00F0) /* EXTI 1 configuration */
+#define AFIO_EXTICR1_EXTI2                      ((uint16_t)0x0F00) /* EXTI 2 configuration */
+#define AFIO_EXTICR1_EXTI3                      ((uint16_t)0xF000) /* EXTI 3 configuration */
+
+#define AFIO_EXTICR1_EXTI0_PA                   ((uint16_t)0x0000) /* PA[0] pin */
+#define AFIO_EXTICR1_EXTI0_PB                   ((uint16_t)0x0001) /* PB[0] pin */
+#define AFIO_EXTICR1_EXTI0_PC                   ((uint16_t)0x0002) /* PC[0] pin */
+
+#define AFIO_EXTICR1_EXTI1_PA                   ((uint16_t)0x0000) /* PA[1] pin */
+#define AFIO_EXTICR1_EXTI1_PB                   ((uint16_t)0x0010) /* PB[1] pin */
+#define AFIO_EXTICR1_EXTI1_PC                   ((uint16_t)0x0020) /* PC[1] pin */
+
+#define AFIO_EXTICR1_EXTI2_PA                   ((uint16_t)0x0000) /* PA[2] pin */
+#define AFIO_EXTICR1_EXTI2_PB                   ((uint16_t)0x0100) /* PB[2] pin */
+#define AFIO_EXTICR1_EXTI2_PC                   ((uint16_t)0x0200) /* PC[2] pin */
+
+#define AFIO_EXTICR1_EXTI3_PA                   ((uint16_t)0x0000) /* PA[3] pin */
+#define AFIO_EXTICR1_EXTI3_PB                   ((uint16_t)0x1000) /* PB[3] pin */
+#define AFIO_EXTICR1_EXTI3_PC                   ((uint16_t)0x2000) /* PC[3] pin */
+
+/*****************  Bit definition for AFIO_EXTICR2 register  *****************/
+#define AFIO_EXTICR2_EXTI4                      ((uint16_t)0x000F) /* EXTI 4 configuration */
+#define AFIO_EXTICR2_EXTI5                      ((uint16_t)0x00F0) /* EXTI 5 configuration */
+#define AFIO_EXTICR2_EXTI6                      ((uint16_t)0x0F00) /* EXTI 6 configuration */
+#define AFIO_EXTICR2_EXTI7                      ((uint16_t)0xF000) /* EXTI 7 configuration */
+
+#define AFIO_EXTICR2_EXTI4_PA                   ((uint16_t)0x0000) /* PA[4] pin */
+#define AFIO_EXTICR2_EXTI4_PB                   ((uint16_t)0x0001) /* PB[4] pin */
+#define AFIO_EXTICR2_EXTI4_PC                   ((uint16_t)0x0002) /* PC[4] pin */
+#define AFIO_EXTICR2_EXTI4_PD                   ((uint16_t)0x0003) /* PD[4] pin */
+#define AFIO_EXTICR2_EXTI4_PE                   ((uint16_t)0x0004) /* PE[4] pin */
+#define AFIO_EXTICR2_EXTI4_PF                   ((uint16_t)0x0005) /* PF[4] pin */
+#define AFIO_EXTICR2_EXTI4_PG                   ((uint16_t)0x0006) /* PG[4] pin */
+
+#define AFIO_EXTICR2_EXTI5_PA                   ((uint16_t)0x0000) /* PA[5] pin */
+#define AFIO_EXTICR2_EXTI5_PB                   ((uint16_t)0x0010) /* PB[5] pin */
+#define AFIO_EXTICR2_EXTI5_PC                   ((uint16_t)0x0020) /* PC[5] pin */
+#define AFIO_EXTICR2_EXTI5_PD                   ((uint16_t)0x0030) /* PD[5] pin */
+#define AFIO_EXTICR2_EXTI5_PE                   ((uint16_t)0x0040) /* PE[5] pin */
+#define AFIO_EXTICR2_EXTI5_PF                   ((uint16_t)0x0050) /* PF[5] pin */
+#define AFIO_EXTICR2_EXTI5_PG                   ((uint16_t)0x0060) /* PG[5] pin */
+
+#define AFIO_EXTICR2_EXTI6_PA                   ((uint16_t)0x0000) /* PA[6] pin */
+#define AFIO_EXTICR2_EXTI6_PB                   ((uint16_t)0x0100) /* PB[6] pin */
+#define AFIO_EXTICR2_EXTI6_PC                   ((uint16_t)0x0200) /* PC[6] pin */
+#define AFIO_EXTICR2_EXTI6_PD                   ((uint16_t)0x0300) /* PD[6] pin */
+#define AFIO_EXTICR2_EXTI6_PE                   ((uint16_t)0x0400) /* PE[6] pin */
+#define AFIO_EXTICR2_EXTI6_PF                   ((uint16_t)0x0500) /* PF[6] pin */
+#define AFIO_EXTICR2_EXTI6_PG                   ((uint16_t)0x0600) /* PG[6] pin */
+
+#define AFIO_EXTICR2_EXTI7_PA                   ((uint16_t)0x0000) /* PA[7] pin */
+#define AFIO_EXTICR2_EXTI7_PB                   ((uint16_t)0x1000) /* PB[7] pin */
+#define AFIO_EXTICR2_EXTI7_PC                   ((uint16_t)0x2000) /* PC[7] pin */
+#define AFIO_EXTICR2_EXTI7_PD                   ((uint16_t)0x3000) /* PD[7] pin */
+#define AFIO_EXTICR2_EXTI7_PE                   ((uint16_t)0x4000) /* PE[7] pin */
+#define AFIO_EXTICR2_EXTI7_PF                   ((uint16_t)0x5000) /* PF[7] pin */
+#define AFIO_EXTICR2_EXTI7_PG                   ((uint16_t)0x6000) /* PG[7] pin */
+
+/*****************  Bit definition for AFIO_EXTICR3 register  *****************/
+#define AFIO_EXTICR3_EXTI8                      ((uint16_t)0x000F) /* EXTI 8 configuration */
+#define AFIO_EXTICR3_EXTI9                      ((uint16_t)0x00F0) /* EXTI 9 configuration */
+#define AFIO_EXTICR3_EXTI10                     ((uint16_t)0x0F00) /* EXTI 10 configuration */
+#define AFIO_EXTICR3_EXTI11                     ((uint16_t)0xF000) /* EXTI 11 configuration */
+
+#define AFIO_EXTICR3_EXTI8_PA                   ((uint16_t)0x0000) /* PA[8] pin */
+#define AFIO_EXTICR3_EXTI8_PB                   ((uint16_t)0x0001) /* PB[8] pin */
+#define AFIO_EXTICR3_EXTI8_PC                   ((uint16_t)0x0002) /* PC[8] pin */
+#define AFIO_EXTICR3_EXTI8_PD                   ((uint16_t)0x0003) /* PD[8] pin */
+#define AFIO_EXTICR3_EXTI8_PE                   ((uint16_t)0x0004) /* PE[8] pin */
+#define AFIO_EXTICR3_EXTI8_PF                   ((uint16_t)0x0005) /* PF[8] pin */
+#define AFIO_EXTICR3_EXTI8_PG                   ((uint16_t)0x0006) /* PG[8] pin */
+
+#define AFIO_EXTICR3_EXTI9_PA                   ((uint16_t)0x0000) /* PA[9] pin */
+#define AFIO_EXTICR3_EXTI9_PB                   ((uint16_t)0x0010) /* PB[9] pin */
+#define AFIO_EXTICR3_EXTI9_PC                   ((uint16_t)0x0020) /* PC[9] pin */
+#define AFIO_EXTICR3_EXTI9_PD                   ((uint16_t)0x0030) /* PD[9] pin */
+#define AFIO_EXTICR3_EXTI9_PE                   ((uint16_t)0x0040) /* PE[9] pin */
+#define AFIO_EXTICR3_EXTI9_PF                   ((uint16_t)0x0050) /* PF[9] pin */
+#define AFIO_EXTICR3_EXTI9_PG                   ((uint16_t)0x0060) /* PG[9] pin */
+
+#define AFIO_EXTICR3_EXTI10_PA                  ((uint16_t)0x0000) /* PA[10] pin */
+#define AFIO_EXTICR3_EXTI10_PB                  ((uint16_t)0x0100) /* PB[10] pin */
+#define AFIO_EXTICR3_EXTI10_PC                  ((uint16_t)0x0200) /* PC[10] pin */
+#define AFIO_EXTICR3_EXTI10_PD                  ((uint16_t)0x0300) /* PD[10] pin */
+#define AFIO_EXTICR3_EXTI10_PE                  ((uint16_t)0x0400) /* PE[10] pin */
+#define AFIO_EXTICR3_EXTI10_PF                  ((uint16_t)0x0500) /* PF[10] pin */
+#define AFIO_EXTICR3_EXTI10_PG                  ((uint16_t)0x0600) /* PG[10] pin */
+
+#define AFIO_EXTICR3_EXTI11_PA                  ((uint16_t)0x0000) /* PA[11] pin */
+#define AFIO_EXTICR3_EXTI11_PB                  ((uint16_t)0x1000) /* PB[11] pin */
+#define AFIO_EXTICR3_EXTI11_PC                  ((uint16_t)0x2000) /* PC[11] pin */
+#define AFIO_EXTICR3_EXTI11_PD                  ((uint16_t)0x3000) /* PD[11] pin */
+#define AFIO_EXTICR3_EXTI11_PE                  ((uint16_t)0x4000) /* PE[11] pin */
+#define AFIO_EXTICR3_EXTI11_PF                  ((uint16_t)0x5000) /* PF[11] pin */
+#define AFIO_EXTICR3_EXTI11_PG                  ((uint16_t)0x6000) /* PG[11] pin */
+
+/*****************  Bit definition for AFIO_EXTICR4 register  *****************/
+#define AFIO_EXTICR4_EXTI12                     ((uint16_t)0x000F) /* EXTI 12 configuration */
+#define AFIO_EXTICR4_EXTI13                     ((uint16_t)0x00F0) /* EXTI 13 configuration */
+#define AFIO_EXTICR4_EXTI14                     ((uint16_t)0x0F00) /* EXTI 14 configuration */
+#define AFIO_EXTICR4_EXTI15                     ((uint16_t)0xF000) /* EXTI 15 configuration */
+
+#define AFIO_EXTICR4_EXTI12_PA                  ((uint16_t)0x0000) /* PA[12] pin */
+#define AFIO_EXTICR4_EXTI12_PB                  ((uint16_t)0x0001) /* PB[12] pin */
+#define AFIO_EXTICR4_EXTI12_PC                  ((uint16_t)0x0002) /* PC[12] pin */
+#define AFIO_EXTICR4_EXTI12_PD                  ((uint16_t)0x0003) /* PD[12] pin */
+#define AFIO_EXTICR4_EXTI12_PE                  ((uint16_t)0x0004) /* PE[12] pin */
+#define AFIO_EXTICR4_EXTI12_PF                  ((uint16_t)0x0005) /* PF[12] pin */
+#define AFIO_EXTICR4_EXTI12_PG                  ((uint16_t)0x0006) /* PG[12] pin */
+
+#define AFIO_EXTICR4_EXTI13_PA                  ((uint16_t)0x0000) /* PA[13] pin */
+#define AFIO_EXTICR4_EXTI13_PB                  ((uint16_t)0x0010) /* PB[13] pin */
+#define AFIO_EXTICR4_EXTI13_PC                  ((uint16_t)0x0020) /* PC[13] pin */
+#define AFIO_EXTICR4_EXTI13_PD                  ((uint16_t)0x0030) /* PD[13] pin */
+#define AFIO_EXTICR4_EXTI13_PE                  ((uint16_t)0x0040) /* PE[13] pin */
+#define AFIO_EXTICR4_EXTI13_PF                  ((uint16_t)0x0050) /* PF[13] pin */
+#define AFIO_EXTICR4_EXTI13_PG                  ((uint16_t)0x0060) /* PG[13] pin */
+
+#define AFIO_EXTICR4_EXTI14_PA                  ((uint16_t)0x0000) /* PA[14] pin */
+#define AFIO_EXTICR4_EXTI14_PB                  ((uint16_t)0x0100) /* PB[14] pin */
+#define AFIO_EXTICR4_EXTI14_PC                  ((uint16_t)0x0200) /* PC[14] pin */
+#define AFIO_EXTICR4_EXTI14_PD                  ((uint16_t)0x0300) /* PD[14] pin */
+#define AFIO_EXTICR4_EXTI14_PE                  ((uint16_t)0x0400) /* PE[14] pin */
+#define AFIO_EXTICR4_EXTI14_PF                  ((uint16_t)0x0500) /* PF[14] pin */
+#define AFIO_EXTICR4_EXTI14_PG                  ((uint16_t)0x0600) /* PG[14] pin */
+
+#define AFIO_EXTICR4_EXTI15_PA                  ((uint16_t)0x0000) /* PA[15] pin */
+#define AFIO_EXTICR4_EXTI15_PB                  ((uint16_t)0x1000) /* PB[15] pin */
+#define AFIO_EXTICR4_EXTI15_PC                  ((uint16_t)0x2000) /* PC[15] pin */
+#define AFIO_EXTICR4_EXTI15_PD                  ((uint16_t)0x3000) /* PD[15] pin */
+#define AFIO_EXTICR4_EXTI15_PE                  ((uint16_t)0x4000) /* PE[15] pin */
+#define AFIO_EXTICR4_EXTI15_PF                  ((uint16_t)0x5000) /* PF[15] pin */
+#define AFIO_EXTICR4_EXTI15_PG                  ((uint16_t)0x6000) /* PG[15] pin */
+
+/******************************************************************************/
+/*                           Independent WATCHDOG                             */
+/******************************************************************************/
+
+/*******************  Bit definition for IWDG_CTLR register  ********************/
+#define IWDG_KEY                                ((uint16_t)0xFFFF) /* Key value (write only, read 0000h) */
+
+/*******************  Bit definition for IWDG_PSCR register  ********************/
+#define IWDG_PR                                 ((uint8_t)0x07) /* PR[2:0] (Prescaler divider) */
+#define IWDG_PR_0                               ((uint8_t)0x01) /* Bit 0 */
+#define IWDG_PR_1                               ((uint8_t)0x02) /* Bit 1 */
+#define IWDG_PR_2                               ((uint8_t)0x04) /* Bit 2 */
+
+/*******************  Bit definition for IWDG_RLDR register  *******************/
+#define IWDG_RL                                 ((uint16_t)0x0FFF) /* Watchdog counter reload value */
+
+/*******************  Bit definition for IWDG_STATR register  ********************/
+#define IWDG_PVU                                ((uint8_t)0x01) /* Watchdog prescaler value update */
+#define IWDG_RVU                                ((uint8_t)0x02) /* Watchdog counter reload value update */
+
+/******************************************************************************/
+/*                      Inter-integrated Circuit Interface                    */
+/******************************************************************************/
+
+/*******************  Bit definition for I2C_CTLR1 register  ********************/
+#define I2C_CTLR1_PE                            ((uint16_t)0x0001) /* Peripheral Enable */
+#define I2C_CTLR1_SMBUS                         ((uint16_t)0x0002) /* SMBus Mode */
+#define I2C_CTLR1_SMBTYPE                       ((uint16_t)0x0008) /* SMBus Type */
+#define I2C_CTLR1_ENARP                         ((uint16_t)0x0010) /* ARP Enable */
+#define I2C_CTLR1_ENPEC                         ((uint16_t)0x0020) /* PEC Enable */
+#define I2C_CTLR1_ENGC                          ((uint16_t)0x0040) /* General Call Enable */
+#define I2C_CTLR1_NOSTRETCH                     ((uint16_t)0x0080) /* Clock Stretching Disable (Slave mode) */
+#define I2C_CTLR1_START                         ((uint16_t)0x0100) /* Start Generation */
+#define I2C_CTLR1_STOP                          ((uint16_t)0x0200) /* Stop Generation */
+#define I2C_CTLR1_ACK                           ((uint16_t)0x0400) /* Acknowledge Enable */
+#define I2C_CTLR1_POS                           ((uint16_t)0x0800) /* Acknowledge/PEC Position (for data reception) */
+#define I2C_CTLR1_PEC                           ((uint16_t)0x1000) /* Packet Error Checking */
+#define I2C_CTLR1_ALERT                         ((uint16_t)0x2000) /* SMBus Alert */
+#define I2C_CTLR1_SWRST                         ((uint16_t)0x8000) /* Software Reset */
+
+/*******************  Bit definition for I2C_CTLR2 register  ********************/
+#define I2C_CTLR2_FREQ                          ((uint16_t)0x003F) /* FREQ[5:0] bits (Peripheral Clock Frequency) */
+#define I2C_CTLR2_FREQ_0                        ((uint16_t)0x0001) /* Bit 0 */
+#define I2C_CTLR2_FREQ_1                        ((uint16_t)0x0002) /* Bit 1 */
+#define I2C_CTLR2_FREQ_2                        ((uint16_t)0x0004) /* Bit 2 */
+#define I2C_CTLR2_FREQ_3                        ((uint16_t)0x0008) /* Bit 3 */
+#define I2C_CTLR2_FREQ_4                        ((uint16_t)0x0010) /* Bit 4 */
+#define I2C_CTLR2_FREQ_5                        ((uint16_t)0x0020) /* Bit 5 */
+
+#define I2C_CTLR2_ITERREN                       ((uint16_t)0x0100) /* Error Interrupt Enable */
+#define I2C_CTLR2_ITEVTEN                       ((uint16_t)0x0200) /* Event Interrupt Enable */
+#define I2C_CTLR2_ITBUFEN                       ((uint16_t)0x0400) /* Buffer Interrupt Enable */
+#define I2C_CTLR2_DMAEN                         ((uint16_t)0x0800) /* DMA Requests Enable */
+#define I2C_CTLR2_LAST                          ((uint16_t)0x1000) /* DMA Last Transfer */
+
+/*******************  Bit definition for I2C_OADDR1 register  *******************/
+#define I2C_OADDR1_ADD1_7                       ((uint16_t)0x00FE) /* Interface Address */
+#define I2C_OADDR1_ADD8_9                       ((uint16_t)0x0300) /* Interface Address */
+
+#define I2C_OADDR1_ADD0                         ((uint16_t)0x0001) /* Bit 0 */
+#define I2C_OADDR1_ADD1                         ((uint16_t)0x0002) /* Bit 1 */
+#define I2C_OADDR1_ADD2                         ((uint16_t)0x0004) /* Bit 2 */
+#define I2C_OADDR1_ADD3                         ((uint16_t)0x0008) /* Bit 3 */
+#define I2C_OADDR1_ADD4                         ((uint16_t)0x0010) /* Bit 4 */
+#define I2C_OADDR1_ADD5                         ((uint16_t)0x0020) /* Bit 5 */
+#define I2C_OADDR1_ADD6                         ((uint16_t)0x0040) /* Bit 6 */
+#define I2C_OADDR1_ADD7                         ((uint16_t)0x0080) /* Bit 7 */
+#define I2C_OADDR1_ADD8                         ((uint16_t)0x0100) /* Bit 8 */
+#define I2C_OADDR1_ADD9                         ((uint16_t)0x0200) /* Bit 9 */
+
+#define I2C_OADDR1_ADDMODE                      ((uint16_t)0x8000) /* Addressing Mode (Slave mode) */
+
+/*******************  Bit definition for I2C_OADDR2 register  *******************/
+#define I2C_OADDR2_ENDUAL                       ((uint8_t)0x01) /* Dual addressing mode enable */
+#define I2C_OADDR2_ADD2                         ((uint8_t)0xFE) /* Interface address */
+
+/********************  Bit definition for I2C_DATAR register  ********************/
+#define I2C_DR_DATAR                            ((uint8_t)0xFF) /* 8-bit Data Register */
+
+/*******************  Bit definition for I2C_STAR1 register  ********************/
+#define I2C_STAR1_SB                            ((uint16_t)0x0001) /* Start Bit (Master mode) */
+#define I2C_STAR1_ADDR                          ((uint16_t)0x0002) /* Address sent (master mode)/matched (slave mode) */
+#define I2C_STAR1_BTF                           ((uint16_t)0x0004) /* Byte Transfer Finished */
+#define I2C_STAR1_ADD10                         ((uint16_t)0x0008) /* 10-bit header sent (Master mode) */
+#define I2C_STAR1_STOPF                         ((uint16_t)0x0010) /* Stop detection (Slave mode) */
+#define I2C_STAR1_RXNE                          ((uint16_t)0x0040) /* Data Register not Empty (receivers) */
+#define I2C_STAR1_TXE                           ((uint16_t)0x0080) /* Data Register Empty (transmitters) */
+#define I2C_STAR1_BERR                          ((uint16_t)0x0100) /* Bus Error */
+#define I2C_STAR1_ARLO                          ((uint16_t)0x0200) /* Arbitration Lost (master mode) */
+#define I2C_STAR1_AF                            ((uint16_t)0x0400) /* Acknowledge Failure */
+#define I2C_STAR1_OVR                           ((uint16_t)0x0800) /* Overrun/Underrun */
+#define I2C_STAR1_PECERR                        ((uint16_t)0x1000) /* PEC Error in reception */
+#define I2C_STAR1_TIMEOUT                       ((uint16_t)0x4000) /* Timeout or Tlow Error */
+#define I2C_STAR1_SMBALERT                      ((uint16_t)0x8000) /* SMBus Alert */
+
+/*******************  Bit definition for I2C_STAR2 register  ********************/
+#define I2C_STAR2_MSL                           ((uint16_t)0x0001) /* Master/Slave */
+#define I2C_STAR2_BUSY                          ((uint16_t)0x0002) /* Bus Busy */
+#define I2C_STAR2_TRA                           ((uint16_t)0x0004) /* Transmitter/Receiver */
+#define I2C_STAR2_GENCALL                       ((uint16_t)0x0010) /* General Call Address (Slave mode) */
+#define I2C_STAR2_SMBDEFAULT                    ((uint16_t)0x0020) /* SMBus Device Default Address (Slave mode) */
+#define I2C_STAR2_SMBHOST                       ((uint16_t)0x0040) /* SMBus Host Header (Slave mode) */
+#define I2C_STAR2_DUALF                         ((uint16_t)0x0080) /* Dual Flag (Slave mode) */
+#define I2C_STAR2_PEC                           ((uint16_t)0xFF00) /* Packet Error Checking Register */
+
+/*******************  Bit definition for I2C_CKCFGR register  ********************/
+#define I2C_CKCFGR_CCR                          ((uint16_t)0x0FFF) /* Clock Control Register in Fast/Standard mode (Master mode) */
+#define I2C_CKCFGR_DUTY                         ((uint16_t)0x4000) /* Fast Mode Duty Cycle */
+#define I2C_CKCFGR_FS                           ((uint16_t)0x8000) /* I2C Master Mode Selection */
+
+/******************************************************************************/
+/*                             Power Control                                  */
+/******************************************************************************/
+
+/********************  Bit definition for PWR_CTLR register  ********************/
+#define PWR_CTLR_PDDS                           ((uint16_t)0x0002) /* Power Down Deepsleep */
+#define PWR_CTLR_PVDE                           ((uint16_t)0x0010) /* Power Voltage Detector Enable */
+
+#define PWR_CTLR_PLS                            ((uint16_t)0x00E0) /* PLS[2:0] bits (PVD Level Selection) */
+#define PWR_CTLR_PLS_0                          ((uint16_t)0x0020) /* Bit 0 */
+#define PWR_CTLR_PLS_1                          ((uint16_t)0x0040) /* Bit 1 */
+#define PWR_CTLR_PLS_2                          ((uint16_t)0x0080) /* Bit 2 */
+
+#define PWR_CTLR_DBP                            ((uint16_t)0x0100) /* Disable Backup Domain write protection */
+
+/*******************  Bit definition for PWR_CSR register  ********************/
+#define PWR_CSR_WUF                             ((uint16_t)0x0001) /* Wakeup Flag */
+#define PWR_CSR_SBF                             ((uint16_t)0x0002) /* Standby Flag */
+#define PWR_CSR_PVDO                            ((uint16_t)0x0004) /* PVD Output */
+#define PWR_CSR_EWUP                            ((uint16_t)0x0100) /* Enable WKUP pin */
+
+/******************************************************************************/
+/*                         Reset and Clock Control                            */
+/******************************************************************************/
+
+/********************  Bit definition for RCC_CTLR register  ********************/
+#define RCC_HSION                               ((uint32_t)0x00000001) /* Internal High Speed clock enable */
+#define RCC_HSIRDY                              ((uint32_t)0x00000002) /* Internal High Speed clock ready flag */
+#define RCC_HSITRIM                             ((uint32_t)0x000000F8) /* Internal High Speed clock trimming */
+#define RCC_HSICAL                              ((uint32_t)0x0000FF00) /* Internal High Speed clock Calibration */
+
+/*******************  Bit definition for RCC_CFGR0 register  *******************/
+#define RCC_HPRE                                ((uint32_t)0x000000F0) /* HPRE[3:0] bits (AHB prescaler) */
+#define RCC_HPRE_0                              ((uint32_t)0x00000010) /* Bit 0 */
+#define RCC_HPRE_1                              ((uint32_t)0x00000020) /* Bit 1 */
+#define RCC_HPRE_2                              ((uint32_t)0x00000040) /* Bit 2 */
+#define RCC_HPRE_3                              ((uint32_t)0x00000080) /* Bit 3 */
+
+#define RCC_HPRE_DIV1                           ((uint32_t)0x00000000) /* SYSCLK not divided */
+#define RCC_HPRE_DIV2                           ((uint32_t)0x00000010) /* SYSCLK divided by 2 */
+#define RCC_HPRE_DIV3                           ((uint32_t)0x00000020) /* SYSCLK divided by 3 */
+#define RCC_HPRE_DIV4                           ((uint32_t)0x00000030) /* SYSCLK divided by 4 */
+#define RCC_HPRE_DIV5                           ((uint32_t)0x00000040) /* SYSCLK divided by 5 */
+#define RCC_HPRE_DIV6                           ((uint32_t)0x00000050) /* SYSCLK divided by 6 */
+#define RCC_HPRE_DIV7                           ((uint32_t)0x00000060) /* SYSCLK divided by 7 */
+#define RCC_HPRE_DIV8                           ((uint32_t)0x00000070) /* SYSCLK divided by 8 */
+#define RCC_HPRE_DIV16                          ((uint32_t)0x000000B0) /* SYSCLK divided by 16 */
+#define RCC_HPRE_DIV32                          ((uint32_t)0x000000C0) /* SYSCLK divided by 32 */
+#define RCC_HPRE_DIV64                          ((uint32_t)0x000000D0) /* SYSCLK divided by 64 */
+#define RCC_HPRE_DIV128                         ((uint32_t)0x000000E0) /* SYSCLK divided by 128 */
+#define RCC_HPRE_DIV256                         ((uint32_t)0x000000F0) /* SYSCLK divided by 256 */
+
+#define RCC_CFGR0_MCO                           ((uint32_t)0x07000000) /* MCO[2:0] bits (Microcontroller Clock Output) */
+#define RCC_MCO_0                               ((uint32_t)0x01000000) /* Bit 0 */
+#define RCC_MCO_1                               ((uint32_t)0x02000000) /* Bit 1 */
+#define RCC_MCO_2                               ((uint32_t)0x04000000) /* Bit 2 */
+
+#define RCC_MCO_NOCLOCK                         ((uint32_t)0x00000000) /* No clock */
+#define RCC_CFGR0_MCO_SYSCLK                    ((uint32_t)0x04000000) /* System clock selected as MCO source */
+#define RCC_CFGR0_MCO_HSI                       ((uint32_t)0x05000000) /* HSI clock selected as MCO source */
+
+/*****************  Bit definition for RCC_APB2PRSTR register  *****************/
+#define RCC_AFIORST                             ((uint32_t)0x00000001) /* Alternate Function I/O reset */
+#define RCC_IOPARST                             ((uint32_t)0x00000004) /* I/O port A reset */
+#define RCC_IOPBRST                             ((uint32_t)0x00000008) /* I/O port B reset */
+#define RCC_IOPCRST                             ((uint32_t)0x00000010) /* I/O port C reset */
+#define RCC_ADC1RST                             ((uint32_t)0x00000200) /* ADC 1 interface reset */
+#define RCC_TIM1RST                             ((uint32_t)0x00000800) /* TIM1 Timer reset */
+#define RCC_SPI1RST                             ((uint32_t)0x00001000) /* SPI 1 reset */
+#define RCC_USART1RST                           ((uint32_t)0x00004000) /* USART1 reset */
+
+/*****************  Bit definition for RCC_APB1PRSTR register  *****************/
+#define RCC_TIM2RST                             ((uint32_t)0x00000001) /* Timer 2 reset */
+#define RCC_TIM3RST                             ((uint32_t)0x00000002) /* Timer 3 reset */
+#define RCC_WWDGRST                             ((uint32_t)0x00000800) /* Window Watchdog reset */
+#define RCC_USART2RST                           ((uint32_t)0x00020000) /* USART 2 reset */
+#define RCC_USART3RST                           ((uint32_t)0x00040000) /* USART 3 reset */
+#define RCC_USART4RST                           ((uint32_t)0x00080000) /* USART 4 reset */
+#define RCC_I2C1RST                             ((uint32_t)0x00200000) /* I2C 1 reset */
+#define RCC_PWRRST                              ((uint32_t)0x10000000) /* Power interface reset */
+
+/******************  Bit definition for RCC_AHBPCENR register  ******************/
+#define RCC_DMA1EN                              ((uint32_t)0x00000001) /* DMA1 clock enable */
+#define RCC_SRAMEN                              ((uint32_t)0x00000004) /* SRAM interface clock enable */
+#define RCC_USBFS                               ((uint32_t)0x00001000) /* USBFS clock enable */
+#define RCC_USBPD                               ((uint32_t)0x00020000) /* USBPD clock enable */
+
+/******************  Bit definition for RCC_APB2PCENR register  *****************/
+#define RCC_AFIOEN                              ((uint32_t)0x00000001) /* Alternate Function I/O clock enable */
+#define RCC_IOPAEN                              ((uint32_t)0x00000004) /* I/O port A clock enable */
+#define RCC_IOPBEN                              ((uint32_t)0x00000008) /* I/O port B clock enable */
+#define RCC_IOPCEN                              ((uint32_t)0x00000010) /* I/O port C clock enable */
+#define RCC_ADC1EN                              ((uint32_t)0x00000200) /* ADC 1 interface clock enable */
+#define RCC_TIM1EN                              ((uint32_t)0x00000800) /* TIM1 Timer clock enable */
+#define RCC_SPI1EN                              ((uint32_t)0x00001000) /* SPI 1 clock enable */
+#define RCC_USART1EN                            ((uint32_t)0x00004000) /* USART1 clock enable */
+
+/*****************  Bit definition for RCC_APB1PCENR register  ******************/
+#define RCC_TIM2EN                              ((uint32_t)0x00000001) /* Timer 2 clock enabled*/
+#define RCC_TIM3EN                              ((uint32_t)0x00000002) /* Timer 3 clock enable */
+#define RCC_WWDGEN                              ((uint32_t)0x00000800) /* Window Watchdog clock enable */
+#define RCC_USART2EN                            ((uint32_t)0x00020000) /* USART 2 clock enable */
+#define RCC_USART3EN                            ((uint32_t)0x00040000) /* USART 3 clock enable */
+#define RCC_USART4EN                            ((uint32_t)0x00080000) /* USART 4 clock enable */
+#define RCC_I2C1EN                              ((uint32_t)0x00200000) /* I2C 1 clock enable */
+#define RCC_PWREN                               ((uint32_t)0x10000000) /* Power interface clock enable */
+
+/*******************  Bit definition for RCC_RSTSCKR register  ********************/
+#define RCC_RMVF                                ((uint32_t)0x01000000) /* Remove reset flag */
+#define RCC_OPARSTF                             ((uint32_t)0x02000000) /* OPA reset flag */
+#define RCC_PINRSTF                             ((uint32_t)0x04000000) /* PIN reset flag */
+#define RCC_PORRSTF                             ((uint32_t)0x08000000) /* POR/PDR reset flag */
+#define RCC_SFTRSTF                             ((uint32_t)0x10000000) /* Software Reset flag */
+#define RCC_IWDGRSTF                            ((uint32_t)0x20000000) /* Independent Watchdog reset flag */
+#define RCC_WWDGRSTF                            ((uint32_t)0x40000000) /* Window watchdog reset flag */
+#define RCC_LPWRRSTF                            ((uint32_t)0x80000000) /* Low-Power reset flag */
+
+/******************************************************************************/
+/*                        Serial Peripheral Interface                         */
+/******************************************************************************/
+
+/*******************  Bit definition for SPI_CTLR1 register  ********************/
+#define SPI_CTLR1_CPHA                          ((uint16_t)0x0001) /* Clock Phase */
+#define SPI_CTLR1_CPOL                          ((uint16_t)0x0002) /* Clock Polarity */
+#define SPI_CTLR1_MSTR                          ((uint16_t)0x0004) /* Master Selection */
+
+#define SPI_CTLR1_BR                            ((uint16_t)0x0038) /* BR[2:0] bits (Baud Rate Control) */
+#define SPI_CTLR1_BR_0                          ((uint16_t)0x0008) /* Bit 0 */
+#define SPI_CTLR1_BR_1                          ((uint16_t)0x0010) /* Bit 1 */
+#define SPI_CTLR1_BR_2                          ((uint16_t)0x0020) /* Bit 2 */
+
+#define SPI_CTLR1_SPE                           ((uint16_t)0x0040) /* SPI Enable */
+#define SPI_CTLR1_LSBFIRST                      ((uint16_t)0x0080) /* Frame Format */
+#define SPI_CTLR1_SSI                           ((uint16_t)0x0100) /* Internal slave select */
+#define SPI_CTLR1_SSM                           ((uint16_t)0x0200) /* Software slave management */
+#define SPI_CTLR1_RXONLY                        ((uint16_t)0x0400) /* Receive only */
+#define SPI_CTLR1_DFF                           ((uint16_t)0x0800) /* Data Frame Format */
+#define SPI_CTLR1_CRCNEXT                       ((uint16_t)0x1000) /* Transmit CRC next */
+#define SPI_CTLR1_CRCEN                         ((uint16_t)0x2000) /* Hardware CRC calculation enable */
+#define SPI_CTLR1_BIDIOE                        ((uint16_t)0x4000) /* Output enable in bidirectional mode */
+#define SPI_CTLR1_BIDIMODE                      ((uint16_t)0x8000) /* Bidirectional data mode enable */
+
+/*******************  Bit definition for SPI_CTLR2 register  ********************/
+#define SPI_CTLR2_RXDMAEN                       ((uint8_t)0x01) /* Rx Buffer DMA Enable */
+#define SPI_CTLR2_TXDMAEN                       ((uint8_t)0x02) /* Tx Buffer DMA Enable */
+#define SPI_CTLR2_SSOE                          ((uint8_t)0x04) /* SS Output Enable */
+#define SPI_CTLR2_ERRIE                         ((uint8_t)0x20) /* Error Interrupt Enable */
+#define SPI_CTLR2_RXNEIE                        ((uint8_t)0x40) /* RX buffer Not Empty Interrupt Enable */
+#define SPI_CTLR2_TXEIE                         ((uint8_t)0x80) /* Tx buffer Empty Interrupt Enable */
+
+/********************  Bit definition for SPI_STATR register  ********************/
+#define SPI_STATR_RXNE                          ((uint8_t)0x01) /* Receive buffer Not Empty */
+#define SPI_STATR_TXE                           ((uint8_t)0x02) /* Transmit buffer Empty */
+#define SPI_STATR_CHSIDE                        ((uint8_t)0x04) /* Channel side */
+#define SPI_STATR_UDR                           ((uint8_t)0x08) /* Underrun flag */
+#define SPI_STATR_CRCERR                        ((uint8_t)0x10) /* CRC Error flag */
+#define SPI_STATR_MODF                          ((uint8_t)0x20) /* Mode fault */
+#define SPI_STATR_OVR                           ((uint8_t)0x40) /* Overrun flag */
+#define SPI_STATR_BSY                           ((uint8_t)0x80) /* Busy flag */
+
+/********************  Bit definition for SPI_DATAR register  ********************/
+#define SPI_DATAR_DR                            ((uint16_t)0xFFFF) /* Data Register */
+
+/*******************  Bit definition for SPI_CRCR register  ******************/
+#define SPI_CRCR_CRCPOLY                        ((uint16_t)0xFFFF) /* CRC polynomial register */
+
+/******************  Bit definition for SPI_RCRCR register  ******************/
+#define SPI_RCRCR_RXCRC                         ((uint16_t)0xFFFF) /* Rx CRC Register */
+
+/******************  Bit definition for SPI_TCRCR register  ******************/
+#define SPI_TCRCR_TXCRC                         ((uint16_t)0xFFFF) /* Tx CRC Register */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define SPI_I2SCFGR_CHLEN                       ((uint16_t)0x0001) /* Channel length (number of bits per audio channel) */
+
+#define SPI_I2SCFGR_DATLEN                      ((uint16_t)0x0006) /* DATLEN[1:0] bits (Data length to be transferred) */
+#define SPI_I2SCFGR_DATLEN_0                    ((uint16_t)0x0002) /* Bit 0 */
+#define SPI_I2SCFGR_DATLEN_1                    ((uint16_t)0x0004) /* Bit 1 */
+
+#define SPI_I2SCFGR_CKPOL                       ((uint16_t)0x0008) /* steady state clock polarity */
+
+#define SPI_I2SCFGR_I2SSTD                      ((uint16_t)0x0030) /* I2SSTD[1:0] bits (I2S standard selection) */
+#define SPI_I2SCFGR_I2SSTD_0                    ((uint16_t)0x0010) /* Bit 0 */
+#define SPI_I2SCFGR_I2SSTD_1                    ((uint16_t)0x0020) /* Bit 1 */
+
+#define SPI_I2SCFGR_PCMSYNC                     ((uint16_t)0x0080) /* PCM frame synchronization */
+
+#define SPI_I2SCFGR_I2SCFG                      ((uint16_t)0x0300) /* I2SCFG[1:0] bits (I2S configuration mode) */
+#define SPI_I2SCFGR_I2SCFG_0                    ((uint16_t)0x0100) /* Bit 0 */
+#define SPI_I2SCFGR_I2SCFG_1                    ((uint16_t)0x0200) /* Bit 1 */
+
+#define SPI_I2SCFGR_I2SE                        ((uint16_t)0x0400) /* I2S Enable */
+#define SPI_I2SCFGR_I2SMOD                      ((uint16_t)0x0800) /* I2S mode selection */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define SPI_I2SPR_I2SDIV                        ((uint16_t)0x00FF) /* I2S Linear prescaler */
+#define SPI_I2SPR_ODD                           ((uint16_t)0x0100) /* Odd factor for the prescaler */
+#define SPI_I2SPR_MCKOE                         ((uint16_t)0x0200) /* Master Clock Output Enable */
+
+/******************************************************************************/
+/*                                    TIM                                     */
+/******************************************************************************/
+
+/*******************  Bit definition for TIM_CTLR1 register  ********************/
+#define TIM_CEN                                 ((uint16_t)0x0001) /* Counter enable */
+#define TIM_UDIS                                ((uint16_t)0x0002) /* Update disable */
+#define TIM_URS                                 ((uint16_t)0x0004) /* Update request source */
+#define TIM_OPM                                 ((uint16_t)0x0008) /* One pulse mode */
+#define TIM_DIR                                 ((uint16_t)0x0010) /* Direction */
+
+#define TIM_CMS                                 ((uint16_t)0x0060) /* CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CMS_0                               ((uint16_t)0x0020) /* Bit 0 */
+#define TIM_CMS_1                               ((uint16_t)0x0040) /* Bit 1 */
+
+#define TIM_ARPE                                ((uint16_t)0x0080) /* Auto-reload preload enable */
+
+#define TIM_CTLR1_CKD                           ((uint16_t)0x0300) /* CKD[1:0] bits (clock division) */
+#define TIM_CKD_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CKD_1                               ((uint16_t)0x0200) /* Bit 1 */
+
+/*******************  Bit definition for TIM_CTLR2 register  ********************/
+#define TIM_CCPC                                ((uint16_t)0x0001) /* Capture/Compare Preloaded Control */
+#define TIM_CCUS                                ((uint16_t)0x0004) /* Capture/Compare Control Update Selection */
+#define TIM_CCDS                                ((uint16_t)0x0008) /* Capture/Compare DMA Selection */
+
+#define TIM_MMS                                 ((uint16_t)0x0070) /* MMS[2:0] bits (Master Mode Selection) */
+#define TIM_MMS_0                               ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_MMS_1                               ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_MMS_2                               ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_TI1S                                ((uint16_t)0x0080) /* TI1 Selection */
+#define TIM_OIS1                                ((uint16_t)0x0100) /* Output Idle state 1 (OC1 output) */
+#define TIM_OIS1N                               ((uint16_t)0x0200) /* Output Idle state 1 (OC1N output) */
+#define TIM_OIS2                                ((uint16_t)0x0400) /* Output Idle state 2 (OC2 output) */
+#define TIM_OIS2N                               ((uint16_t)0x0800) /* Output Idle state 2 (OC2N output) */
+#define TIM_OIS3                                ((uint16_t)0x1000) /* Output Idle state 3 (OC3 output) */
+#define TIM_OIS3N                               ((uint16_t)0x2000) /* Output Idle state 3 (OC3N output) */
+#define TIM_OIS4                                ((uint16_t)0x4000) /* Output Idle state 4 (OC4 output) */
+
+/*******************  Bit definition for TIM_SMCFGR register  *******************/
+#define TIM_SMS                                 ((uint16_t)0x0007) /* SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMS_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_SMS_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_SMS_2                               ((uint16_t)0x0004) /* Bit 2 */
+
+#define TIM_TS                                  ((uint16_t)0x0070) /* TS[2:0] bits (Trigger selection) */
+#define TIM_TS_0                                ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_TS_1                                ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_TS_2                                ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_MSM                                 ((uint16_t)0x0080) /* Master/slave mode */
+
+#define TIM_ETF                                 ((uint16_t)0x0F00) /* ETF[3:0] bits (External trigger filter) */
+#define TIM_ETF_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_ETF_1                               ((uint16_t)0x0200) /* Bit 1 */
+#define TIM_ETF_2                               ((uint16_t)0x0400) /* Bit 2 */
+#define TIM_ETF_3                               ((uint16_t)0x0800) /* Bit 3 */
+
+#define TIM_ETPS                                ((uint16_t)0x3000) /* ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_ETPS_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_ETPS_1                              ((uint16_t)0x2000) /* Bit 1 */
+
+#define TIM_ECE                                 ((uint16_t)0x4000) /* External clock enable */
+#define TIM_ETP                                 ((uint16_t)0x8000) /* External trigger polarity */
+
+/*******************  Bit definition for TIM_DMAINTENR register  *******************/
+#define TIM_UIE                                 ((uint16_t)0x0001) /* Update interrupt enable */
+#define TIM_CC1IE                               ((uint16_t)0x0002) /* Capture/Compare 1 interrupt enable */
+#define TIM_CC2IE                               ((uint16_t)0x0004) /* Capture/Compare 2 interrupt enable */
+#define TIM_CC3IE                               ((uint16_t)0x0008) /* Capture/Compare 3 interrupt enable */
+#define TIM_CC4IE                               ((uint16_t)0x0010) /* Capture/Compare 4 interrupt enable */
+#define TIM_COMIE                               ((uint16_t)0x0020) /* COM interrupt enable */
+#define TIM_TIE                                 ((uint16_t)0x0040) /* Trigger interrupt enable */
+#define TIM_BIE                                 ((uint16_t)0x0080) /* Break interrupt enable */
+#define TIM_UDE                                 ((uint16_t)0x0100) /* Update DMA request enable */
+#define TIM_CC1DE                               ((uint16_t)0x0200) /* Capture/Compare 1 DMA request enable */
+#define TIM_CC2DE                               ((uint16_t)0x0400) /* Capture/Compare 2 DMA request enable */
+#define TIM_CC3DE                               ((uint16_t)0x0800) /* Capture/Compare 3 DMA request enable */
+#define TIM_CC4DE                               ((uint16_t)0x1000) /* Capture/Compare 4 DMA request enable */
+#define TIM_COMDE                               ((uint16_t)0x2000) /* COM DMA request enable */
+#define TIM_TDE                                 ((uint16_t)0x4000) /* Trigger DMA request enable */
+
+/********************  Bit definition for TIM_INTFR register  ********************/
+#define TIM_UIF                                 ((uint16_t)0x0001) /* Update interrupt Flag */
+#define TIM_CC1IF                               ((uint16_t)0x0002) /* Capture/Compare 1 interrupt Flag */
+#define TIM_CC2IF                               ((uint16_t)0x0004) /* Capture/Compare 2 interrupt Flag */
+#define TIM_CC3IF                               ((uint16_t)0x0008) /* Capture/Compare 3 interrupt Flag */
+#define TIM_CC4IF                               ((uint16_t)0x0010) /* Capture/Compare 4 interrupt Flag */
+#define TIM_COMIF                               ((uint16_t)0x0020) /* COM interrupt Flag */
+#define TIM_TIF                                 ((uint16_t)0x0040) /* Trigger interrupt Flag */
+#define TIM_BIF                                 ((uint16_t)0x0080) /* Break interrupt Flag */
+#define TIM_CC1OF                               ((uint16_t)0x0200) /* Capture/Compare 1 Overcapture Flag */
+#define TIM_CC2OF                               ((uint16_t)0x0400) /* Capture/Compare 2 Overcapture Flag */
+#define TIM_CC3OF                               ((uint16_t)0x0800) /* Capture/Compare 3 Overcapture Flag */
+#define TIM_CC4OF                               ((uint16_t)0x1000) /* Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_SWEVGR register  ********************/
+#define TIM_UG                                  ((uint8_t)0x01) /* Update Generation */
+#define TIM_CC1G                                ((uint8_t)0x02) /* Capture/Compare 1 Generation */
+#define TIM_CC2G                                ((uint8_t)0x04) /* Capture/Compare 2 Generation */
+#define TIM_CC3G                                ((uint8_t)0x08) /* Capture/Compare 3 Generation */
+#define TIM_CC4G                                ((uint8_t)0x10) /* Capture/Compare 4 Generation */
+#define TIM_COMG                                ((uint8_t)0x20) /* Capture/Compare Control Update Generation */
+#define TIM_TG                                  ((uint8_t)0x40) /* Trigger Generation */
+#define TIM_BG                                  ((uint8_t)0x80) /* Break Generation */
+
+/******************  Bit definition for TIM_CHCTLR1 register  *******************/
+#define TIM_CC1S                                ((uint16_t)0x0003) /* CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CC1S_0                              ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_CC1S_1                              ((uint16_t)0x0002) /* Bit 1 */
+
+#define TIM_OC1FE                               ((uint16_t)0x0004) /* Output Compare 1 Fast enable */
+#define TIM_OC1PE                               ((uint16_t)0x0008) /* Output Compare 1 Preload enable */
+
+#define TIM_OC1M                                ((uint16_t)0x0070) /* OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_OC1M_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_OC1M_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_OC1M_2                              ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_OC1CE                               ((uint16_t)0x0080) /* Output Compare 1Clear Enable */
+
+#define TIM_CC2S                                ((uint16_t)0x0300) /* CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CC2S_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CC2S_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OC2FE                               ((uint16_t)0x0400) /* Output Compare 2 Fast enable */
+#define TIM_OC2PE                               ((uint16_t)0x0800) /* Output Compare 2 Preload enable */
+
+#define TIM_OC2M                                ((uint16_t)0x7000) /* OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_OC2M_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_OC2M_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_OC2M_2                              ((uint16_t)0x4000) /* Bit 2 */
+
+#define TIM_OC2CE                               ((uint16_t)0x8000) /* Output Compare 2 Clear Enable */
+
+#define TIM_IC1PSC                              ((uint16_t)0x000C) /* IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_IC1PSC_0                            ((uint16_t)0x0004) /* Bit 0 */
+#define TIM_IC1PSC_1                            ((uint16_t)0x0008) /* Bit 1 */
+
+#define TIM_IC1F                                ((uint16_t)0x00F0) /* IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_IC1F_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_IC1F_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_IC1F_2                              ((uint16_t)0x0040) /* Bit 2 */
+#define TIM_IC1F_3                              ((uint16_t)0x0080) /* Bit 3 */
+
+#define TIM_IC2PSC                              ((uint16_t)0x0C00) /* IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_IC2PSC_0                            ((uint16_t)0x0400) /* Bit 0 */
+#define TIM_IC2PSC_1                            ((uint16_t)0x0800) /* Bit 1 */
+
+#define TIM_IC2F                                ((uint16_t)0xF000) /* IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_IC2F_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_IC2F_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_IC2F_2                              ((uint16_t)0x4000) /* Bit 2 */
+#define TIM_IC2F_3                              ((uint16_t)0x8000) /* Bit 3 */
+
+/******************  Bit definition for TIM_CHCTLR2 register  *******************/
+#define TIM_CC3S                                ((uint16_t)0x0003) /* CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CC3S_0                              ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_CC3S_1                              ((uint16_t)0x0002) /* Bit 1 */
+
+#define TIM_OC3FE                               ((uint16_t)0x0004) /* Output Compare 3 Fast enable */
+#define TIM_OC3PE                               ((uint16_t)0x0008) /* Output Compare 3 Preload enable */
+
+#define TIM_OC3M                                ((uint16_t)0x0070) /* OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_OC3M_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_OC3M_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_OC3M_2                              ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_OC3CE                               ((uint16_t)0x0080) /* Output Compare 3 Clear Enable */
+
+#define TIM_CC4S                                ((uint16_t)0x0300) /* CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CC4S_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CC4S_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OC4FE                               ((uint16_t)0x0400) /* Output Compare 4 Fast enable */
+#define TIM_OC4PE                               ((uint16_t)0x0800) /* Output Compare 4 Preload enable */
+
+#define TIM_OC4M                                ((uint16_t)0x7000) /* OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_OC4M_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_OC4M_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_OC4M_2                              ((uint16_t)0x4000) /* Bit 2 */
+
+#define TIM_OC4CE                               ((uint16_t)0x8000) /* Output Compare 4 Clear Enable */
+
+#define TIM_IC3PSC                              ((uint16_t)0x000C) /* IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_IC3PSC_0                            ((uint16_t)0x0004) /* Bit 0 */
+#define TIM_IC3PSC_1                            ((uint16_t)0x0008) /* Bit 1 */
+
+#define TIM_IC3F                                ((uint16_t)0x00F0) /* IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_IC3F_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_IC3F_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_IC3F_2                              ((uint16_t)0x0040) /* Bit 2 */
+#define TIM_IC3F_3                              ((uint16_t)0x0080) /* Bit 3 */
+
+#define TIM_IC4PSC                              ((uint16_t)0x0C00) /* IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_IC4PSC_0                            ((uint16_t)0x0400) /* Bit 0 */
+#define TIM_IC4PSC_1                            ((uint16_t)0x0800) /* Bit 1 */
+
+#define TIM_IC4F                                ((uint16_t)0xF000) /* IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_IC4F_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_IC4F_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_IC4F_2                              ((uint16_t)0x4000) /* Bit 2 */
+#define TIM_IC4F_3                              ((uint16_t)0x8000) /* Bit 3 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CC1E                                ((uint16_t)0x0001) /* Capture/Compare 1 output enable */
+#define TIM_CC1P                                ((uint16_t)0x0002) /* Capture/Compare 1 output Polarity */
+#define TIM_CC1NE                               ((uint16_t)0x0004) /* Capture/Compare 1 Complementary output enable */
+#define TIM_CC1NP                               ((uint16_t)0x0008) /* Capture/Compare 1 Complementary output Polarity */
+#define TIM_CC2E                                ((uint16_t)0x0010) /* Capture/Compare 2 output enable */
+#define TIM_CC2P                                ((uint16_t)0x0020) /* Capture/Compare 2 output Polarity */
+#define TIM_CC2NE                               ((uint16_t)0x0040) /* Capture/Compare 2 Complementary output enable */
+#define TIM_CC2NP                               ((uint16_t)0x0080) /* Capture/Compare 2 Complementary output Polarity */
+#define TIM_CC3E                                ((uint16_t)0x0100) /* Capture/Compare 3 output enable */
+#define TIM_CC3P                                ((uint16_t)0x0200) /* Capture/Compare 3 output Polarity */
+#define TIM_CC3NE                               ((uint16_t)0x0400) /* Capture/Compare 3 Complementary output enable */
+#define TIM_CC3NP                               ((uint16_t)0x0800) /* Capture/Compare 3 Complementary output Polarity */
+#define TIM_CC4E                                ((uint16_t)0x1000) /* Capture/Compare 4 output enable */
+#define TIM_CC4P                                ((uint16_t)0x2000) /* Capture/Compare 4 output Polarity */
+#define TIM_CC4NP                               ((uint16_t)0x8000) /* Capture/Compare 4 Complementary output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT                                 ((uint16_t)0xFFFF) /* Counter Value */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC                                 ((uint16_t)0xFFFF) /* Prescaler Value */
+
+/*******************  Bit definition for TIM_ATRLR register  ********************/
+#define TIM_ARR                                 ((uint16_t)0xFFFF) /* actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RPTCR register  ********************/
+#define TIM_REP                                 ((uint8_t)0xFF) /* Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CH1CVR register  *******************/
+#define TIM_CCR1                                ((uint16_t)0xFFFF) /* Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CH2CVR register  *******************/
+#define TIM_CCR2                                ((uint16_t)0xFFFF) /* Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CH3CVR register  *******************/
+#define TIM_CCR3                                ((uint16_t)0xFFFF) /* Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CH4CVR register  *******************/
+#define TIM_CCR4                                ((uint16_t)0xFFFF) /* Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_DTG                                 ((uint16_t)0x00FF) /* DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_DTG_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_DTG_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_DTG_2                               ((uint16_t)0x0004) /* Bit 2 */
+#define TIM_DTG_3                               ((uint16_t)0x0008) /* Bit 3 */
+#define TIM_DTG_4                               ((uint16_t)0x0010) /* Bit 4 */
+#define TIM_DTG_5                               ((uint16_t)0x0020) /* Bit 5 */
+#define TIM_DTG_6                               ((uint16_t)0x0040) /* Bit 6 */
+#define TIM_DTG_7                               ((uint16_t)0x0080) /* Bit 7 */
+
+#define TIM_LOCK                                ((uint16_t)0x0300) /* LOCK[1:0] bits (Lock Configuration) */
+#define TIM_LOCK_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_LOCK_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OSSI                                ((uint16_t)0x0400) /* Off-State Selection for Idle mode */
+#define TIM_OSSR                                ((uint16_t)0x0800) /* Off-State Selection for Run mode */
+#define TIM_BKE                                 ((uint16_t)0x1000) /* Break enable */
+#define TIM_BKP                                 ((uint16_t)0x2000) /* Break Polarity */
+#define TIM_AOE                                 ((uint16_t)0x4000) /* Automatic Output enable */
+#define TIM_MOE                                 ((uint16_t)0x8000) /* Main Output enable */
+
+/*******************  Bit definition for TIM_DMACFGR register  ********************/
+#define TIM_DBA                                 ((uint16_t)0x001F) /* DBA[4:0] bits (DMA Base Address) */
+#define TIM_DBA_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_DBA_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_DBA_2                               ((uint16_t)0x0004) /* Bit 2 */
+#define TIM_DBA_3                               ((uint16_t)0x0008) /* Bit 3 */
+#define TIM_DBA_4                               ((uint16_t)0x0010) /* Bit 4 */
+
+#define TIM_DBL                                 ((uint16_t)0x1F00) /* DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DBL_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_DBL_1                               ((uint16_t)0x0200) /* Bit 1 */
+#define TIM_DBL_2                               ((uint16_t)0x0400) /* Bit 2 */
+#define TIM_DBL_3                               ((uint16_t)0x0800) /* Bit 3 */
+#define TIM_DBL_4                               ((uint16_t)0x1000) /* Bit 4 */
+
+/*******************  Bit definition for TIM_DMAADR register  *******************/
+#define TIM_DMAR_DMAB                           ((uint16_t)0xFFFF) /* DMA register for burst accesses */
+
+/******************************************************************************/
+/*         Universal Synchronous Asynchronous Receiver Transmitter            */
+/******************************************************************************/
+
+/*******************  Bit definition for USART_STATR register  *******************/
+#define USART_STATR_PE                          ((uint16_t)0x0001) /* Parity Error */
+#define USART_STATR_FE                          ((uint16_t)0x0002) /* Framing Error */
+#define USART_STATR_NE                          ((uint16_t)0x0004) /* Noise Error Flag */
+#define USART_STATR_ORE                         ((uint16_t)0x0008) /* OverRun Error */
+#define USART_STATR_IDLE                        ((uint16_t)0x0010) /* IDLE line detected */
+#define USART_STATR_RXNE                        ((uint16_t)0x0020) /* Read Data Register Not Empty */
+#define USART_STATR_TC                          ((uint16_t)0x0040) /* Transmission Complete */
+#define USART_STATR_TXE                         ((uint16_t)0x0080) /* Transmit Data Register Empty */
+#define USART_STATR_LBD                         ((uint16_t)0x0100) /* LIN Break Detection Flag */
+#define USART_STATR_CTS                         ((uint16_t)0x0200) /* CTS Flag */
+
+/*******************  Bit definition for USART_DATAR register  *******************/
+#define USART_DATAR_DR                          ((uint16_t)0x01FF) /* Data value */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_DIV_Fraction                  ((uint16_t)0x000F) /* Fraction of USARTDIV */
+#define USART_BRR_DIV_Mantissa                  ((uint16_t)0xFFF0) /* Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_CTLR1 register  *******************/
+#define USART_CTLR1_SBK                         ((uint16_t)0x0001) /* Send Break */
+#define USART_CTLR1_RWU                         ((uint16_t)0x0002) /* Receiver wakeup */
+#define USART_CTLR1_RE                          ((uint16_t)0x0004) /* Receiver Enable */
+#define USART_CTLR1_TE                          ((uint16_t)0x0008) /* Transmitter Enable */
+#define USART_CTLR1_IDLEIE                      ((uint16_t)0x0010) /* IDLE Interrupt Enable */
+#define USART_CTLR1_RXNEIE                      ((uint16_t)0x0020) /* RXNE Interrupt Enable */
+#define USART_CTLR1_TCIE                        ((uint16_t)0x0040) /* Transmission Complete Interrupt Enable */
+#define USART_CTLR1_TXEIE                       ((uint16_t)0x0080) /* PE Interrupt Enable */
+#define USART_CTLR1_PEIE                        ((uint16_t)0x0100) /* PE Interrupt Enable */
+#define USART_CTLR1_PS                          ((uint16_t)0x0200) /* Parity Selection */
+#define USART_CTLR1_PCE                         ((uint16_t)0x0400) /* Parity Control Enable */
+#define USART_CTLR1_WAKE                        ((uint16_t)0x0800) /* Wakeup method */
+#define USART_CTLR1_M                           ((uint16_t)0x1000) /* Word length */
+#define USART_CTLR1_UE                          ((uint16_t)0x2000) /* USART Enable */
+#define USART_CTLR1_OVER8                       ((uint16_t)0x8000) /* USART Oversmapling 8-bits */
+
+/******************  Bit definition for USART_CTLR2 register  *******************/
+#define USART_CTLR2_ADD                         ((uint16_t)0x000F) /* Address of the USART node */
+#define USART_CTLR2_LBDL                        ((uint16_t)0x0020) /* LIN Break Detection Length */
+#define USART_CTLR2_LBDIE                       ((uint16_t)0x0040) /* LIN Break Detection Interrupt Enable */
+#define USART_CTLR2_LBCL                        ((uint16_t)0x0100) /* Last Bit Clock pulse */
+#define USART_CTLR2_CPHA                        ((uint16_t)0x0200) /* Clock Phase */
+#define USART_CTLR2_CPOL                        ((uint16_t)0x0400) /* Clock Polarity */
+#define USART_CTLR2_CLKEN                       ((uint16_t)0x0800) /* Clock Enable */
+
+#define USART_CTLR2_STOP                        ((uint16_t)0x3000) /* STOP[1:0] bits (STOP bits) */
+#define USART_CTLR2_STOP_0                      ((uint16_t)0x1000) /* Bit 0 */
+#define USART_CTLR2_STOP_1                      ((uint16_t)0x2000) /* Bit 1 */
+
+#define USART_CTLR2_LINEN                       ((uint16_t)0x4000) /* LIN mode enable */
+
+/******************  Bit definition for USART_CTLR3 register  *******************/
+#define USART_CTLR3_EIE                         ((uint16_t)0x0001) /* Error Interrupt Enable */
+#define USART_CTLR3_IREN                        ((uint16_t)0x0002) /* IrDA mode Enable */
+#define USART_CTLR3_IRLP                        ((uint16_t)0x0004) /* IrDA Low-Power */
+#define USART_CTLR3_HDSEL                       ((uint16_t)0x0008) /* Half-Duplex Selection */
+#define USART_CTLR3_NACK                        ((uint16_t)0x0010) /* Smartcard NACK enable */
+#define USART_CTLR3_SCEN                        ((uint16_t)0x0020) /* Smartcard mode enable */
+#define USART_CTLR3_DMAR                        ((uint16_t)0x0040) /* DMA Enable Receiver */
+#define USART_CTLR3_DMAT                        ((uint16_t)0x0080) /* DMA Enable Transmitter */
+#define USART_CTLR3_RTSE                        ((uint16_t)0x0100) /* RTS Enable */
+#define USART_CTLR3_CTSE                        ((uint16_t)0x0200) /* CTS Enable */
+#define USART_CTLR3_CTSIE                       ((uint16_t)0x0400) /* CTS Interrupt Enable */
+#define USART_CTLR3_ONEBIT                      ((uint16_t)0x0800) /* One Bit method */
+
+/******************  Bit definition for USART_GPR register  ******************/
+#define USART_GPR_PSC                           ((uint16_t)0x00FF) /* PSC[7:0] bits (Prescaler value) */
+#define USART_GPR_PSC_0                         ((uint16_t)0x0001) /* Bit 0 */
+#define USART_GPR_PSC_1                         ((uint16_t)0x0002) /* Bit 1 */
+#define USART_GPR_PSC_2                         ((uint16_t)0x0004) /* Bit 2 */
+#define USART_GPR_PSC_3                         ((uint16_t)0x0008) /* Bit 3 */
+#define USART_GPR_PSC_4                         ((uint16_t)0x0010) /* Bit 4 */
+#define USART_GPR_PSC_5                         ((uint16_t)0x0020) /* Bit 5 */
+#define USART_GPR_PSC_6                         ((uint16_t)0x0040) /* Bit 6 */
+#define USART_GPR_PSC_7                         ((uint16_t)0x0080) /* Bit 7 */
+
+#define USART_GPR_GT                            ((uint16_t)0xFF00) /* Guard time value */
+
+/******************************************************************************/
+/*                            Window WATCHDOG                                 */
+/******************************************************************************/
+
+/*******************  Bit definition for WWDG_CTLR register  ********************/
+#define WWDG_CTLR_T                             ((uint8_t)0x7F) /* T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CTLR_T0                            ((uint8_t)0x01) /* Bit 0 */
+#define WWDG_CTLR_T1                            ((uint8_t)0x02) /* Bit 1 */
+#define WWDG_CTLR_T2                            ((uint8_t)0x04) /* Bit 2 */
+#define WWDG_CTLR_T3                            ((uint8_t)0x08) /* Bit 3 */
+#define WWDG_CTLR_T4                            ((uint8_t)0x10) /* Bit 4 */
+#define WWDG_CTLR_T5                            ((uint8_t)0x20) /* Bit 5 */
+#define WWDG_CTLR_T6                            ((uint8_t)0x40) /* Bit 6 */
+
+#define WWDG_CTLR_WDGA                          ((uint8_t)0x80) /* Activation bit */
+
+/*******************  Bit definition for WWDG_CFGR register  *******************/
+#define WWDG_CFGR_W                             ((uint16_t)0x007F) /* W[6:0] bits (7-bit window value) */
+#define WWDG_CFGR_W0                            ((uint16_t)0x0001) /* Bit 0 */
+#define WWDG_CFGR_W1                            ((uint16_t)0x0002) /* Bit 1 */
+#define WWDG_CFGR_W2                            ((uint16_t)0x0004) /* Bit 2 */
+#define WWDG_CFGR_W3                            ((uint16_t)0x0008) /* Bit 3 */
+#define WWDG_CFGR_W4                            ((uint16_t)0x0010) /* Bit 4 */
+#define WWDG_CFGR_W5                            ((uint16_t)0x0020) /* Bit 5 */
+#define WWDG_CFGR_W6                            ((uint16_t)0x0040) /* Bit 6 */
+
+#define WWDG_CFGR_WDGTB                         ((uint16_t)0x0180) /* WDGTB[1:0] bits (Timer Base) */
+#define WWDG_CFGR_WDGTB0                        ((uint16_t)0x0080) /* Bit 0 */
+#define WWDG_CFGR_WDGTB1                        ((uint16_t)0x0100) /* Bit 1 */
+
+#define WWDG_CFGR_EWI                           ((uint16_t)0x0200) /* Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_STATR register  ********************/
+#define WWDG_STATR_EWIF                         ((uint8_t)0x01) /* Early Wakeup Interrupt Flag */
+
+
+#include "ch32x035_conf.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_adc.h
+++ b/Peripheral/ch32x035/inc/ch32x035_adc.h
@@ -1,0 +1,210 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_adc.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      ADC firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_ADC_H
+#define __CH32X035_ADC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* ADC Init structure definition */
+typedef struct
+{
+    uint32_t ADC_Mode; /* Configures the ADC to operate in independent or
+                          dual mode.
+                          This parameter can be a value of @ref ADC_mode */
+
+    FunctionalState ADC_ScanConvMode; /* Specifies whether the conversion is performed in
+                                         Scan (multichannels) or Single (one channel) mode.
+                                         This parameter can be set to ENABLE or DISABLE */
+
+    FunctionalState ADC_ContinuousConvMode; /* Specifies whether the conversion is performed in
+                                               Continuous or Single mode.
+                                               This parameter can be set to ENABLE or DISABLE. */
+
+    uint32_t ADC_ExternalTrigConv; /* Defines the external trigger used to start the analog
+                                      to digital conversion of regular channels. This parameter
+                                      can be a value of @ref ADC_external_trigger_sources_for_regular_channels_conversion */
+
+    uint32_t ADC_DataAlign; /* Specifies whether the ADC data alignment is left or right.
+                               This parameter can be a value of @ref ADC_data_align */
+
+    uint8_t ADC_NbrOfChannel; /* Specifies the number of ADC channels that will be converted
+                                   using the sequencer for regular channel group.
+                                   This parameter must range from 1 to 16. */
+
+    uint32_t ADC_OutputBuffer; /* Specifies whether the ADC channel output buffer is enabled or disabled.
+                                    This parameter can be a value of @ref ADC_OutputBuffer */
+
+    uint32_t ADC_Pga; /* Specifies the PGA gain multiple.
+                           This parameter can be a value of @ref ADC_Pga */
+} ADC_InitTypeDef;
+
+/* ADC_mode */
+#define ADC_Mode_Independent                           ((uint32_t)0x00000000)
+
+/* ADC_external_trigger_sources_for_regular_channels_conversion */
+#define ADC_ExternalTrigConv_T1_TRGO                   ((uint32_t)0x00000000)
+#define ADC_ExternalTrigConv_T1_CC1                    ((uint32_t)0x00020000)
+#define ADC_ExternalTrigConv_T1_CC2                    ((uint32_t)0x00040000)
+#define ADC_ExternalTrigConv_T2_TRGO                   ((uint32_t)0x00060000)
+#define ADC_ExternalTrigConv_T2_CC1                    ((uint32_t)0x00080000)
+#define ADC_ExternalTrigConv_T3_CC1                    ((uint32_t)0x000A0000)
+#define ADC_ExternalTrigConv_Ext_IT11                  ((uint32_t)0x000C0000)
+#define ADC_ExternalTrigConv_None                      ((uint32_t)0x000E0000)
+
+/* ADC_data_align */
+#define ADC_DataAlign_Right                            ((uint32_t)0x00000000)
+#define ADC_DataAlign_Left                             ((uint32_t)0x00000800)
+
+/* ADC_channels */
+#define ADC_Channel_0                                  ((uint8_t)0x00)
+#define ADC_Channel_1                                  ((uint8_t)0x01)
+#define ADC_Channel_2                                  ((uint8_t)0x02)
+#define ADC_Channel_3                                  ((uint8_t)0x03)
+#define ADC_Channel_4                                  ((uint8_t)0x04)
+#define ADC_Channel_5                                  ((uint8_t)0x05)
+#define ADC_Channel_6                                  ((uint8_t)0x06)
+#define ADC_Channel_7                                  ((uint8_t)0x07)
+#define ADC_Channel_8                                  ((uint8_t)0x08)
+#define ADC_Channel_9                                  ((uint8_t)0x09)
+#define ADC_Channel_10                                 ((uint8_t)0x0A)
+#define ADC_Channel_11                                 ((uint8_t)0x0B)
+#define ADC_Channel_12                                 ((uint8_t)0x0C)
+#define ADC_Channel_13                                 ((uint8_t)0x0D)
+#define ADC_Channel_14                                 ((uint8_t)0x0E)
+#define ADC_Channel_15                                 ((uint8_t)0x0F)
+
+#define ADC_Channel_Vrefint                            ((uint8_t)ADC_Channel_15)
+
+/* ADC_sampling_time */
+#define ADC_SampleTime_4Cycles                         ((uint8_t)0x00)
+#define ADC_SampleTime_5Cycles                         ((uint8_t)0x01)
+#define ADC_SampleTime_6Cycles                         ((uint8_t)0x02)
+#define ADC_SampleTime_7Cycles                         ((uint8_t)0x03)
+#define ADC_SampleTime_8Cycles                         ((uint8_t)0x04)
+#define ADC_SampleTime_9Cycles                         ((uint8_t)0x05)
+#define ADC_SampleTime_10Cycles                        ((uint8_t)0x06)
+#define ADC_SampleTime_11Cycles                        ((uint8_t)0x07)
+
+/* ADC_external_trigger_sources_for_injected_channels_conversion */
+#define ADC_ExternalTrigInjecConv_T1_CC3               ((uint32_t)0x00000000)
+#define ADC_ExternalTrigInjecConv_T1_CC4               ((uint32_t)0x00001000)
+#define ADC_ExternalTrigInjecConv_T2_CC3               ((uint32_t)0x00002000)
+#define ADC_ExternalTrigInjecConv_T2_CC4               ((uint32_t)0x00003000)
+#define ADC_ExternalTrigInjecConv_T2_CC2               ((uint32_t)0x00004000)
+#define ADC_ExternalTrigInjecConv_T3_CC2               ((uint32_t)0x00005000)
+#define ADC_ExternalTrigInjecConv_Ext_IT15             ((uint32_t)0x00006000)
+#define ADC_ExternalTrigInjecConv_None                 ((uint32_t)0x00007000)
+
+/* ADC_injected_channel_selection */
+#define ADC_InjectedChannel_1                          ((uint8_t)0x14)
+#define ADC_InjectedChannel_2                          ((uint8_t)0x18)
+#define ADC_InjectedChannel_3                          ((uint8_t)0x1C)
+#define ADC_InjectedChannel_4                          ((uint8_t)0x20)
+
+/* ADC_analog_watchdog_selection */
+#define ADC_AnalogWatchdog_SingleRegEnable             ((uint32_t)0x00800200)
+#define ADC_AnalogWatchdog_SingleInjecEnable           ((uint32_t)0x00400200)
+#define ADC_AnalogWatchdog_SingleRegOrInjecEnable      ((uint32_t)0x00C00200)
+#define ADC_AnalogWatchdog_AllRegEnable                ((uint32_t)0x00800000)
+#define ADC_AnalogWatchdog_AllInjecEnable              ((uint32_t)0x00400000)
+#define ADC_AnalogWatchdog_AllRegAllInjecEnable        ((uint32_t)0x00C00000)
+#define ADC_AnalogWatchdog_None                        ((uint32_t)0x00000000)
+
+/* ADC_interrupts_definition */
+#define ADC_IT_EOC                                     ((uint16_t)0x0220)
+#define ADC_IT_AWD                                     ((uint16_t)0x0140)
+#define ADC_IT_JEOC                                    ((uint16_t)0x0480)
+
+/* ADC_flags_definition */
+#define ADC_FLAG_AWD                                   ((uint8_t)0x01)
+#define ADC_FLAG_EOC                                   ((uint8_t)0x02)
+#define ADC_FLAG_JEOC                                  ((uint8_t)0x04)
+#define ADC_FLAG_JSTRT                                 ((uint8_t)0x08)
+#define ADC_FLAG_STRT                                  ((uint8_t)0x10)
+
+/* ADC_analog_watchdog_reset_enable_selection */
+#define ADC_AnalogWatchdog_0_RST_EN                    ((uint32_t)0x00001000)
+#define ADC_AnalogWatchdog_1_RST_EN                    ((uint32_t)0x00002000)
+#define ADC_AnalogWatchdog_2_RST_EN                    ((uint32_t)0x00004000)
+#define ADC_AnalogWatchdog_3_RST_EN                    ((uint32_t)0x00008000)
+
+/* ADC_analog_watchdog_reset_flags_definition */
+#define ADC_AnalogWatchdogResetFLAG_0                  ((uint32_t)0x00010000)
+#define ADC_AnalogWatchdogResetFLAG_1                  ((uint32_t)0x00020000)
+#define ADC_AnalogWatchdogResetFLAG_2                  ((uint32_t)0x00040000)
+#define ADC_AnalogWatchdogResetFLAG_3                  ((uint32_t)0x00080000)
+
+/* ADC_clock */
+#define ADC_CLK_Div4                                   ((uint32_t)0x00000013)
+#define ADC_CLK_Div5                                   ((uint32_t)0x00000014)
+#define ADC_CLK_Div6                                   ((uint32_t)0x00000025)
+#define ADC_CLK_Div7                                   ((uint32_t)0x00000026)
+#define ADC_CLK_Div8                                   ((uint32_t)0x00000037)
+#define ADC_CLK_Div9                                   ((uint32_t)0x00000038)
+#define ADC_CLK_Div10                                  ((uint32_t)0x00000049)
+#define ADC_CLK_Div11                                  ((uint32_t)0x0000004A)
+#define ADC_CLK_Div12                                  ((uint32_t)0x0000005B)
+#define ADC_CLK_Div13                                  ((uint32_t)0x0000005C)
+#define ADC_CLK_Div14                                  ((uint32_t)0x0000006D)
+#define ADC_CLK_Div15                                  ((uint32_t)0x0000006E)
+#define ADC_CLK_Div16                                  ((uint32_t)0x0000007F)
+
+
+void       ADC_DeInit(ADC_TypeDef *ADCx);
+void       ADC_Init(ADC_TypeDef *ADCx, ADC_InitTypeDef *ADC_InitStruct);
+void       ADC_StructInit(ADC_InitTypeDef *ADC_InitStruct);
+void       ADC_Cmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+void       ADC_DMACmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+void       ADC_ITConfig(ADC_TypeDef *ADCx, uint16_t ADC_IT, FunctionalState NewState);
+void       ADC_SoftwareStartConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+FlagStatus ADC_GetSoftwareStartConvStatus(ADC_TypeDef *ADCx);
+void       ADC_DiscModeChannelCountConfig(ADC_TypeDef *ADCx, uint8_t Number);
+void       ADC_DiscModeCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+void       ADC_RegularChannelConfig(ADC_TypeDef *ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime);
+void       ADC_ExternalTrigConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+uint16_t   ADC_GetConversionValue(ADC_TypeDef *ADCx);
+uint32_t   ADC_GetDualModeConversionValue(void);
+void       ADC_AutoInjectedConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+void       ADC_InjectedDiscModeCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+void       ADC_ExternalTrigInjectedConvConfig(ADC_TypeDef *ADCx, uint32_t ADC_ExternalTrigInjecConv);
+void       ADC_ExternalTrigInjectedConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+void       ADC_SoftwareStartInjectedConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+FlagStatus ADC_GetSoftwareStartInjectedConvCmdStatus(ADC_TypeDef *ADCx);
+void       ADC_InjectedChannelConfig(ADC_TypeDef *ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime);
+void       ADC_InjectedSequencerLengthConfig(ADC_TypeDef *ADCx, uint8_t Length);
+void       ADC_SetInjectedOffset(ADC_TypeDef *ADCx, uint8_t ADC_InjectedChannel, uint16_t Offset);
+uint16_t   ADC_GetInjectedConversionValue(ADC_TypeDef *ADCx, uint8_t ADC_InjectedChannel);
+void       ADC_AnalogWatchdogCmd(ADC_TypeDef *ADCx, uint32_t ADC_AnalogWatchdog);
+void       ADC_AnalogWatchdogThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold, uint16_t LowThreshold);
+void       ADC_AnalogWatchdog1ThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold, uint16_t LowThreshold);
+void       ADC_AnalogWatchdog2ThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold, uint16_t LowThreshold);
+void       ADC_AnalogWatchdog3ThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold, uint16_t LowThreshold);
+void       ADC_AnalogWatchdogSingleChannelConfig(ADC_TypeDef *ADCx, uint8_t ADC_Channel);
+FlagStatus ADC_GetFlagStatus(ADC_TypeDef *ADCx, uint8_t ADC_FLAG);
+void       ADC_ClearFlag(ADC_TypeDef *ADCx, uint8_t ADC_FLAG);
+ITStatus   ADC_GetITStatus(ADC_TypeDef *ADCx, uint16_t ADC_IT);
+void       ADC_ClearITPendingBit(ADC_TypeDef *ADCx, uint16_t ADC_IT);
+void       ADC_AnalogWatchdogResetCmd(ADC_TypeDef *ADCx, uint32_t ADC_AnalogWatchdog_x, FunctionalState NewState);
+void       ADC_AnalogWatchdogScanCmd(ADC_TypeDef *ADCx, FunctionalState NewState);
+void       ADC_CLKConfig(ADC_TypeDef *ADCx, uint32_t ADC_CLK_Div_x);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_awu.h
+++ b/Peripheral/ch32x035/inc/ch32x035_awu.h
@@ -1,0 +1,48 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_awu.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      AWU firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_AWU_H
+#define __CH32X035_AWU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* PWR_AWU_Prescaler */
+#define AWU_Prescaler_1       ((uint32_t)0x00000000)
+#define AWU_Prescaler_2       ((uint32_t)0x00000002)
+#define AWU_Prescaler_4       ((uint32_t)0x00000003)
+#define AWU_Prescaler_8       ((uint32_t)0x00000004)
+#define AWU_Prescaler_16      ((uint32_t)0x00000005)
+#define AWU_Prescaler_32      ((uint32_t)0x00000006)
+#define AWU_Prescaler_64      ((uint32_t)0x00000007)
+#define AWU_Prescaler_128     ((uint32_t)0x00000008)
+#define AWU_Prescaler_256     ((uint32_t)0x00000009)
+#define AWU_Prescaler_512     ((uint32_t)0x0000000A)
+#define AWU_Prescaler_1024    ((uint32_t)0x0000000B)
+#define AWU_Prescaler_2048    ((uint32_t)0x0000000C)
+#define AWU_Prescaler_4096    ((uint32_t)0x0000000D)
+#define AWU_Prescaler_10240   ((uint32_t)0x0000000E)
+#define AWU_Prescaler_61440   ((uint32_t)0x0000000F)
+
+
+void AutoWakeUpCmd(FunctionalState NewState);
+void AWU_SetPrescaler(uint32_t AWU_Prescaler);
+void AWU_SetWindowValue(uint8_t WindowValue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_conf.h
+++ b/Peripheral/ch32x035/inc/ch32x035_conf.h
@@ -1,0 +1,32 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_conf.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : Library configuration file.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_CONF_H
+#define __CH32X035_CONF_H
+
+#include "ch32x035_adc.h"
+#include "ch32x035_awu.h"
+#include "ch32x035_dbgmcu.h"
+#include "ch32x035_dma.h"
+#include "ch32x035_exti.h"
+#include "ch32x035_flash.h"
+#include "ch32x035_gpio.h"
+#include "ch32x035_i2c.h"
+#include "ch32x035_iwdg.h"
+#include "ch32x035_pwr.h"
+#include "ch32x035_rcc.h"
+#include "ch32x035_spi.h"
+#include "ch32x035_tim.h"
+#include "ch32x035_usart.h"
+#include "ch32x035_wwdg.h"
+#include "ch32x035_misc.h"
+
+#endif /* __CH32V035_CONF_H */

--- a/Peripheral/ch32x035/inc/ch32x035_dbgmcu.h
+++ b/Peripheral/ch32x035/inc/ch32x035_dbgmcu.h
@@ -1,0 +1,41 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_dbgmcu.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      DBGMCU firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_DBGMCU_H
+#define __CH32X035_DBGMCU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+#define DBGMCU_SLEEP                 ((uint32_t)0x00000001)
+#define DBGMCU_STOP                  ((uint32_t)0x00000002)
+#define DBGMCU_STANDBY               ((uint32_t)0x00000004)
+#define DBGMCU_IWDG_STOP             ((uint32_t)0x00000100)
+#define DBGMCU_WWDG_STOP             ((uint32_t)0x00000200)
+#define DBGMCU_TIM1_STOP             ((uint32_t)0x00001000)
+#define DBGMCU_TIM2_STOP             ((uint32_t)0x00002000)
+#define DBGMCU_TIM3_STOP             ((uint32_t)0x00004000)
+
+uint32_t DBGMCU_GetREVID(void);
+uint32_t DBGMCU_GetDEVID(void);
+uint32_t __get_DEBUG_CR(void);
+void __set_DEBUG_CR(uint32_t value);
+void DBGMCU_Config(uint32_t DBGMCU_Periph, FunctionalState NewState);
+uint32_t DBGMCU_GetCHIPID( void );
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_dma.h
+++ b/Peripheral/ch32x035/inc/ch32x035_dma.h
@@ -1,0 +1,184 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_dma.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      DMA firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_DMA_H
+#define __CH32X035_DMA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* DMA Init structure definition */
+typedef struct
+{
+    uint32_t DMA_PeripheralBaseAddr; /* Specifies the peripheral base address for DMAy Channelx. */
+
+    uint32_t DMA_MemoryBaseAddr; /* Specifies the memory base address for DMAy Channelx. */
+
+    uint32_t DMA_DIR; /* Specifies if the peripheral is the source or destination.
+                         This parameter can be a value of @ref DMA_data_transfer_direction */
+
+    uint32_t DMA_BufferSize; /* Specifies the buffer size, in data unit, of the specified Channel.
+                                The data unit is equal to the configuration set in DMA_PeripheralDataSize
+                                or DMA_MemoryDataSize members depending in the transfer direction. */
+
+    uint32_t DMA_PeripheralInc; /* Specifies whether the Peripheral address register is incremented or not.
+                                   This parameter can be a value of @ref DMA_peripheral_incremented_mode */
+
+    uint32_t DMA_MemoryInc; /* Specifies whether the memory address register is incremented or not.
+                               This parameter can be a value of @ref DMA_memory_incremented_mode */
+
+    uint32_t DMA_PeripheralDataSize; /* Specifies the Peripheral data width.
+                                        This parameter can be a value of @ref DMA_peripheral_data_size */
+
+    uint32_t DMA_MemoryDataSize; /* Specifies the Memory data width.
+                                    This parameter can be a value of @ref DMA_memory_data_size */
+
+    uint32_t DMA_Mode; /* Specifies the operation mode of the DMAy Channelx.
+                          This parameter can be a value of @ref DMA_circular_normal_mode.
+                          @note: The circular buffer mode cannot be used if the memory-to-memory
+                                data transfer is configured on the selected Channel */
+
+    uint32_t DMA_Priority; /* Specifies the software priority for the DMAy Channelx.
+                              This parameter can be a value of @ref DMA_priority_level */
+
+    uint32_t DMA_M2M; /* Specifies if the DMAy Channelx will be used in memory-to-memory transfer.
+                         This parameter can be a value of @ref DMA_memory_to_memory */
+} DMA_InitTypeDef;
+
+/* DMA_data_transfer_direction */
+#define DMA_DIR_PeripheralDST              ((uint32_t)0x00000010)
+#define DMA_DIR_PeripheralSRC              ((uint32_t)0x00000000)
+
+/* DMA_peripheral_incremented_mode */
+#define DMA_PeripheralInc_Enable           ((uint32_t)0x00000040)
+#define DMA_PeripheralInc_Disable          ((uint32_t)0x00000000)
+
+/* DMA_memory_incremented_mode */
+#define DMA_MemoryInc_Enable               ((uint32_t)0x00000080)
+#define DMA_MemoryInc_Disable              ((uint32_t)0x00000000)
+
+/* DMA_peripheral_data_size */
+#define DMA_PeripheralDataSize_Byte        ((uint32_t)0x00000000)
+#define DMA_PeripheralDataSize_HalfWord    ((uint32_t)0x00000100)
+#define DMA_PeripheralDataSize_Word        ((uint32_t)0x00000200)
+
+/* DMA_memory_data_size */
+#define DMA_MemoryDataSize_Byte            ((uint32_t)0x00000000)
+#define DMA_MemoryDataSize_HalfWord        ((uint32_t)0x00000400)
+#define DMA_MemoryDataSize_Word            ((uint32_t)0x00000800)
+
+/* DMA_circular_normal_mode */
+#define DMA_Mode_Circular                  ((uint32_t)0x00000020)
+#define DMA_Mode_Normal                    ((uint32_t)0x00000000)
+
+/* DMA_priority_level */
+#define DMA_Priority_VeryHigh              ((uint32_t)0x00003000)
+#define DMA_Priority_High                  ((uint32_t)0x00002000)
+#define DMA_Priority_Medium                ((uint32_t)0x00001000)
+#define DMA_Priority_Low                   ((uint32_t)0x00000000)
+
+/* DMA_memory_to_memory */
+#define DMA_M2M_Enable                     ((uint32_t)0x00004000)
+#define DMA_M2M_Disable                    ((uint32_t)0x00000000)
+
+/* DMA_interrupts_definition */
+#define DMA_IT_TC                          ((uint32_t)0x00000002)
+#define DMA_IT_HT                          ((uint32_t)0x00000004)
+#define DMA_IT_TE                          ((uint32_t)0x00000008)
+
+#define DMA1_IT_GL1                        ((uint32_t)0x00000001)
+#define DMA1_IT_TC1                        ((uint32_t)0x00000002)
+#define DMA1_IT_HT1                        ((uint32_t)0x00000004)
+#define DMA1_IT_TE1                        ((uint32_t)0x00000008)
+#define DMA1_IT_GL2                        ((uint32_t)0x00000010)
+#define DMA1_IT_TC2                        ((uint32_t)0x00000020)
+#define DMA1_IT_HT2                        ((uint32_t)0x00000040)
+#define DMA1_IT_TE2                        ((uint32_t)0x00000080)
+#define DMA1_IT_GL3                        ((uint32_t)0x00000100)
+#define DMA1_IT_TC3                        ((uint32_t)0x00000200)
+#define DMA1_IT_HT3                        ((uint32_t)0x00000400)
+#define DMA1_IT_TE3                        ((uint32_t)0x00000800)
+#define DMA1_IT_GL4                        ((uint32_t)0x00001000)
+#define DMA1_IT_TC4                        ((uint32_t)0x00002000)
+#define DMA1_IT_HT4                        ((uint32_t)0x00004000)
+#define DMA1_IT_TE4                        ((uint32_t)0x00008000)
+#define DMA1_IT_GL5                        ((uint32_t)0x00010000)
+#define DMA1_IT_TC5                        ((uint32_t)0x00020000)
+#define DMA1_IT_HT5                        ((uint32_t)0x00040000)
+#define DMA1_IT_TE5                        ((uint32_t)0x00080000)
+#define DMA1_IT_GL6                        ((uint32_t)0x00100000)
+#define DMA1_IT_TC6                        ((uint32_t)0x00200000)
+#define DMA1_IT_HT6                        ((uint32_t)0x00400000)
+#define DMA1_IT_TE6                        ((uint32_t)0x00800000)
+#define DMA1_IT_GL7                        ((uint32_t)0x01000000)
+#define DMA1_IT_TC7                        ((uint32_t)0x02000000)
+#define DMA1_IT_HT7                        ((uint32_t)0x04000000)
+#define DMA1_IT_TE7                        ((uint32_t)0x08000000)
+#define DMA1_IT_GL8                        ((uint32_t)0x10000000)
+#define DMA1_IT_TC8                        ((uint32_t)0x20000000)
+#define DMA1_IT_HT8                        ((uint32_t)0x40000000)
+#define DMA1_IT_TE8                        ((uint32_t)0x80000000)
+
+/* DMA_flags_definition */
+#define DMA1_FLAG_GL1                      ((uint32_t)0x00000001)
+#define DMA1_FLAG_TC1                      ((uint32_t)0x00000002)
+#define DMA1_FLAG_HT1                      ((uint32_t)0x00000004)
+#define DMA1_FLAG_TE1                      ((uint32_t)0x00000008)
+#define DMA1_FLAG_GL2                      ((uint32_t)0x00000010)
+#define DMA1_FLAG_TC2                      ((uint32_t)0x00000020)
+#define DMA1_FLAG_HT2                      ((uint32_t)0x00000040)
+#define DMA1_FLAG_TE2                      ((uint32_t)0x00000080)
+#define DMA1_FLAG_GL3                      ((uint32_t)0x00000100)
+#define DMA1_FLAG_TC3                      ((uint32_t)0x00000200)
+#define DMA1_FLAG_HT3                      ((uint32_t)0x00000400)
+#define DMA1_FLAG_TE3                      ((uint32_t)0x00000800)
+#define DMA1_FLAG_GL4                      ((uint32_t)0x00001000)
+#define DMA1_FLAG_TC4                      ((uint32_t)0x00002000)
+#define DMA1_FLAG_HT4                      ((uint32_t)0x00004000)
+#define DMA1_FLAG_TE4                      ((uint32_t)0x00008000)
+#define DMA1_FLAG_GL5                      ((uint32_t)0x00010000)
+#define DMA1_FLAG_TC5                      ((uint32_t)0x00020000)
+#define DMA1_FLAG_HT5                      ((uint32_t)0x00040000)
+#define DMA1_FLAG_TE5                      ((uint32_t)0x00080000)
+#define DMA1_FLAG_GL6                      ((uint32_t)0x00100000)
+#define DMA1_FLAG_TC6                      ((uint32_t)0x00200000)
+#define DMA1_FLAG_HT6                      ((uint32_t)0x00400000)
+#define DMA1_FLAG_TE6                      ((uint32_t)0x00800000)
+#define DMA1_FLAG_GL7                      ((uint32_t)0x01000000)
+#define DMA1_FLAG_TC7                      ((uint32_t)0x02000000)
+#define DMA1_FLAG_HT7                      ((uint32_t)0x04000000)
+#define DMA1_FLAG_TE7                      ((uint32_t)0x08000000)
+#define DMA1_FLAG_GL8                      ((uint32_t)0x10000000)
+#define DMA1_FLAG_TC8                      ((uint32_t)0x20000000)
+#define DMA1_FLAG_HT8                      ((uint32_t)0x40000000)
+#define DMA1_FLAG_TE8                      ((uint32_t)0x80000000)
+
+void       DMA_DeInit(DMA_Channel_TypeDef *DMAy_Channelx);
+void       DMA_Init(DMA_Channel_TypeDef *DMAy_Channelx, DMA_InitTypeDef *DMA_InitStruct);
+void       DMA_StructInit(DMA_InitTypeDef *DMA_InitStruct);
+void       DMA_Cmd(DMA_Channel_TypeDef *DMAy_Channelx, FunctionalState NewState);
+void       DMA_ITConfig(DMA_Channel_TypeDef *DMAy_Channelx, uint32_t DMA_IT, FunctionalState NewState);
+void       DMA_SetCurrDataCounter(DMA_Channel_TypeDef *DMAy_Channelx, uint16_t DataNumber);
+uint16_t   DMA_GetCurrDataCounter(DMA_Channel_TypeDef *DMAy_Channelx);
+FlagStatus DMA_GetFlagStatus(uint32_t DMAy_FLAG);
+void       DMA_ClearFlag(uint32_t DMAy_FLAG);
+ITStatus   DMA_GetITStatus(uint32_t DMAy_IT);
+void       DMA_ClearITPendingBit(uint32_t DMAy_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_exti.h
+++ b/Peripheral/ch32x035/inc/ch32x035_exti.h
@@ -1,0 +1,99 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_exti.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      EXTI firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_EXTI_H
+#define __CH32X035_EXTI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* EXTI mode enumeration */
+typedef enum
+{
+    EXTI_Mode_Interrupt = 0x00,
+    EXTI_Mode_Event = 0x04
+} EXTIMode_TypeDef;
+
+/* EXTI Trigger enumeration */
+typedef enum
+{
+    EXTI_Trigger_Rising = 0x08,
+    EXTI_Trigger_Falling = 0x0C,
+    EXTI_Trigger_Rising_Falling = 0x10
+} EXTITrigger_TypeDef;
+
+/* EXTI Init Structure definition */
+typedef struct
+{
+    uint32_t EXTI_Line; /* Specifies the EXTI lines to be enabled or disabled.
+                           This parameter can be any combination of @ref EXTI_Lines */
+
+    EXTIMode_TypeDef EXTI_Mode; /* Specifies the mode for the EXTI lines.
+                                   This parameter can be a value of @ref EXTIMode_TypeDef */
+
+    EXTITrigger_TypeDef EXTI_Trigger; /* Specifies the trigger signal active edge for the EXTI lines.
+                                         This parameter can be a value of @ref EXTIMode_TypeDef */
+
+    FunctionalState EXTI_LineCmd; /* Specifies the new state of the selected EXTI lines.
+                                     This parameter can be set either to ENABLE or DISABLE */
+} EXTI_InitTypeDef;
+
+/* EXTI_Lines */
+#define EXTI_Line0     ((uint32_t)0x00000001)  /* External interrupt line 0 */
+#define EXTI_Line1     ((uint32_t)0x00000002)  /* External interrupt line 1 */
+#define EXTI_Line2     ((uint32_t)0x00000004)  /* External interrupt line 2 */
+#define EXTI_Line3     ((uint32_t)0x00000008)  /* External interrupt line 3 */
+#define EXTI_Line4     ((uint32_t)0x00000010)  /* External interrupt line 4 */
+#define EXTI_Line5     ((uint32_t)0x00000020)  /* External interrupt line 5 */
+#define EXTI_Line6     ((uint32_t)0x00000040)  /* External interrupt line 6 */
+#define EXTI_Line7     ((uint32_t)0x00000080)  /* External interrupt line 7 */
+#define EXTI_Line8     ((uint32_t)0x00000100)  /* External interrupt line 8 */
+#define EXTI_Line9     ((uint32_t)0x00000200)  /* External interrupt line 9 */
+#define EXTI_Line10    ((uint32_t)0x00000400)  /* External interrupt line 10 */
+#define EXTI_Line11    ((uint32_t)0x00000800)  /* External interrupt line 11 */
+#define EXTI_Line12    ((uint32_t)0x00001000)  /* External interrupt line 12 */
+#define EXTI_Line13    ((uint32_t)0x00002000)  /* External interrupt line 13 */
+#define EXTI_Line14    ((uint32_t)0x00004000)  /* External interrupt line 14 */
+#define EXTI_Line15    ((uint32_t)0x00008000)  /* External interrupt line 15 */
+#define EXTI_Line16    ((uint32_t)0x00010000)  /* External interrupt line 16 */
+#define EXTI_Line17    ((uint32_t)0x00020000)  /* External interrupt line 17 */
+#define EXTI_Line18    ((uint32_t)0x00040000)  /* External interrupt line 18 */
+#define EXTI_Line19    ((uint32_t)0x00080000)  /* External interrupt line 19 */
+#define EXTI_Line20    ((uint32_t)0x00100000)  /* External interrupt line 20 */
+#define EXTI_Line21    ((uint32_t)0x00200000)  /* External interrupt line 21 */
+#define EXTI_Line22    ((uint32_t)0x00400000)  /* External interrupt line 22 */
+#define EXTI_Line23    ((uint32_t)0x00800000)  /* External interrupt line 23 */
+#define EXTI_Line24    ((uint32_t)0x01000000)  /* External interrupt line 24 Connected to the PC18(SDI on) */
+#define EXTI_Line25    ((uint32_t)0x02000000)  /* External interrupt line 25 Connected to the PC19(SDI on) */
+#define EXTI_Line26    ((uint32_t)0x04000000)  /* External interrupt line 26 Connected to the PVD Output */
+#define EXTI_Line27    ((uint32_t)0x08000000)  /* External interrupt line 27 Connected to the Auto Wake-up event */
+#define EXTI_Line28    ((uint32_t)0x10000000)  /* External interrupt line 28 Connected to the the USBFS Wake-up event */
+#define EXTI_Line29    ((uint32_t)0x20000000)  /* External interrupt line 29 Connected to the the USB PD Wake-up event */
+
+
+void       EXTI_DeInit(void);
+void       EXTI_Init(EXTI_InitTypeDef *EXTI_InitStruct);
+void       EXTI_StructInit(EXTI_InitTypeDef *EXTI_InitStruct);
+void       EXTI_GenerateSWInterrupt(uint32_t EXTI_Line);
+FlagStatus EXTI_GetFlagStatus(uint32_t EXTI_Line);
+void       EXTI_ClearFlag(uint32_t EXTI_Line);
+ITStatus   EXTI_GetITStatus(uint32_t EXTI_Line);
+void       EXTI_ClearITPendingBit(uint32_t EXTI_Line);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_flash.h
+++ b/Peripheral/ch32x035/inc/ch32x035_flash.h
@@ -1,0 +1,144 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_flash.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the FLASH
+ *                      firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_FLASH_H
+#define __CH32X035_FLASH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* FLASH Status */
+typedef enum
+{
+    FLASH_BUSY = 1,
+    FLASH_ERROR_PG,
+    FLASH_ERROR_WRP,
+    FLASH_COMPLETE,
+    FLASH_TIMEOUT,
+    FLASH_RDP
+} FLASH_Status;
+
+/* Flash_Latency */
+#define FLASH_Latency_0                  ((uint32_t)0x00000000) /* FLASH Zero Latency cycle */
+#define FLASH_Latency_1                  ((uint32_t)0x00000001) /* FLASH One Latency cycle */
+#define FLASH_Latency_2                  ((uint32_t)0x00000002) /* FLASH Two Latency cycles */
+
+/* Values to be used with devices (1page = 256Byte) */
+#define FLASH_WRProt_Pages0to7           ((uint32_t)0x00000001) /* Write protection of page 0 to 7 */
+#define FLASH_WRProt_Pages8to15          ((uint32_t)0x00000002) /* Write protection of page 8 to 15 */
+#define FLASH_WRProt_Pages16to23         ((uint32_t)0x00000004) /* Write protection of page 16 to 23 */
+#define FLASH_WRProt_Pages24to31         ((uint32_t)0x00000008) /* Write protection of page 24 to 31 */
+#define FLASH_WRProt_Pages32to39         ((uint32_t)0x00000010) /* Write protection of page 32 to 39 */
+#define FLASH_WRProt_Pages40to47         ((uint32_t)0x00000020) /* Write protection of page 40 to 47 */
+#define FLASH_WRProt_Pages48to55         ((uint32_t)0x00000040) /* Write protection of page 48 to 55 */
+#define FLASH_WRProt_Pages56to63         ((uint32_t)0x00000080) /* Write protection of page 56 to 63 */
+#define FLASH_WRProt_Pages64to71         ((uint32_t)0x00000100) /* Write protection of page 64 to 71 */
+#define FLASH_WRProt_Pages72to79         ((uint32_t)0x00000200) /* Write protection of page 72 to 79 */
+#define FLASH_WRProt_Pages80to87         ((uint32_t)0x00000400) /* Write protection of page 80 to 87 */
+#define FLASH_WRProt_Pages88to95         ((uint32_t)0x00000800) /* Write protection of page 88 to 95 */
+#define FLASH_WRProt_Pages96to103        ((uint32_t)0x00001000) /* Write protection of page 96 to 103 */
+#define FLASH_WRProt_Pages104to111       ((uint32_t)0x00002000) /* Write protection of page 104 to 111 */
+#define FLASH_WRProt_Pages112to119       ((uint32_t)0x00004000) /* Write protection of page 112 to 119 */
+#define FLASH_WRProt_Pages120to127       ((uint32_t)0x00008000) /* Write protection of page 120 to 127 */
+#define FLASH_WRProt_Pages128to135       ((uint32_t)0x00010000) /* Write protection of page 128 to 135 */
+#define FLASH_WRProt_Pages136to143       ((uint32_t)0x00020000) /* Write protection of page 136 to 143 */
+#define FLASH_WRProt_Pages144to151       ((uint32_t)0x00040000) /* Write protection of page 144 to 151 */
+#define FLASH_WRProt_Pages152to159       ((uint32_t)0x00080000) /* Write protection of page 152 to 159 */
+#define FLASH_WRProt_Pages160to167       ((uint32_t)0x00100000) /* Write protection of page 160 to 167 */
+#define FLASH_WRProt_Pages168to175       ((uint32_t)0x00200000) /* Write protection of page 168 to 175 */
+#define FLASH_WRProt_Pages176to183       ((uint32_t)0x00400000) /* Write protection of page 176 to 183 */
+#define FLASH_WRProt_Pages184to191       ((uint32_t)0x00800000) /* Write protection of page 184 to 191 */
+#define FLASH_WRProt_Pages192to199       ((uint32_t)0x01000000) /* Write protection of page 192 to 199 */
+#define FLASH_WRProt_Pages200to207       ((uint32_t)0x02000000) /* Write protection of page 200 to 207 */
+#define FLASH_WRProt_Pages208to215       ((uint32_t)0x04000000) /* Write protection of page 208 to 215 */
+#define FLASH_WRProt_Pages216to223       ((uint32_t)0x08000000) /* Write protection of page 216 to 223 */
+#define FLASH_WRProt_Pages224to231       ((uint32_t)0x10000000) /* Write protection of page 224 to 231 */
+#define FLASH_WRProt_Pages232to239       ((uint32_t)0x20000000) /* Write protection of page 232 to 239 */
+#define FLASH_WRProt_Pages240to247       ((uint32_t)0x40000000) /* Write protection of page 240 to 247 */
+
+
+#define FLASH_WRProt_AllPages            ((uint32_t)0xFFFFFFFF) /* Write protection of all Pages */
+
+/* Option_Bytes_IWatchdog */
+#define OB_IWDG_SW                       ((uint8_t)0x01) /* Software IWDG selected */
+#define OB_IWDG_HW                       ((uint8_t)0x00) /* Hardware IWDG selected */
+
+/* Option_Bytes_nRST_STOP */
+#define OB_STOP_NoRST                    ((uint8_t)0x02) /* No reset generated when entering in STOP */
+#define OB_STOP_RST                      ((uint8_t)0x00) /* Reset generated when entering in STOP */
+
+/* Option_Bytes_nRST_STDBY */
+#define OB_STDBY_NoRST                   ((uint8_t)0x04) /* No reset generated when entering in STANDBY */
+#define OB_STDBY_RST                     ((uint8_t)0x00) /* Reset generated when entering in STANDBY */
+
+/* Option_Bytes_RST_ENandDT */
+#define OB_RST_NoEN                      ((uint8_t)0x18) /* Reset IO disable */
+#define OB_RST_EN_DT12ms                 ((uint8_t)0x10) /* Reset IO enable and  Ignore delay time 12ms */
+#define OB_RST_EN_DT1ms                  ((uint8_t)0x08) /* Reset IO enable and  Ignore delay time 1ms */
+#define OB_RST_EN_DT128us                ((uint8_t)0x00) /* Reset IO enable and  Ignore delay time 128us */
+
+/* FLASH_Interrupts */
+#define FLASH_IT_ERROR                   ((uint32_t)0x00000400) /* FPEC error interrupt source */
+#define FLASH_IT_EOP                     ((uint32_t)0x00001000) /* End of FLASH Operation Interrupt source */
+#define FLASH_IT_BANK1_ERROR             FLASH_IT_ERROR         /* FPEC BANK1 error interrupt source */
+#define FLASH_IT_BANK1_EOP               FLASH_IT_EOP           /* End of FLASH BANK1 Operation Interrupt source */
+
+/* FLASH_Flags */
+#define FLASH_FLAG_BSY                   ((uint32_t)0x00000001) /* FLASH Busy flag */
+#define FLASH_FLAG_EOP                   ((uint32_t)0x00000020) /* FLASH End of Operation flag */
+#define FLASH_FLAG_WRPRTERR              ((uint32_t)0x00000010) /* FLASH Write protected error flag */
+#define FLASH_FLAG_OPTERR                ((uint32_t)0x00000001) /* FLASH Option Byte error flag */
+
+#define FLASH_FLAG_BANK1_BSY             FLASH_FLAG_BSY       /* FLASH BANK1 Busy flag*/
+#define FLASH_FLAG_BANK1_EOP             FLASH_FLAG_EOP       /* FLASH BANK1 End of Operation flag */
+#define FLASH_FLAG_BANK1_WRPRTERR        FLASH_FLAG_WRPRTERR  /* FLASH BANK1 Write protected error flag */
+
+/* System_Reset_Start_Mode */
+#define Start_Mode_USER                  ((uint32_t)0x00000000)
+#define Start_Mode_BOOT                  ((uint32_t)0x00004000)
+
+
+/*Functions used for all CH32V00x devices*/
+void         FLASH_SetLatency(uint32_t FLASH_Latency);
+void         FLASH_Unlock(void);
+void         FLASH_Lock(void);
+FLASH_Status FLASH_ErasePage(uint32_t Page_Address);
+FLASH_Status FLASH_EraseAllPages(void);
+FLASH_Status FLASH_EraseOptionBytes(void);
+FLASH_Status FLASH_EnableWriteProtection(uint32_t FLASH_Pages);
+FLASH_Status FLASH_EnableReadOutProtection(void);
+FLASH_Status FLASH_UserOptionByteConfig(uint8_t OB_IWDG, uint8_t OB_STOP, uint8_t OB_STDBY, uint8_t OB_RST);
+uint32_t     FLASH_GetUserOptionByte(void);
+uint32_t     FLASH_GetWriteProtectionOptionByte(void);
+FlagStatus   FLASH_GetReadOutProtectionStatus(void);
+void         FLASH_ITConfig(uint32_t FLASH_IT, FunctionalState NewState);
+FlagStatus   FLASH_GetFlagStatus(uint32_t FLASH_FLAG);
+void         FLASH_ClearFlag(uint32_t FLASH_FLAG);
+FLASH_Status FLASH_GetStatus(void);
+FLASH_Status FLASH_WaitForLastOperation(uint32_t Timeout);
+void         FLASH_Unlock_Fast(void);
+void         FLASH_Lock_Fast(void);
+void         FLASH_BufReset(void);
+void         FLASH_BufLoad(uint32_t Address, uint32_t Data0);
+void         FLASH_ErasePage_Fast(uint32_t Page_Address);
+void         FLASH_ProgramPage_Fast(uint32_t Page_Address);
+void         SystemReset_StartMode(uint32_t Mode);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_gpio.h
+++ b/Peripheral/ch32x035/inc/ch32x035_gpio.h
@@ -1,0 +1,183 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_gpio.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      GPIO firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_GPIO_H
+#define __CH32X035_GPIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* Output Maximum frequency selection */
+typedef enum
+{
+    GPIO_Speed_50MHz = 1,
+} GPIOSpeed_TypeDef;
+
+/* Configuration Mode enumeration */
+typedef enum
+{
+    GPIO_Mode_AIN = 0x0,
+    GPIO_Mode_IN_FLOATING = 0x04,
+    GPIO_Mode_IPD = 0x28,   /* Only PA0--PA15 and PC16--PC17 support input pull-down */
+    GPIO_Mode_IPU = 0x48,
+    GPIO_Mode_Out_OD = 0x14,
+    GPIO_Mode_Out_PP = 0x10,
+    GPIO_Mode_AF_OD = 0x1C,
+    GPIO_Mode_AF_PP = 0x18
+} GPIOMode_TypeDef;
+
+/* GPIO Init structure definition */
+typedef struct
+{
+    uint32_t GPIO_Pin; /* Specifies the GPIO pins to be configured.
+                          This parameter can be any value of @ref GPIO_pins_define */
+
+    GPIOSpeed_TypeDef GPIO_Speed; /* Specifies the speed for the selected pins.
+                                     This parameter can be a value of @ref GPIOSpeed_TypeDef */
+
+    GPIOMode_TypeDef GPIO_Mode; /* Specifies the operating mode for the selected pins.
+                                   This parameter can be a value of @ref GPIOMode_TypeDef */
+} GPIO_InitTypeDef;
+
+/* Bit_SET and Bit_RESET enumeration */
+typedef enum
+{
+    Bit_RESET = 0,
+    Bit_SET
+} BitAction;
+
+/* GPIO_pins_define */
+#define GPIO_Pin_0                      ((uint32_t)0x000001) /* Pin 0 selected */
+#define GPIO_Pin_1                      ((uint32_t)0x000002) /* Pin 1 selected */
+#define GPIO_Pin_2                      ((uint32_t)0x000004) /* Pin 2 selected */
+#define GPIO_Pin_3                      ((uint32_t)0x000008) /* Pin 3 selected */
+#define GPIO_Pin_4                      ((uint32_t)0x000010) /* Pin 4 selected */
+#define GPIO_Pin_5                      ((uint32_t)0x000020) /* Pin 5 selected */
+#define GPIO_Pin_6                      ((uint32_t)0x000040) /* Pin 6 selected */
+#define GPIO_Pin_7                      ((uint32_t)0x000080) /* Pin 7 selected */
+#define GPIO_Pin_8                      ((uint32_t)0x000100) /* Pin 8 selected */
+#define GPIO_Pin_9                      ((uint32_t)0x000200) /* Pin 9 selected */
+#define GPIO_Pin_10                     ((uint32_t)0x000400) /* Pin 10 selected */
+#define GPIO_Pin_11                     ((uint32_t)0x000800) /* Pin 11 selected */
+#define GPIO_Pin_12                     ((uint32_t)0x001000) /* Pin 12 selected */
+#define GPIO_Pin_13                     ((uint32_t)0x002000) /* Pin 13 selected */
+#define GPIO_Pin_14                     ((uint32_t)0x004000) /* Pin 14 selected */
+#define GPIO_Pin_15                     ((uint32_t)0x008000) /* Pin 15 selected */
+#define GPIO_Pin_16                     ((uint32_t)0x010000) /* Pin 16 selected */
+#define GPIO_Pin_17                     ((uint32_t)0x020000) /* Pin 17 selected */
+#define GPIO_Pin_18                     ((uint32_t)0x040000) /* Pin 18 selected */
+#define GPIO_Pin_19                     ((uint32_t)0x080000) /* Pin 19 selected */
+#define GPIO_Pin_20                     ((uint32_t)0x100000) /* Pin 20 selected */
+#define GPIO_Pin_21                     ((uint32_t)0x200000) /* Pin 21 selected */
+#define GPIO_Pin_22                     ((uint32_t)0x400000) /* Pin 22 selected */
+#define GPIO_Pin_23                     ((uint32_t)0x800000) /* Pin 23 selected */
+#define GPIO_Pin_All                    ((uint32_t)0xFFFFFF) /* All pins selected */
+
+/* GPIO_Remap_define */
+/* PCFR1 */
+#define GPIO_PartialRemap1_SPI1         ((uint32_t)0x00100001) /* SPI1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_SPI1         ((uint32_t)0x00100002) /* SPI1 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_SPI1             ((uint32_t)0x00100003) /* SPI1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_I2C1         ((uint32_t)0x08000004) /* I2C1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_I2C1         ((uint32_t)0x08000008) /* I2C1 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_I2C1         ((uint32_t)0x0800000C) /* I2C1 Partial3 Alternate Function mapping */
+#define GPIO_PartialRemap4_I2C1         ((uint32_t)0x08000010) /* I2C1 Partial4 Alternate Function mapping */
+#define GPIO_FullRemap_I2C1             ((uint32_t)0x08000014) /* I2C1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART1       ((uint32_t)0x00150020) /* USART1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART1       ((uint32_t)0x00150040) /* USART1 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_USART1           ((uint32_t)0x00150060) /* USART1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART2       ((uint32_t)0x08000080) /* USART2 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART2       ((uint32_t)0x08000100) /* USART2 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_USART2       ((uint32_t)0x08000180) /* USART2 Partial3 Alternate Function mapping */
+#define GPIO_FullRemap_USART2           ((uint32_t)0x08000200) /* USART2 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART3       ((uint32_t)0x00100400) /* USART3 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART3       ((uint32_t)0x00100800) /* USART3 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_USART3           ((uint32_t)0x00100C00) /* USART3 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART4       ((uint32_t)0x08001000) /* USART4 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART4       ((uint32_t)0x08002000) /* USART4 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_USART4       ((uint32_t)0x08003000) /* USART4 Partial3 Alternate Function mapping */
+#define GPIO_PartialRemap4_USART4       ((uint32_t)0x08004000) /* USART4 Partial4 Alternate Function mapping */
+#define GPIO_FullRemap_USART4           ((uint32_t)0x08007000) /* USART4 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM1         ((uint32_t)0x08400001) /* TIM1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM1         ((uint32_t)0x08400002) /* TIM1 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_TIM1         ((uint32_t)0x08400003) /* TIM1 Partial3 Alternate Function mapping */
+#define GPIO_FullRemap_TIM1             ((uint32_t)0x08400004) /* TIM1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM2         ((uint32_t)0x08200004) /* TIM2 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM2         ((uint32_t)0x08200008) /* TIM2 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_TIM2         ((uint32_t)0x0820000C) /* TIM2 Partial3 Alternate Function mapping */
+#define GPIO_PartialRemap4_TIM2         ((uint32_t)0x08200010) /* TIM2 Partial4 Alternate Function mapping */
+#define GPIO_PartialRemap5_TIM2         ((uint32_t)0x08200014) /* TIM2 Partial5 Alternate Function mapping */
+#define GPIO_FullRemap_TIM2             ((uint32_t)0x08200018) /* TIM2 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM3         ((uint32_t)0x00300020) /* TIM3 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM3         ((uint32_t)0x00300040) /* TIM3 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_TIM3             ((uint32_t)0x00300060) /* TIM3 Full Alternate Function mapping */
+#define GPIO_Remap_PIOC                 ((uint32_t)0x00200080) /* PIOC Alternate Function mapping */
+#define GPIO_Remap_SWJ_Disable          ((uint32_t)0x08300400) /* SDI Disabled (SDI) */
+
+/* GPIO_Port_Sources */
+#define GPIO_PortSourceGPIOA            ((uint8_t)0x00)
+#define GPIO_PortSourceGPIOB            ((uint8_t)0x01)
+#define GPIO_PortSourceGPIOC            ((uint8_t)0x02)
+
+/* GPIO_Pin_sources */
+#define GPIO_PinSource0                 ((uint8_t)0x00)
+#define GPIO_PinSource1                 ((uint8_t)0x01)
+#define GPIO_PinSource2                 ((uint8_t)0x02)
+#define GPIO_PinSource3                 ((uint8_t)0x03)
+#define GPIO_PinSource4                 ((uint8_t)0x04)
+#define GPIO_PinSource5                 ((uint8_t)0x05)
+#define GPIO_PinSource6                 ((uint8_t)0x06)
+#define GPIO_PinSource7                 ((uint8_t)0x07)
+#define GPIO_PinSource8                 ((uint8_t)0x08)
+#define GPIO_PinSource9                 ((uint8_t)0x09)
+#define GPIO_PinSource10                ((uint8_t)0x0A)
+#define GPIO_PinSource11                ((uint8_t)0x0B)
+#define GPIO_PinSource12                ((uint8_t)0x0C)
+#define GPIO_PinSource13                ((uint8_t)0x0D)
+#define GPIO_PinSource14                ((uint8_t)0x0E)
+#define GPIO_PinSource15                ((uint8_t)0x0F)
+#define GPIO_PinSource16                ((uint8_t)0x10)
+#define GPIO_PinSource17                ((uint8_t)0x11)
+#define GPIO_PinSource18                ((uint8_t)0x12)
+#define GPIO_PinSource19                ((uint8_t)0x13)
+#define GPIO_PinSource20                ((uint8_t)0x14)
+#define GPIO_PinSource21                ((uint8_t)0x15)
+#define GPIO_PinSource22                ((uint8_t)0x16)
+#define GPIO_PinSource23                ((uint8_t)0x17)
+
+
+void     GPIO_DeInit(GPIO_TypeDef *GPIOx);
+void     GPIO_AFIODeInit(void);
+void     GPIO_Init(GPIO_TypeDef *GPIOx, GPIO_InitTypeDef *GPIO_InitStruct);
+void     GPIO_StructInit(GPIO_InitTypeDef *GPIO_InitStruct);
+uint8_t  GPIO_ReadInputDataBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin);
+uint32_t GPIO_ReadInputData(GPIO_TypeDef *GPIOx);
+uint8_t  GPIO_ReadOutputDataBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin);
+uint32_t GPIO_ReadOutputData(GPIO_TypeDef *GPIOx);
+void     GPIO_SetBits(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin);
+void     GPIO_ResetBits(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin);
+void     GPIO_WriteBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin, BitAction BitVal);
+void     GPIO_Write(GPIO_TypeDef *GPIOx, uint32_t PortVal);
+void     GPIO_PinLockConfig(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin);
+void     GPIO_PinRemapConfig(uint32_t GPIO_Remap, FunctionalState NewState);
+void     GPIO_EXTILineConfig(uint8_t GPIO_PortSource, uint16_t GPIO_PinSource);
+void     GPIO_IPD_Unused(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_i2c.h
+++ b/Peripheral/ch32x035/inc/ch32x035_i2c.h
@@ -1,0 +1,416 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_i2c.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      I2C firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_I2C_H
+#define __CH32X035_I2C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* I2C Init structure definition  */
+typedef struct
+{
+    uint32_t I2C_ClockSpeed; /* Specifies the clock frequency.
+                                This parameter must be set to a value lower than 400kHz */
+
+    uint16_t I2C_Mode; /* Specifies the I2C mode.
+                          This parameter can be a value of @ref I2C_mode */
+
+    uint16_t I2C_DutyCycle; /* Specifies the I2C fast mode duty cycle.
+                               This parameter can be a value of @ref I2C_duty_cycle_in_fast_mode */
+
+    uint16_t I2C_OwnAddress1; /* Specifies the first device own address.
+                                 This parameter can be a 7-bit or 10-bit address. */
+
+    uint16_t I2C_Ack; /* Enables or disables the acknowledgement.
+                         This parameter can be a value of @ref I2C_acknowledgement */
+
+    uint16_t I2C_AcknowledgedAddress; /* Specifies if 7-bit or 10-bit address is acknowledged.
+                                         This parameter can be a value of @ref I2C_acknowledged_address */
+} I2C_InitTypeDef;
+
+/* I2C_mode */
+#define I2C_Mode_I2C                                         ((uint16_t)0x0000)
+
+/* I2C_duty_cycle_in_fast_mode */
+#define I2C_DutyCycle_16_9                                   ((uint16_t)0x4000) /* I2C fast mode Tlow/Thigh = 16/9 */
+#define I2C_DutyCycle_2                                      ((uint16_t)0xBFFF) /* I2C fast mode Tlow/Thigh = 2 */
+
+/* I2C_acknowledgement */
+#define I2C_Ack_Enable                                       ((uint16_t)0x0400)
+#define I2C_Ack_Disable                                      ((uint16_t)0x0000)
+
+/* I2C_transfer_direction */
+#define I2C_Direction_Transmitter                            ((uint8_t)0x00)
+#define I2C_Direction_Receiver                               ((uint8_t)0x01)
+
+/* I2C_acknowledged_address */
+#define I2C_AcknowledgedAddress_7bit                         ((uint16_t)0x4000)
+#define I2C_AcknowledgedAddress_10bit                        ((uint16_t)0xC000)
+
+/* I2C_registers */
+#define I2C_Register_CTLR1                                   ((uint8_t)0x00)
+#define I2C_Register_CTLR2                                   ((uint8_t)0x04)
+#define I2C_Register_OADDR1                                  ((uint8_t)0x08)
+#define I2C_Register_OADDR2                                  ((uint8_t)0x0C)
+#define I2C_Register_DATAR                                   ((uint8_t)0x10)
+#define I2C_Register_STAR1                                   ((uint8_t)0x14)
+#define I2C_Register_STAR2                                   ((uint8_t)0x18)
+#define I2C_Register_CKCFGR                                  ((uint8_t)0x1C)
+#define I2C_Register_RTR                                     ((uint8_t)0x20)
+
+/* I2C_PEC_position */
+#define I2C_PECPosition_Next                                 ((uint16_t)0x0800)
+#define I2C_PECPosition_Current                              ((uint16_t)0xF7FF)
+
+/* I2C_NACK_position */
+#define I2C_NACKPosition_Next                                ((uint16_t)0x0800)
+#define I2C_NACKPosition_Current                             ((uint16_t)0xF7FF)
+
+/* I2C_interrupts_definition */
+#define I2C_IT_BUF                                           ((uint16_t)0x0400)
+#define I2C_IT_EVT                                           ((uint16_t)0x0200)
+#define I2C_IT_ERR                                           ((uint16_t)0x0100)
+
+/* I2C_interrupts_definition */
+#define I2C_IT_PECERR                                        ((uint32_t)0x01001000)
+#define I2C_IT_OVR                                           ((uint32_t)0x01000800)
+#define I2C_IT_AF                                            ((uint32_t)0x01000400)
+#define I2C_IT_ARLO                                          ((uint32_t)0x01000200)
+#define I2C_IT_BERR                                          ((uint32_t)0x01000100)
+#define I2C_IT_TXE                                           ((uint32_t)0x06000080)
+#define I2C_IT_RXNE                                          ((uint32_t)0x06000040)
+#define I2C_IT_STOPF                                         ((uint32_t)0x02000010)
+#define I2C_IT_ADD10                                         ((uint32_t)0x02000008)
+#define I2C_IT_BTF                                           ((uint32_t)0x02000004)
+#define I2C_IT_ADDR                                          ((uint32_t)0x02000002)
+#define I2C_IT_SB                                            ((uint32_t)0x02000001)
+
+/* SR2 register flags  */
+#define I2C_FLAG_DUALF                                       ((uint32_t)0x00800000)
+#define I2C_FLAG_GENCALL                                     ((uint32_t)0x00100000)
+#define I2C_FLAG_TRA                                         ((uint32_t)0x00040000)
+#define I2C_FLAG_BUSY                                        ((uint32_t)0x00020000)
+#define I2C_FLAG_MSL                                         ((uint32_t)0x00010000)
+
+/* SR1 register flags */
+#define I2C_FLAG_PECERR                                      ((uint32_t)0x10001000)
+#define I2C_FLAG_OVR                                         ((uint32_t)0x10000800)
+#define I2C_FLAG_AF                                          ((uint32_t)0x10000400)
+#define I2C_FLAG_ARLO                                        ((uint32_t)0x10000200)
+#define I2C_FLAG_BERR                                        ((uint32_t)0x10000100)
+#define I2C_FLAG_TXE                                         ((uint32_t)0x10000080)
+#define I2C_FLAG_RXNE                                        ((uint32_t)0x10000040)
+#define I2C_FLAG_STOPF                                       ((uint32_t)0x10000010)
+#define I2C_FLAG_ADD10                                       ((uint32_t)0x10000008)
+#define I2C_FLAG_BTF                                         ((uint32_t)0x10000004)
+#define I2C_FLAG_ADDR                                        ((uint32_t)0x10000002)
+#define I2C_FLAG_SB                                          ((uint32_t)0x10000001)
+
+/****************I2C Master Events (Events grouped in order of communication)********************/
+
+/******************************************************************************************************************** 
+  * @brief  Start communicate
+  * 
+  * After master use I2C_GenerateSTART() function sending the START condition,the master 
+  * has to wait for event 5(the Start condition has been correctly 
+  * released on the I2C bus ).
+  * 
+  */
+/* EVT5 */
+#define  I2C_EVENT_MASTER_MODE_SELECT                      ((uint32_t)0x00030001)  /* BUSY, MSL and SB flag */
+
+/********************************************************************************************************************
+  * @brief  Address Acknowledge
+  * 
+  * When start condition correctly released on the bus(check EVT5), the 
+  * master use I2C_Send7bitAddress() function sends the address of the slave(s) with which it will communicate 
+  * it also determines master as transmitter or Receiver. Then the master has to wait that a slave acknowledges 
+  * his address. If an acknowledge is sent on the bus, one of the following events will be set:
+  * 
+  *
+  * 
+  *  1) In case of Master Receiver (7-bit addressing): the I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED 
+  *     event is set.
+  *  
+  *  2) In case of Master Transmitter (7-bit addressing): the I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED 
+  *     is set
+  *  
+  *  3) In case of 10-Bit addressing mode, the master (after generating the START 
+  *  and checking on EVT5) use I2C_SendData() function send the header of 10-bit addressing mode.  
+  *  Then master wait EVT9. EVT9 means that the 10-bit addressing header has been correctly sent 
+  *  on the bus. Then master should use the function I2C_Send7bitAddress() to send the second part 
+  *  of the 10-bit address (LSB) . Then master should wait for event 6. 
+  *
+  *     
+  */
+
+/* EVT6 */
+#define  I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED        ((uint32_t)0x00070082)  /* BUSY, MSL, ADDR, TXE and TRA flags */
+#define  I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED           ((uint32_t)0x00030002)  /* BUSY, MSL and ADDR flags */
+/*EVT9 */
+#define  I2C_EVENT_MASTER_MODE_ADDRESS10                   ((uint32_t)0x00030008)  /* BUSY, MSL and ADD10 flags */
+
+/******************************************************************************************************************** 
+  * @brief Communication events
+  * 
+  * If START condition has generated and slave address 
+  * been acknowledged. then the master has to check one of the following events for 
+  * communication procedures:
+  *  
+  * 1) Master Receiver mode: The master has to wait on the event EVT7 then use  
+  *   I2C_ReceiveData() function to read the data received from the slave .
+  * 
+  * 2) Master Transmitter mode: The master use I2C_SendData() function to send data  
+  *     then to wait on event EVT8 or EVT8_2.
+  *    These two events are similar: 
+  *     - EVT8 means that the data has been written in the data register and is 
+  *       being shifted out.
+  *     - EVT8_2 means that the data has been physically shifted out and output 
+  *       on the bus.
+  *     In most cases, using EVT8 is sufficient for the application.
+  *     Using EVT8_2  will leads to a slower communication  speed but will more reliable .
+  *     EVT8_2 is also more suitable than EVT8 for testing on the last data transmission 
+  *    
+  *     
+  *  Note:
+  *  In case the  user software does not guarantee that this event EVT7 is managed before 
+  *  the current byte end of transfer, then user may check on I2C_EVENT_MASTER_BYTE_RECEIVED 
+  *  and I2C_FLAG_BTF flag at the same time .But in this case the communication may be slower.
+  *
+  * 
+  */
+
+/* Master Receive mode */ 
+/* EVT7 */
+#define  I2C_EVENT_MASTER_BYTE_RECEIVED                    ((uint32_t)0x00030040)  /* BUSY, MSL and RXNE flags */
+
+/* Master Transmitter mode*/
+/* EVT8 */
+#define I2C_EVENT_MASTER_BYTE_TRANSMITTING                 ((uint32_t)0x00070080) /* TRA, BUSY, MSL, TXE flags */
+/* EVT8_2 */
+#define  I2C_EVENT_MASTER_BYTE_TRANSMITTED                 ((uint32_t)0x00070084)  /* TRA, BUSY, MSL, TXE and BTF flags */
+
+/******************I2C Slave Events (Events grouped in order of communication)******************/
+
+/******************************************************************************************************************** 
+  * @brief  Start Communicate events
+  * 
+  * Wait on one of these events at the start of the communication. It means that 
+  * the I2C peripheral detected a start condition of master device generate on the bus.  
+  * If the acknowledge feature is enabled through function I2C_AcknowledgeConfig()),The peripheral generates an ACK condition on the bus. 
+  *    
+  *
+  *
+  * a) In normal case (only one address managed by the slave), when the address 
+  *   sent by the master matches the own address of the peripheral (configured by 
+  *   I2C_OwnAddress1 field) the I2C_EVENT_SLAVE_XXX_ADDRESS_MATCHED event is set 
+  *   (where XXX could be TRANSMITTER or RECEIVER).
+  *    
+  * b) In case the address sent by the master matches the second address of the 
+  *   peripheral (configured by the function I2C_OwnAddress2Config() and enabled 
+  *   by the function I2C_DualAddressCmd()) the events I2C_EVENT_SLAVE_XXX_SECONDADDRESS_MATCHED 
+  *   (where XXX could be TRANSMITTER or RECEIVER) are set.
+  *   
+  * c) In case the address sent by the master is General Call (address 0x00) and 
+  *   if the General Call is enabled for the peripheral (using function I2C_GeneralCallCmd()) 
+  *   the following event is set I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED.   
+  * 
+  */
+
+/* EVT1 */   
+/* a) Case of One Single Address managed by the slave */
+#define  I2C_EVENT_SLAVE_RECEIVER_ADDRESS_MATCHED          ((uint32_t)0x00020002) /* BUSY and ADDR flags */
+#define  I2C_EVENT_SLAVE_TRANSMITTER_ADDRESS_MATCHED       ((uint32_t)0x00060082) /* TRA, BUSY, TXE and ADDR flags */
+
+/* b) Case of Dual address managed by the slave */
+#define  I2C_EVENT_SLAVE_RECEIVER_SECONDADDRESS_MATCHED    ((uint32_t)0x00820000)  /* DUALF and BUSY flags */
+#define  I2C_EVENT_SLAVE_TRANSMITTER_SECONDADDRESS_MATCHED ((uint32_t)0x00860080)  /* DUALF, TRA, BUSY and TXE flags */
+
+/* c) Case of General Call enabled for the slave */
+#define  I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED        ((uint32_t)0x00120000)  /* GENCALL and BUSY flags */
+
+/******************************************************************************************************************** 
+  * @brief  Communication events
+  * 
+  * Wait on one of these events when EVT1 has already been checked : 
+  * 
+  * - Slave Receiver mode:
+  *     - EVT2--The device is expecting to receive a data byte . 
+  *     - EVT4--The device is expecting the end of the communication: master 
+  *       sends a stop condition and data transmission is stopped.
+  *    
+  * - Slave Transmitter mode:
+  *    - EVT3--When a byte has been transmitted by the slave and the Master is expecting 
+  *      the end of the byte transmission. The two events I2C_EVENT_SLAVE_BYTE_TRANSMITTED and
+  *      I2C_EVENT_SLAVE_BYTE_TRANSMITTING are similar. If the user software doesn't guarantee 
+  *      the EVT3 is managed before the current byte end of transfer The second one can optionally
+  *      be used. 
+  *    - EVT3_2--When the master sends a NACK  to tell slave device that data transmission 
+  *      shall end . The slave device has to stop sending 
+  *      data bytes and wait a Stop condition from bus.
+  *      
+  *  Note:
+  *  If the  user software does not guarantee that the event 2 is 
+  *  managed before the current byte end of transfer, User may check on I2C_EVENT_SLAVE_BYTE_RECEIVED 
+  *  and I2C_FLAG_BTF flag at the same time .
+  *  In this case the communication will be slower.
+  *
+  */
+
+/* Slave Receiver mode*/ 
+/* EVT2 */
+#define  I2C_EVENT_SLAVE_BYTE_RECEIVED                     ((uint32_t)0x00020040)  /* BUSY and RXNE flags */
+/* EVT4  */
+#define  I2C_EVENT_SLAVE_STOP_DETECTED                     ((uint32_t)0x00000010)  /* STOPF flag */
+
+/* Slave Transmitter mode*/
+/* EVT3 */
+#define  I2C_EVENT_SLAVE_BYTE_TRANSMITTED                  ((uint32_t)0x00060084)  /* TRA, BUSY, TXE and BTF flags */
+#define  I2C_EVENT_SLAVE_BYTE_TRANSMITTING                 ((uint32_t)0x00060080)  /* TRA, BUSY and TXE flags */
+/*EVT3_2 */
+#define  I2C_EVENT_SLAVE_ACK_FAILURE                       ((uint32_t)0x00000400)  /* AF flag */
+
+
+void     I2C_DeInit(I2C_TypeDef *I2Cx);
+void     I2C_Init(I2C_TypeDef *I2Cx, I2C_InitTypeDef *I2C_InitStruct);
+void     I2C_StructInit(I2C_InitTypeDef *I2C_InitStruct);
+void     I2C_Cmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_DMACmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_DMALastTransferCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_GenerateSTART(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_GenerateSTOP(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_AcknowledgeConfig(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_OwnAddress2Config(I2C_TypeDef *I2Cx, uint8_t Address);
+void     I2C_DualAddressCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_GeneralCallCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_ITConfig(I2C_TypeDef *I2Cx, uint16_t I2C_IT, FunctionalState NewState);
+void     I2C_SendData(I2C_TypeDef *I2Cx, uint8_t Data);
+uint8_t  I2C_ReceiveData(I2C_TypeDef *I2Cx);
+void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction);
+uint16_t I2C_ReadRegister(I2C_TypeDef *I2Cx, uint8_t I2C_Register);
+void     I2C_SoftwareResetCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_NACKPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_NACKPosition);
+void     I2C_TransmitPEC(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_PECPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_PECPosition);
+void     I2C_CalculatePEC(I2C_TypeDef *I2Cx, FunctionalState NewState);
+uint8_t  I2C_GetPEC(I2C_TypeDef *I2Cx);
+void     I2C_ARPCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_StretchClockCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_FastModeDutyCycleConfig(I2C_TypeDef *I2Cx, uint16_t I2C_DutyCycle);
+
+
+/*****************************************************************************************
+ *
+ *                         I2C State Monitoring Functions
+ *                       
+ ****************************************************************************************   
+ * This I2C driver provides three different ways for I2C state monitoring
+ *  profit the application requirements and constraints:
+ *        
+ *  
+ * a) First way:
+ *    Using I2C_CheckEvent() function:
+ *    It compares the status registers (STARR1 and STAR2) content to a given event
+ *    (can be the combination of more flags).
+ *    If the current status registers includes the given flags  will return SUCCESS.
+ *    and  if the current status registers miss flags will returns ERROR.
+ *    - When to use:
+ *      - This function is suitable for most applications as well as for startup 
+ *      activity since the events are fully described in the product reference manual 
+ *      (CH64xRM).
+ *      - It is also suitable for users who need to define their own events.
+ *    - Limitations:
+ *      - If an error occurs besides to the monitored error,
+ *        the I2C_CheckEvent() function may return SUCCESS despite the communication
+ *       in corrupted state.  it is suggeted to use error interrupts to monitor the error
+ *        events and handle them in IRQ handler.
+ *
+ *        
+ *        Note: 
+ *        The following functions are recommended for error management: :
+ *          - I2C_ITConfig() main function of configure and enable the error interrupts.
+ *          - I2Cx_ER_IRQHandler() will be called when the error interrupt happen.
+ *            Where x is the peripheral instance (I2C1, I2C2 ...)
+ *          -  I2Cx_ER_IRQHandler() will call I2C_GetFlagStatus() or I2C_GetITStatus() functions
+ *            to determine which error occurred.
+ *          - I2C_ClearFlag() \ I2C_ClearITPendingBit() \ I2C_SoftwareResetCmd()
+ *            \ I2C_GenerateStop() will be use to clear the error flag and source,
+ *            and return to correct communication status.
+ *            
+ *
+ *  b) Second way:
+ *     Using the function to get a single word(uint32_t) composed of status register 1 and register 2. 
+ *     (Status Register 2 value is shifted left by 16 bits and concatenated to Status Register 1).
+ *     - When to use:
+ *
+ *       - This function is suitable for the same applications above but it 
+ *         don't have the limitations of I2C_GetFlagStatus() function .
+ *         The returned value could be compared to events already defined in the 
+ *         library (ch64x_i2c.h) or to custom values defined by user.
+ *       - This function can be used to monitor the status of multiple flags simultaneously.
+ *       - Contrary to the I2C_CheckEvent () function, this function can choose the time to
+ *         accept the event according to the user's needs (when all event flags are set and  
+ *         no other flags are set, or only when the required flags are set) 
+ *     
+ *     - Limitations:
+ *       - User may need to define his own events.
+ *       - Same remark concerning the error management is applicable for this 
+ *         function if user decides to check only regular communication flags (and 
+ *         ignores error flags).
+ *     
+ *
+ *  c) Third way:
+ *     Using the function I2C_GetFlagStatus() get the status of 
+ *     one single flag . 
+ *     - When to use:
+ *        - This function could be used for specific applications or in debug phase.
+ *        - It is suitable when only one flag checking is needed . 
+ *          
+ *     - Limitations: 
+ *        - Call this function to access the status register. Some flag bits may be cleared.           
+ *       - Function may need to be called twice or more in order to monitor one single event. 
+ */
+            
+ 
+
+/*********************************************************
+ * 
+ *  a) Basic state monitoring(First way)
+ ********************************************************
+ */
+ErrorStatus I2C_CheckEvent(I2C_TypeDef* I2Cx, uint32_t I2C_EVENT);
+/*********************************************************
+ * 
+ *  b) Advanced state monitoring(Second way:)
+ ********************************************************
+ */
+uint32_t I2C_GetLastEvent(I2C_TypeDef* I2Cx);
+/*********************************************************
+ * 
+ *  c) Flag-based state monitoring(Third way)
+ *********************************************************
+ */
+FlagStatus I2C_GetFlagStatus(I2C_TypeDef* I2Cx, uint32_t I2C_FLAG);
+
+void     I2C_ClearFlag(I2C_TypeDef *I2Cx, uint32_t I2C_FLAG);
+ITStatus I2C_GetITStatus(I2C_TypeDef *I2Cx, uint32_t I2C_IT);
+void     I2C_ClearITPendingBit(I2C_TypeDef *I2Cx, uint32_t I2C_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_iwdg.h
+++ b/Peripheral/ch32x035/inc/ch32x035_iwdg.h
@@ -1,0 +1,50 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_iwdg.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      IWDG firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_IWDG_H
+#define __CH32X035_IWDG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* IWDG_WriteAccess */
+#define IWDG_WriteAccess_Enable     ((uint16_t)0x5555)
+#define IWDG_WriteAccess_Disable    ((uint16_t)0x0000)
+
+/* IWDG_prescaler */
+#define IWDG_Prescaler_4            ((uint8_t)0x00)
+#define IWDG_Prescaler_8            ((uint8_t)0x01)
+#define IWDG_Prescaler_16           ((uint8_t)0x02)
+#define IWDG_Prescaler_32           ((uint8_t)0x03)
+#define IWDG_Prescaler_64           ((uint8_t)0x04)
+#define IWDG_Prescaler_128          ((uint8_t)0x05)
+#define IWDG_Prescaler_256          ((uint8_t)0x06)
+
+/* IWDG_Flag */
+#define IWDG_FLAG_PVU               ((uint16_t)0x0001)
+#define IWDG_FLAG_RVU               ((uint16_t)0x0002)
+
+void       IWDG_WriteAccessCmd(uint16_t IWDG_WriteAccess);
+void       IWDG_SetPrescaler(uint8_t IWDG_Prescaler);
+void       IWDG_SetReload(uint16_t Reload);
+void       IWDG_ReloadCounter(void);
+void       IWDG_Enable(void);
+FlagStatus IWDG_GetFlagStatus(uint16_t IWDG_FLAG);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_misc.h
+++ b/Peripheral/ch32x035/inc/ch32x035_misc.h
@@ -1,0 +1,45 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_misc.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      miscellaneous firmware library functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_MISC_H
+#define __CH32X035_MISC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* NVIC Init Structure definition */
+typedef struct
+{
+    uint8_t         NVIC_IRQChannel;
+    uint8_t         NVIC_IRQChannelPreemptionPriority;
+    uint8_t         NVIC_IRQChannelSubPriority;
+    FunctionalState NVIC_IRQChannelCmd;
+} NVIC_InitTypeDef;
+
+/* Preemption_Priority_Group */
+#define NVIC_PriorityGroup_0    ((uint32_t)0x00)
+#define NVIC_PriorityGroup_1    ((uint32_t)0x01)
+#define NVIC_PriorityGroup_2    ((uint32_t)0x02)
+#define NVIC_PriorityGroup_3    ((uint32_t)0x03)
+#define NVIC_PriorityGroup_4    ((uint32_t)0x04)
+
+void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup);
+void NVIC_Init(NVIC_InitTypeDef *NVIC_InitStruct);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_opa.h
+++ b/Peripheral/ch32x035/inc/ch32x035_opa.h
@@ -1,0 +1,221 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_opa.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      OPA firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_OPA_H
+#define __CH32X035_OPA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* OPA_member_enumeration */
+typedef enum
+{
+    OPA1 = 0,
+    OPA2
+} OPA_Num_TypeDef;
+
+/* OPA_out_channel_enumeration */
+typedef enum
+{
+    OUT_IO_OUT0 = 0,
+    OUT_IO_OUT1
+} OPA_Mode_TypeDef;
+
+/* OPA_PSEL_enumeration */
+typedef enum
+{
+    CHP0 = 0,
+    CHP1,
+    CHP2,
+    CHP_OFF
+} OPA_PSEL_TypeDef;
+
+/* OPA_FB_enumeration */
+typedef enum
+{
+    FB_OFF = 0,
+    FB_ON
+} OPA_FB_TypeDef;
+
+/* OPA_NSEL_enumeration */
+typedef enum
+{
+    CHN0 = 0,
+    CHN1,
+    CHN2_PGA_16xIN,
+    CHN_PGA_4xIN,
+    CHN_PGA_8xIN,
+    CHN_PGA_16xIN,
+    CHN_PGA_32xIN,
+    CHN_OFF
+} OPA_NSEL_TypeDef;
+
+/* OPA_PSEL_POLL_enumeration */
+typedef enum
+{
+    CHP_OPA1_OFF_OPA2_OFF = 0,
+    CHP_OPA1_ON_OPA2_OFF,
+    CHP_OPA1_OFF_OPA2_ON,
+    CHP_OPA1_ON_OPA2_ON
+} OPA_PSEL_POLL_TypeDef;
+
+/* OPA_BKIN_EN_enumeration */
+typedef enum
+{
+    BKIN_OPA1_OFF_OPA2_OFF = 0,
+    BKIN_OPA1_ON_OPA2_OFF,
+    BKIN_OPA1_OFF_OPA2_ON,
+    BKIN_OPA1_ON_OPA2_ON
+} OPA_BKIN_EN_TypeDef;
+
+/* OPA_RST_EN_enumeration */
+typedef enum
+{
+    RST_OPA1_OFF_OPA2_OFF = 0,
+    RST_OPA1_ON_OPA2_OFF,
+    RST_OPA1_OFF_OPA2_ON,
+    RST_OPA1_ON_OPA2_ON
+} OPA_RST_EN_TypeDef;
+
+/* OPA_BKIN_SEL_enumeration */
+typedef enum
+{
+    BKIN_OPA1_TIM1_OPA2_TIM2 = 0,
+    BKIN_OPA1_TIM2_OPA2_TIM1
+} OPA_BKIN_SEL_TypeDef;
+
+/* OPA_OUT_IE_enumeration */
+typedef enum
+{
+    OUT_IE_OPA1_OFF_OPA2_OFF = 0,
+    OUT_IE_OPA1_ON_OPA2_OFF,
+    OUT_IE_OPA1_OFF_OPA2_ON,
+    OUT_IE_OPA1_ON_OPA2_ON
+} OPA_OUT_IE_TypeDef;
+
+/* OPA_CNT_IE_enumeration */
+typedef enum
+{
+    CNT_IE_OFF = 0,
+    CNT_IE_ON,
+} OPA_CNT_IE_TypeDef;
+
+/* OPA_NMI_IE_enumeration */
+typedef enum
+{
+    NMI_IE_OFF = 0,
+    NMI_IE_ON,
+} OPA_NMI_IE_TypeDef;
+
+/* OPA_PSEL_POLL_NUM_enumeration */
+typedef enum
+{
+    CHP_POLL_NUM_1 = 0,
+    CHP_POLL_NUM_2,
+    CHP_POLL_NUM_3
+} OPA_PSEL_POLL_NUM_TypeDef;
+
+
+/* OPA Init Structure definition */
+typedef struct
+{
+    uint16_t                  OPA_POLL_Interval; /* OPA polling interval = (OPA_POLL_Interval+1)*1us
+                                                      This parameter must range from 0 to 0x1FF.*/
+    OPA_Num_TypeDef           OPA_NUM;  /* Specifies the members of OPA */
+    OPA_Mode_TypeDef          Mode;     /* Specifies the mode of OPA */
+    OPA_PSEL_TypeDef          PSEL;     /* Specifies the positive channel of OPA */
+    OPA_FB_TypeDef            FB;       /* Specifies the internal feedback resistor of OPA */
+    OPA_NSEL_TypeDef          NSEL;     /* Specifies the negative channel of OPA */
+    OPA_PSEL_POLL_TypeDef     PSEL_POLL; /* Specifies the positive channel poll of OPA */
+    OPA_BKIN_EN_TypeDef       BKIN_EN;  /* Specifies the brake input source of OPA */
+    OPA_RST_EN_TypeDef        RST_EN;   /* Specifies the reset source of OPA */
+    OPA_BKIN_SEL_TypeDef      BKIN_SEL; /* Specifies the brake input source selection of OPA */
+    OPA_OUT_IE_TypeDef        OUT_IE;   /* Specifies the out interrupt of OPA */
+    OPA_CNT_IE_TypeDef        CNT_IE;   /* Specifies the out interrupt rising edge of sampling data */
+    OPA_NMI_IE_TypeDef        NMI_IE;   /* Specifies the out NIM interrupt of OPA */
+    OPA_PSEL_POLL_NUM_TypeDef POLL_NUM; /* Specifies the number of forward inputs*/
+} OPA_InitTypeDef;
+
+/* CMP_member_enumeration */
+typedef enum
+{
+    CMP1 = 0,
+    CMP2,
+    CMP3
+} CMP_Num_TypeDef;
+
+/* CMP_out_channel_enumeration */
+typedef enum
+{
+    OUT_IO_TIM2_CH1 = 0,
+    OUT_IO_PA1
+} CMP_Mode_TypeDef;
+
+/* CMP_NSEL_enumeration */
+typedef enum
+{
+    CMP_CHN0 = 0,
+    CMP_CHN1,
+} CMP_NSEL_TypeDef;
+
+/* CMP_PSEL_enumeration */
+typedef enum
+{
+    CMP_CHP1 = 0,
+    CMP_CHP2,
+} CMP_PSEL_TypeDef;
+
+/* CMP_HYEN_enumeration */
+typedef enum
+{
+    CMP_HYEN1 = 0,
+    CMP_HYEN2,
+} CMP_HYEN_TypeDef;
+
+/* CMP Init Structure definition */
+typedef struct
+{
+    CMP_Num_TypeDef    CMP_NUM;  /* Specifies the members of CMP */
+    CMP_Mode_TypeDef   Mode;     /* Specifies the mode of CMP */
+    CMP_NSEL_TypeDef   NSEL;     /* Specifies the negative channel of CMP */
+    CMP_PSEL_TypeDef   PSEL;     /* Specifies the positive channel of CMP */
+    CMP_HYEN_TypeDef   HYEN;     /* Specifies the hysteresis comparator of CMP */
+} CMP_InitTypeDef;
+
+/* OPA_flags_definition */
+#define OPA_FLAG_OUT_OPA1                  ((uint16_t)0x1000)
+#define OPA_FLAG_OUT_OPA2                  ((uint16_t)0x2000)
+#define OPA_FLAG_OUT_CNT                   ((uint16_t)0x4000)
+
+void       OPA_Unlock(void);
+void       OPA_Lock(void);
+void       OPA_POLL_Unlock(void);
+void       OPA_POLL_Lock(void);
+void       OPA_CMP_Unlock(void);
+void       OPA_CMP_Lock(void);
+void       OPA_Init(OPA_InitTypeDef *OPA_InitStruct);
+void       OPA_StructInit(OPA_InitTypeDef *OPA_InitStruct);
+void       OPA_Cmd(OPA_Num_TypeDef OPA_NUM, FunctionalState NewState);
+void       OPA_CMP_Init(CMP_InitTypeDef *CMP_InitStruct);
+void       OPA_CMP_StructInit(CMP_InitTypeDef *CMP_InitStruct);
+void       OPA_CMP_Cmd(CMP_Num_TypeDef CMP_NUM, FunctionalState NewState);
+FlagStatus OPA_GetFlagStatus( uint16_t OPA_FLAG);
+void       OPA_ClearFlag(uint16_t OPA_FLAG);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_pwr.h
+++ b/Peripheral/ch32x035/inc/ch32x035_pwr.h
@@ -1,0 +1,46 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_pwr.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the PWR
+ *                      firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_PWR_H
+#define __CH32X035_PWR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* PVD_detection_level  */
+#define PWR_PVDLevel_2V1          ((uint32_t)0x00000000)
+#define PWR_PVDLevel_2V3          ((uint32_t)0x00000020)
+#define PWR_PVDLevel_3V0          ((uint32_t)0x00000040)
+#define PWR_PVDLevel_4V0          ((uint32_t)0x00000060)
+
+/* STOP_mode_entry */
+#define PWR_STOPEntry_WFI         ((uint8_t)0x01)
+#define PWR_STOPEntry_WFE         ((uint8_t)0x02)
+
+/* PWR_Flag */
+#define PWR_FLAG_PVDO             ((uint32_t)0x00000004)
+#define PWR_FLAG_FLASH            ((uint32_t)0x00000020)
+
+void       PWR_DeInit(void);
+void       PWR_PVDLevelConfig(uint32_t PWR_PVDLevel);
+void       PWR_EnterSTOPMode(uint8_t PWR_STOPEntry);
+void       PWR_EnterSTANDBYMode(void);
+FlagStatus PWR_GetFlagStatus(uint32_t PWR_FLAG);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_rcc.h
+++ b/Peripheral/ch32x035/inc/ch32x035_rcc.h
@@ -1,0 +1,111 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_rcc.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the RCC firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_RCC_H
+#define __CH32X035_RCC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* RCC_Exported_Types */
+typedef struct
+{
+    uint32_t SYSCLK_Frequency; /* returns SYSCLK clock frequency expressed in Hz */
+    uint32_t HCLK_Frequency;   /* returns HCLK clock frequency expressed in Hz */
+    uint32_t PCLK1_Frequency;  /* returns PCLK1 clock frequency expressed in Hz */
+    uint32_t PCLK2_Frequency;  /* returns PCLK2 clock frequency expressed in Hz */
+} RCC_ClocksTypeDef;
+
+/* AHB_clock_source */
+#define RCC_SYSCLK_Div1                  ((uint32_t)0x00000000)
+#define RCC_SYSCLK_Div2                  ((uint32_t)0x00000010)
+#define RCC_SYSCLK_Div3                  ((uint32_t)0x00000020)
+#define RCC_SYSCLK_Div4                  ((uint32_t)0x00000030)
+#define RCC_SYSCLK_Div5                  ((uint32_t)0x00000040)
+#define RCC_SYSCLK_Div6                  ((uint32_t)0x00000050)
+#define RCC_SYSCLK_Div7                  ((uint32_t)0x00000060)
+#define RCC_SYSCLK_Div8                  ((uint32_t)0x00000070)
+#define RCC_SYSCLK_Div16                 ((uint32_t)0x000000B0)
+#define RCC_SYSCLK_Div32                 ((uint32_t)0x000000C0)
+#define RCC_SYSCLK_Div64                 ((uint32_t)0x000000D0)
+#define RCC_SYSCLK_Div128                ((uint32_t)0x000000E0)
+#define RCC_SYSCLK_Div256                ((uint32_t)0x000000F0)
+
+/* AHB_peripheral */
+#define RCC_AHBPeriph_DMA1             ((uint32_t)0x00000001)
+#define RCC_AHBPeriph_SRAM             ((uint32_t)0x00000004)
+#define RCC_AHBPeriph_USBFS            ((uint32_t)0x00001000)
+#define RCC_AHBPeriph_IO2W             ((uint32_t)0x00002000)
+#define RCC_AHBPeriph_USBPD            ((uint32_t)0x00020000)
+
+/* APB2_peripheral */
+#define RCC_APB2Periph_AFIO            ((uint32_t)0x00000001)
+#define RCC_APB2Periph_GPIOA           ((uint32_t)0x00000004)
+#define RCC_APB2Periph_GPIOB           ((uint32_t)0x00000008)
+#define RCC_APB2Periph_GPIOC           ((uint32_t)0x00000010)
+#define RCC_APB2Periph_ADC1            ((uint32_t)0x00000200)
+#define RCC_APB2Periph_TIM1            ((uint32_t)0x00000800)
+#define RCC_APB2Periph_SPI1            ((uint32_t)0x00001000)
+#define RCC_APB2Periph_USART1          ((uint32_t)0x00004000)
+
+/* APB1_peripheral */
+#define RCC_APB1Periph_TIM2            ((uint32_t)0x00000001)
+#define RCC_APB1Periph_TIM3            ((uint32_t)0x00000002)
+#define RCC_APB1Periph_WWDG            ((uint32_t)0x00000800)
+#define RCC_APB1Periph_USART2          ((uint32_t)0x00020000)
+#define RCC_APB1Periph_USART3          ((uint32_t)0x00040000)
+#define RCC_APB1Periph_USART4          ((uint32_t)0x00080000)
+#define RCC_APB1Periph_I2C1            ((uint32_t)0x00200000)
+#define RCC_APB1Periph_PWR             ((uint32_t)0x10000000)
+
+/* Clock_source_to_output_on_MCO_pin */
+#define RCC_MCO_NoClock                ((uint8_t)0x00)
+#define RCC_MCO_SYSCLK                 ((uint8_t)0x04)
+#define RCC_MCO_HSI                    ((uint8_t)0x05)
+
+/* RCC_Flag */
+#define RCC_FLAG_HSIRDY                ((uint8_t)0x21)
+#define RCC_FLAG_OPARST                ((uint8_t)0x79)
+#define RCC_FLAG_PINRST                ((uint8_t)0x7A)
+#define RCC_FLAG_PORRST                ((uint8_t)0x7B)
+#define RCC_FLAG_SFTRST                ((uint8_t)0x7C)
+#define RCC_FLAG_IWDGRST               ((uint8_t)0x7D)
+#define RCC_FLAG_WWDGRST               ((uint8_t)0x7E)
+#define RCC_FLAG_LPWRRST               ((uint8_t)0x7F)
+
+/* SysTick_clock_source */
+#define SysTick_CLKSource_HCLK_Div8    ((uint32_t)0xFFFFFFFB)
+#define SysTick_CLKSource_HCLK         ((uint32_t)0x00000004)
+
+
+void        RCC_DeInit(void);
+void        RCC_AdjustHSICalibrationValue(uint8_t HSICalibrationValue);
+void        RCC_HSICmd(FunctionalState NewState);
+void        RCC_HCLKConfig(uint32_t RCC_SYSCLK);
+void        RCC_GetClocksFreq(RCC_ClocksTypeDef *RCC_Clocks);
+void        RCC_AHBPeriphClockCmd(uint32_t RCC_AHBPeriph, FunctionalState NewState);
+void        RCC_APB2PeriphClockCmd(uint32_t RCC_APB2Periph, FunctionalState NewState);
+void        RCC_APB1PeriphClockCmd(uint32_t RCC_APB1Periph, FunctionalState NewState);
+void        RCC_AHBPeriphResetCmd(uint32_t RCC_AHBPeriph, FunctionalState NewState);
+void        RCC_APB2PeriphResetCmd(uint32_t RCC_APB2Periph, FunctionalState NewState);
+void        RCC_APB1PeriphResetCmd(uint32_t RCC_APB1Periph, FunctionalState NewState);
+void        RCC_MCOConfig(uint8_t RCC_MCO);
+FlagStatus  RCC_GetFlagStatus(uint8_t RCC_FLAG);
+void        RCC_ClearFlag(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_spi.h
+++ b/Peripheral/ch32x035/inc/ch32x035_spi.h
@@ -1,0 +1,153 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_spi.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      SPI firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_SPI_H
+#define __CH32X035_SPI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* SPI Init structure definition */
+typedef struct
+{
+    uint16_t SPI_Direction; /* Specifies the SPI unidirectional or bidirectional data mode.
+                               This parameter can be a value of @ref SPI_data_direction */
+
+    uint16_t SPI_Mode; /* Specifies the SPI operating mode.
+                          This parameter can be a value of @ref SPI_mode */
+
+    uint16_t SPI_DataSize; /* Specifies the SPI data size.
+                              This parameter can be a value of @ref SPI_data_size */
+
+    uint16_t SPI_CPOL; /* Specifies the serial clock steady state.
+                          This parameter can be a value of @ref SPI_Clock_Polarity */
+
+    uint16_t SPI_CPHA; /* Specifies the clock active edge for the bit capture.
+                          This parameter can be a value of @ref SPI_Clock_Phase */
+
+    uint16_t SPI_NSS; /* Specifies whether the NSS signal is managed by
+                         hardware (NSS pin) or by software using the SSI bit.
+                         This parameter can be a value of @ref SPI_Slave_Select_management */
+
+    uint16_t SPI_BaudRatePrescaler; /* Specifies the Baud Rate prescaler value which will be
+                                       used to configure the transmit and receive SCK clock.
+                                       This parameter can be a value of @ref SPI_BaudRate_Prescaler.
+                                       @note The communication clock is derived from the master
+                                             clock. The slave clock does not need to be set. */
+
+    uint16_t SPI_FirstBit; /* Specifies whether data transfers start from MSB or LSB bit.
+                              This parameter can be a value of @ref SPI_MSB_transmission */
+
+    uint16_t SPI_CRCPolynomial; /* Specifies the polynomial used for the CRC calculation. */
+} SPI_InitTypeDef;
+
+/* SPI_data_direction */
+#define SPI_Direction_2Lines_FullDuplex    ((uint16_t)0x0000)
+#define SPI_Direction_2Lines_RxOnly        ((uint16_t)0x0400)
+#define SPI_Direction_1Line_Rx             ((uint16_t)0x8000)
+#define SPI_Direction_1Line_Tx             ((uint16_t)0xC000)
+
+/* SPI_mode */
+#define SPI_Mode_Master                    ((uint16_t)0x0104)
+#define SPI_Mode_Slave                     ((uint16_t)0x0000)
+
+/* SPI_data_size */
+#define SPI_DataSize_16b                   ((uint16_t)0x0800)
+#define SPI_DataSize_8b                    ((uint16_t)0x0000)
+
+/* SPI_Clock_Polarity */
+#define SPI_CPOL_Low                       ((uint16_t)0x0000)
+#define SPI_CPOL_High                      ((uint16_t)0x0002)
+
+/* SPI_Clock_Phase */
+#define SPI_CPHA_1Edge                     ((uint16_t)0x0000)
+#define SPI_CPHA_2Edge                     ((uint16_t)0x0001)
+
+/* SPI_Slave_Select_management */
+#define SPI_NSS_Soft                       ((uint16_t)0x0200)
+#define SPI_NSS_Hard                       ((uint16_t)0x0000)
+
+/* SPI_BaudRate_Prescaler */
+#define SPI_BaudRatePrescaler_2            ((uint16_t)0x0000)
+#define SPI_BaudRatePrescaler_4            ((uint16_t)0x0008)
+#define SPI_BaudRatePrescaler_8            ((uint16_t)0x0010)
+#define SPI_BaudRatePrescaler_16           ((uint16_t)0x0018)
+#define SPI_BaudRatePrescaler_32           ((uint16_t)0x0020)
+#define SPI_BaudRatePrescaler_64           ((uint16_t)0x0028)
+#define SPI_BaudRatePrescaler_128          ((uint16_t)0x0030)
+#define SPI_BaudRatePrescaler_256          ((uint16_t)0x0038)
+
+/* SPI_MSB_LSB_transmission */
+#define SPI_FirstBit_MSB                   ((uint16_t)0x0000)
+#define SPI_FirstBit_LSB                   ((uint16_t)0x0080)//not support SPI slave mode
+
+/* SPI_I2S_DMA_transfer_requests */
+#define SPI_I2S_DMAReq_Tx                  ((uint16_t)0x0002)
+#define SPI_I2S_DMAReq_Rx                  ((uint16_t)0x0001)
+
+/* SPI_NSS_internal_software_management */
+#define SPI_NSSInternalSoft_Set            ((uint16_t)0x0100)
+#define SPI_NSSInternalSoft_Reset          ((uint16_t)0xFEFF)
+
+/* SPI_CRC_Transmit_Receive */
+#define SPI_CRC_Tx                         ((uint8_t)0x00)
+#define SPI_CRC_Rx                         ((uint8_t)0x01)
+
+/* SPI_direction_transmit_receive */
+#define SPI_Direction_Rx                   ((uint16_t)0xBFFF)
+#define SPI_Direction_Tx                   ((uint16_t)0x4000)
+
+/* SPI_I2S_interrupts_definition */
+#define SPI_I2S_IT_TXE                     ((uint8_t)0x71)
+#define SPI_I2S_IT_RXNE                    ((uint8_t)0x60)
+#define SPI_I2S_IT_ERR                     ((uint8_t)0x50)
+#define SPI_I2S_IT_OVR                     ((uint8_t)0x56)
+#define SPI_IT_MODF                        ((uint8_t)0x55)
+#define SPI_IT_CRCERR                      ((uint8_t)0x54)
+
+/* SPI_I2S_flags_definition */
+#define SPI_I2S_FLAG_RXNE                  ((uint16_t)0x0001)
+#define SPI_I2S_FLAG_TXE                   ((uint16_t)0x0002)
+#define SPI_FLAG_CRCERR                    ((uint16_t)0x0010)
+#define SPI_FLAG_MODF                      ((uint16_t)0x0020)
+#define SPI_I2S_FLAG_OVR                   ((uint16_t)0x0040)
+#define SPI_I2S_FLAG_BSY                   ((uint16_t)0x0080)
+
+void       SPI_I2S_DeInit(SPI_TypeDef *SPIx);
+void       SPI_Init(SPI_TypeDef *SPIx, SPI_InitTypeDef *SPI_InitStruct);
+void       SPI_StructInit(SPI_InitTypeDef *SPI_InitStruct);
+void       SPI_Cmd(SPI_TypeDef *SPIx, FunctionalState NewState);
+void       SPI_I2S_ITConfig(SPI_TypeDef *SPIx, uint8_t SPI_I2S_IT, FunctionalState NewState);
+void       SPI_I2S_DMACmd(SPI_TypeDef *SPIx, uint16_t SPI_I2S_DMAReq, FunctionalState NewState);
+void       SPI_I2S_SendData(SPI_TypeDef *SPIx, uint16_t Data);
+uint16_t   SPI_I2S_ReceiveData(SPI_TypeDef *SPIx);
+void       SPI_NSSInternalSoftwareConfig(SPI_TypeDef *SPIx, uint16_t SPI_NSSInternalSoft);
+void       SPI_SSOutputCmd(SPI_TypeDef *SPIx, FunctionalState NewState);
+void       SPI_DataSizeConfig(SPI_TypeDef *SPIx, uint16_t SPI_DataSize);
+void       SPI_TransmitCRC(SPI_TypeDef *SPIx);
+void       SPI_CalculateCRC(SPI_TypeDef *SPIx, FunctionalState NewState);
+uint16_t   SPI_GetCRC(SPI_TypeDef *SPIx, uint8_t SPI_CRC);
+uint16_t   SPI_GetCRCPolynomial(SPI_TypeDef *SPIx);
+void       SPI_BiDirectionalLineConfig(SPI_TypeDef *SPIx, uint16_t SPI_Direction);
+FlagStatus SPI_I2S_GetFlagStatus(SPI_TypeDef *SPIx, uint16_t SPI_I2S_FLAG);
+void       SPI_I2S_ClearFlag(SPI_TypeDef *SPIx, uint16_t SPI_I2S_FLAG);
+ITStatus   SPI_I2S_GetITStatus(SPI_TypeDef *SPIx, uint8_t SPI_I2S_IT);
+void       SPI_I2S_ClearITPendingBit(SPI_TypeDef *SPIx, uint8_t SPI_I2S_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_tim.h
+++ b/Peripheral/ch32x035/inc/ch32x035_tim.h
@@ -1,0 +1,530 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_tim.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      TIM firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_TIM_H
+#define __CH32X035_TIM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* TIM Time Base Init structure definition */
+typedef struct
+{
+    uint16_t TIM_Prescaler; /* Specifies the prescaler value used to divide the TIM clock.
+                               This parameter can be a number between 0x0000 and 0xFFFF */
+
+    uint16_t TIM_CounterMode; /* Specifies the counter mode.
+                                 This parameter can be a value of @ref TIM_Counter_Mode (TIM1 and TIM2) */
+
+    uint16_t TIM_Period; /* Specifies the period value to be loaded into the active
+                            Auto-Reload Register at the next update event.
+                            This parameter must be a number between 0x0000 and 0xFFFF.  */
+
+    uint16_t TIM_ClockDivision; /* Specifies the clock division.
+                                  This parameter can be a value of @ref TIM_Clock_Division_CKD */
+
+    uint8_t TIM_RepetitionCounter; /* Specifies the repetition counter value. Each time the RCR downcounter
+                                      reaches zero, an update event is generated and counting restarts
+                                      from the RCR value (N).
+                                      This means in PWM mode that (N+1) corresponds to:
+                                         - the number of PWM periods in edge-aligned mode
+                                         - the number of half PWM period in center-aligned mode
+                                      This parameter must be a number between 0x00 and 0xFF.
+                                      @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_TimeBaseInitTypeDef;
+
+/* TIM Output Compare Init structure definition */
+typedef struct
+{
+    uint16_t TIM_OCMode; /* Specifies the TIM mode.
+                            This parameter can be a value of @ref TIM_Output_Compare_and_PWM_modes */
+
+    uint16_t TIM_OutputState; /* Specifies the TIM Output Compare state.
+                                 This parameter can be a value of @ref TIM_Output_Compare_state */
+
+    uint16_t TIM_OutputNState; /* Specifies the TIM complementary Output Compare state.
+                                  This parameter can be a value of @ref TIM_Output_Compare_N_state
+                                  @note This parameter is valid only for TIM1 and TIM8. */
+
+    uint16_t TIM_Pulse; /* Specifies the pulse value to be loaded into the Capture Compare Register.
+                           This parameter can be a number between 0x0000 and 0xFFFF */
+
+    uint16_t TIM_OCPolarity; /* Specifies the output polarity.
+                                This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+    uint16_t TIM_OCNPolarity; /* Specifies the complementary output polarity.
+                                 This parameter can be a value of @ref TIM_Output_Compare_N_Polarity
+                                 @note This parameter is valid only for TIM1 and TIM8. */
+
+    uint16_t TIM_OCIdleState; /* Specifies the TIM Output Compare pin state during Idle state.
+                                 This parameter can be a value of @ref TIM_Output_Compare_Idle_State
+                                 @note This parameter is valid only for TIM1 and TIM8. */
+
+    uint16_t TIM_OCNIdleState; /* Specifies the TIM Output Compare pin state during Idle state.
+                                  This parameter can be a value of @ref TIM_Output_Compare_N_Idle_State
+                                  @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_OCInitTypeDef;
+
+/* TIM Input Capture Init structure definition */
+typedef struct
+{
+    uint16_t TIM_Channel; /* Specifies the TIM channel.
+                             This parameter can be a value of @ref TIM_Channel */
+
+    uint16_t TIM_ICPolarity; /* Specifies the active edge of the input signal.
+                                This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+    uint16_t TIM_ICSelection; /* Specifies the input.
+                                 This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+    uint16_t TIM_ICPrescaler; /* Specifies the Input Capture Prescaler.
+                                 This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+    uint16_t TIM_ICFilter; /* Specifies the input capture filter.
+                              This parameter can be a number between 0x0 and 0xF */
+} TIM_ICInitTypeDef;
+
+/* BDTR structure definition */
+typedef struct
+{
+    uint16_t TIM_OSSRState; /* Specifies the Off-State selection used in Run mode.
+                               This parameter can be a value of @ref OSSR_Off_State_Selection_for_Run_mode_state */
+
+    uint16_t TIM_OSSIState; /* Specifies the Off-State used in Idle state.
+                               This parameter can be a value of @ref OSSI_Off_State_Selection_for_Idle_mode_state */
+
+    uint16_t TIM_LOCKLevel; /* Specifies the LOCK level parameters.
+                               This parameter can be a value of @ref Lock_level */
+
+    uint16_t TIM_DeadTime; /* Specifies the delay time between the switching-off and the
+                              switching-on of the outputs.
+                              This parameter can be a number between 0x00 and 0xFF  */
+
+    uint16_t TIM_Break; /* Specifies whether the TIM Break input is enabled or not.
+                           This parameter can be a value of @ref Break_Input_enable_disable */
+
+    uint16_t TIM_BreakPolarity; /* Specifies the TIM Break Input pin polarity.
+                                   This parameter can be a value of @ref Break_Polarity */
+
+    uint16_t TIM_AutomaticOutput; /* Specifies whether the TIM Automatic Output feature is enabled or not.
+                                     This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */
+} TIM_BDTRInitTypeDef;
+
+/* TIM_Output_Compare_and_PWM_modes */
+#define TIM_OCMode_Timing                  ((uint16_t)0x0000)
+#define TIM_OCMode_Active                  ((uint16_t)0x0010)
+#define TIM_OCMode_Inactive                ((uint16_t)0x0020)
+#define TIM_OCMode_Toggle                  ((uint16_t)0x0030)
+#define TIM_OCMode_PWM1                    ((uint16_t)0x0060)
+#define TIM_OCMode_PWM2                    ((uint16_t)0x0070)
+
+/* TIM_One_Pulse_Mode */
+#define TIM_OPMode_Single                  ((uint16_t)0x0008)
+#define TIM_OPMode_Repetitive              ((uint16_t)0x0000)
+
+/* TIM_Channel */
+#define TIM_Channel_1                      ((uint16_t)0x0000)
+#define TIM_Channel_2                      ((uint16_t)0x0004)
+#define TIM_Channel_3                      ((uint16_t)0x0008)
+#define TIM_Channel_4                      ((uint16_t)0x000C)
+
+/* TIM_Clock_Division_CKD */
+#define TIM_CKD_DIV1                       ((uint16_t)0x0000)
+#define TIM_CKD_DIV2                       ((uint16_t)0x0100)
+#define TIM_CKD_DIV4                       ((uint16_t)0x0200)
+
+/* TIM_Counter_Mode */
+#define TIM_CounterMode_Up                 ((uint16_t)0x0000)
+#define TIM_CounterMode_Down               ((uint16_t)0x0010)
+#define TIM_CounterMode_CenterAligned1     ((uint16_t)0x0020)
+#define TIM_CounterMode_CenterAligned2     ((uint16_t)0x0040)
+#define TIM_CounterMode_CenterAligned3     ((uint16_t)0x0060)
+
+/* TIM_Output_Compare_Polarity */
+#define TIM_OCPolarity_High                ((uint16_t)0x0000)
+#define TIM_OCPolarity_Low                 ((uint16_t)0x0002)
+
+/* TIM_Output_Compare_N_Polarity */
+#define TIM_OCNPolarity_High               ((uint16_t)0x0000)
+#define TIM_OCNPolarity_Low                ((uint16_t)0x0008)
+
+/* TIM_Output_Compare_state */
+#define TIM_OutputState_Disable            ((uint16_t)0x0000)
+#define TIM_OutputState_Enable             ((uint16_t)0x0001)
+
+/* TIM_Output_Compare_N_state */
+#define TIM_OutputNState_Disable           ((uint16_t)0x0000)
+#define TIM_OutputNState_Enable            ((uint16_t)0x0004)
+
+/* TIM_Capture_Compare_state */
+#define TIM_CCx_Enable                     ((uint16_t)0x0001)
+#define TIM_CCx_Disable                    ((uint16_t)0x0000)
+
+/* TIM_Capture_Compare_N_state */
+#define TIM_CCxN_Enable                    ((uint16_t)0x0004)
+#define TIM_CCxN_Disable                   ((uint16_t)0x0000)
+
+/* Break_Input_enable_disable */
+#define TIM_Break_Enable                   ((uint16_t)0x1000)
+#define TIM_Break_Disable                  ((uint16_t)0x0000)
+
+/* Break_Polarity */
+#define TIM_BreakPolarity_Low              ((uint16_t)0x0000)
+#define TIM_BreakPolarity_High             ((uint16_t)0x2000)
+
+/* TIM_AOE_Bit_Set_Reset */
+#define TIM_AutomaticOutput_Enable         ((uint16_t)0x4000)
+#define TIM_AutomaticOutput_Disable        ((uint16_t)0x0000)
+
+/* Lock_level */
+#define TIM_LOCKLevel_OFF                  ((uint16_t)0x0000)
+#define TIM_LOCKLevel_1                    ((uint16_t)0x0100)
+#define TIM_LOCKLevel_2                    ((uint16_t)0x0200)
+#define TIM_LOCKLevel_3                    ((uint16_t)0x0300)
+
+/* OSSI_Off_State_Selection_for_Idle_mode_state */
+#define TIM_OSSIState_Enable               ((uint16_t)0x0400)
+#define TIM_OSSIState_Disable              ((uint16_t)0x0000)
+
+/* OSSR_Off_State_Selection_for_Run_mode_state */
+#define TIM_OSSRState_Enable               ((uint16_t)0x0800)
+#define TIM_OSSRState_Disable              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Idle_State */
+#define TIM_OCIdleState_Set                ((uint16_t)0x0100)
+#define TIM_OCIdleState_Reset              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_N_Idle_State */
+#define TIM_OCNIdleState_Set               ((uint16_t)0x0200)
+#define TIM_OCNIdleState_Reset             ((uint16_t)0x0000)
+
+/* TIM_Input_Capture_Polarity */
+#define TIM_ICPolarity_Rising              ((uint16_t)0x0000)
+#define TIM_ICPolarity_Falling             ((uint16_t)0x0002)
+#define TIM_ICPolarity_BothEdge            ((uint16_t)0x000A)
+
+/* TIM_Input_Capture_Selection */
+#define TIM_ICSelection_DirectTI           ((uint16_t)0x0001) /* TIM Input 1, 2, 3 or 4 is selected to be \
+                                                                 connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSelection_IndirectTI         ((uint16_t)0x0002) /* TIM Input 1, 2, 3 or 4 is selected to be \
+                                                                 connected to IC2, IC1, IC4 or IC3, respectively. */
+#define TIM_ICSelection_TRC                ((uint16_t)0x0003) /* TIM Input 1, 2, 3 or 4 is selected to be connected to TRC. */
+
+/* TIM_Input_Capture_Prescaler */
+#define TIM_ICPSC_DIV1                     ((uint16_t)0x0000) /* Capture performed each time an edge is detected on the capture input. */
+#define TIM_ICPSC_DIV2                     ((uint16_t)0x0004) /* Capture performed once every 2 events. */
+#define TIM_ICPSC_DIV4                     ((uint16_t)0x0008) /* Capture performed once every 4 events. */
+#define TIM_ICPSC_DIV8                     ((uint16_t)0x000C) /* Capture performed once every 8 events. */
+
+/* TIM_interrupt_sources */
+#define TIM_IT_Update                      ((uint16_t)0x0001)
+#define TIM_IT_CC1                         ((uint16_t)0x0002)
+#define TIM_IT_CC2                         ((uint16_t)0x0004)
+#define TIM_IT_CC3                         ((uint16_t)0x0008)
+#define TIM_IT_CC4                         ((uint16_t)0x0010)
+#define TIM_IT_COM                         ((uint16_t)0x0020)
+#define TIM_IT_Trigger                     ((uint16_t)0x0040)
+#define TIM_IT_Break                       ((uint16_t)0x0080)
+
+/* TIM_DMA_Base_address */
+#define TIM_DMABase_CR1                    ((uint16_t)0x0000)
+#define TIM_DMABase_CR2                    ((uint16_t)0x0001)
+#define TIM_DMABase_SMCR                   ((uint16_t)0x0002)
+#define TIM_DMABase_DIER                   ((uint16_t)0x0003)
+#define TIM_DMABase_SR                     ((uint16_t)0x0004)
+#define TIM_DMABase_EGR                    ((uint16_t)0x0005)
+#define TIM_DMABase_CCMR1                  ((uint16_t)0x0006)
+#define TIM_DMABase_CCMR2                  ((uint16_t)0x0007)
+#define TIM_DMABase_CCER                   ((uint16_t)0x0008)
+#define TIM_DMABase_CNT                    ((uint16_t)0x0009)
+#define TIM_DMABase_PSC                    ((uint16_t)0x000A)
+#define TIM_DMABase_ARR                    ((uint16_t)0x000B)
+#define TIM_DMABase_RCR                    ((uint16_t)0x000C)
+#define TIM_DMABase_CCR1                   ((uint16_t)0x000D)
+#define TIM_DMABase_CCR2                   ((uint16_t)0x000E)
+#define TIM_DMABase_CCR3                   ((uint16_t)0x000F)
+#define TIM_DMABase_CCR4                   ((uint16_t)0x0010)
+#define TIM_DMABase_BDTR                   ((uint16_t)0x0011)
+#define TIM_DMABase_DCR                    ((uint16_t)0x0012)
+
+/* TIM_DMA_Burst_Length */
+#define TIM_DMABurstLength_1Transfer       ((uint16_t)0x0000)
+#define TIM_DMABurstLength_2Transfers      ((uint16_t)0x0100)
+#define TIM_DMABurstLength_3Transfers      ((uint16_t)0x0200)
+#define TIM_DMABurstLength_4Transfers      ((uint16_t)0x0300)
+#define TIM_DMABurstLength_5Transfers      ((uint16_t)0x0400)
+#define TIM_DMABurstLength_6Transfers      ((uint16_t)0x0500)
+#define TIM_DMABurstLength_7Transfers      ((uint16_t)0x0600)
+#define TIM_DMABurstLength_8Transfers      ((uint16_t)0x0700)
+#define TIM_DMABurstLength_9Transfers      ((uint16_t)0x0800)
+#define TIM_DMABurstLength_10Transfers     ((uint16_t)0x0900)
+#define TIM_DMABurstLength_11Transfers     ((uint16_t)0x0A00)
+#define TIM_DMABurstLength_12Transfers     ((uint16_t)0x0B00)
+#define TIM_DMABurstLength_13Transfers     ((uint16_t)0x0C00)
+#define TIM_DMABurstLength_14Transfers     ((uint16_t)0x0D00)
+#define TIM_DMABurstLength_15Transfers     ((uint16_t)0x0E00)
+#define TIM_DMABurstLength_16Transfers     ((uint16_t)0x0F00)
+#define TIM_DMABurstLength_17Transfers     ((uint16_t)0x1000)
+#define TIM_DMABurstLength_18Transfers     ((uint16_t)0x1100)
+
+/* TIM_DMA_sources */
+#define TIM_DMA_Update                     ((uint16_t)0x0100)
+#define TIM_DMA_CC1                        ((uint16_t)0x0200)
+#define TIM_DMA_CC2                        ((uint16_t)0x0400)
+#define TIM_DMA_CC3                        ((uint16_t)0x0800)
+#define TIM_DMA_CC4                        ((uint16_t)0x1000)
+#define TIM_DMA_COM                        ((uint16_t)0x2000)
+#define TIM_DMA_Trigger                    ((uint16_t)0x4000)
+
+/* TIM_External_Trigger_Prescaler */
+#define TIM_ExtTRGPSC_OFF                  ((uint16_t)0x0000)
+#define TIM_ExtTRGPSC_DIV2                 ((uint16_t)0x1000)
+#define TIM_ExtTRGPSC_DIV4                 ((uint16_t)0x2000)
+#define TIM_ExtTRGPSC_DIV8                 ((uint16_t)0x3000)
+
+/* TIM_Internal_Trigger_Selection */
+#define TIM_TS_ITR0                        ((uint16_t)0x0000)
+#define TIM_TS_ITR1                        ((uint16_t)0x0010)
+#define TIM_TS_ITR2                        ((uint16_t)0x0020)
+#define TIM_TS_ITR3                        ((uint16_t)0x0030)
+#define TIM_TS_TI1F_ED                     ((uint16_t)0x0040)
+#define TIM_TS_TI1FP1                      ((uint16_t)0x0050)
+#define TIM_TS_TI2FP2                      ((uint16_t)0x0060)
+#define TIM_TS_ETRF                        ((uint16_t)0x0070)
+
+/* TIM_TIx_External_Clock_Source */
+#define TIM_TIxExternalCLK1Source_TI1      ((uint16_t)0x0050)
+#define TIM_TIxExternalCLK1Source_TI2      ((uint16_t)0x0060)
+#define TIM_TIxExternalCLK1Source_TI1ED    ((uint16_t)0x0040)
+
+/* TIM_External_Trigger_Polarity */
+#define TIM_ExtTRGPolarity_Inverted        ((uint16_t)0x8000)
+#define TIM_ExtTRGPolarity_NonInverted     ((uint16_t)0x0000)
+
+/* TIM_Prescaler_Reload_Mode */
+#define TIM_PSCReloadMode_Update           ((uint16_t)0x0000)
+#define TIM_PSCReloadMode_Immediate        ((uint16_t)0x0001)
+
+/* TIM_Forced_Action */
+#define TIM_ForcedAction_Active            ((uint16_t)0x0050)
+#define TIM_ForcedAction_InActive          ((uint16_t)0x0040)
+
+/* TIM_Encoder_Mode */
+#define TIM_EncoderMode_TI1                ((uint16_t)0x0001)
+#define TIM_EncoderMode_TI2                ((uint16_t)0x0002)
+#define TIM_EncoderMode_TI12               ((uint16_t)0x0003)
+
+/* TIM_Event_Source */
+#define TIM_EventSource_Update             ((uint16_t)0x0001)
+#define TIM_EventSource_CC1                ((uint16_t)0x0002)
+#define TIM_EventSource_CC2                ((uint16_t)0x0004)
+#define TIM_EventSource_CC3                ((uint16_t)0x0008)
+#define TIM_EventSource_CC4                ((uint16_t)0x0010)
+#define TIM_EventSource_COM                ((uint16_t)0x0020)
+#define TIM_EventSource_Trigger            ((uint16_t)0x0040)
+#define TIM_EventSource_Break              ((uint16_t)0x0080)
+
+/* TIM_Update_Source */
+#define TIM_UpdateSource_Global            ((uint16_t)0x0000) /* Source of update is the counter overflow/underflow \
+                                                                 or the setting of UG bit, or an update generation  \
+                                                                 through the slave mode controller. */
+#define TIM_UpdateSource_Regular           ((uint16_t)0x0001) /* Source of update is counter overflow/underflow. */
+
+/* TIM_Output_Compare_Preload_State */
+#define TIM_OCPreload_Enable               ((uint16_t)0x0008)
+#define TIM_OCPreload_Disable              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Fast_State */
+#define TIM_OCFast_Enable                  ((uint16_t)0x0004)
+#define TIM_OCFast_Disable                 ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Clear_State */
+#define TIM_OCClear_Enable                 ((uint16_t)0x0080)
+#define TIM_OCClear_Disable                ((uint16_t)0x0000)
+
+/* TIM_Trigger_Output_Source */
+#define TIM_TRGOSource_Reset               ((uint16_t)0x0000)
+#define TIM_TRGOSource_Enable              ((uint16_t)0x0010)
+#define TIM_TRGOSource_Update              ((uint16_t)0x0020)
+#define TIM_TRGOSource_OC1                 ((uint16_t)0x0030)
+#define TIM_TRGOSource_OC1Ref              ((uint16_t)0x0040)
+#define TIM_TRGOSource_OC2Ref              ((uint16_t)0x0050)
+#define TIM_TRGOSource_OC3Ref              ((uint16_t)0x0060)
+#define TIM_TRGOSource_OC4Ref              ((uint16_t)0x0070)
+
+/* TIM_Slave_Mode */
+#define TIM_SlaveMode_Reset                ((uint16_t)0x0004)
+#define TIM_SlaveMode_Gated                ((uint16_t)0x0005)
+#define TIM_SlaveMode_Trigger              ((uint16_t)0x0006)
+#define TIM_SlaveMode_External1            ((uint16_t)0x0007)
+
+/* TIM_Master_Slave_Mode */
+#define TIM_MasterSlaveMode_Enable         ((uint16_t)0x0080)
+#define TIM_MasterSlaveMode_Disable        ((uint16_t)0x0000)
+
+/* TIM_Flags */
+#define TIM_FLAG_Update                    ((uint16_t)0x0001)
+#define TIM_FLAG_CC1                       ((uint16_t)0x0002)
+#define TIM_FLAG_CC2                       ((uint16_t)0x0004)
+#define TIM_FLAG_CC3                       ((uint16_t)0x0008)
+#define TIM_FLAG_CC4                       ((uint16_t)0x0010)
+#define TIM_FLAG_COM                       ((uint16_t)0x0020)
+#define TIM_FLAG_Trigger                   ((uint16_t)0x0040)
+#define TIM_FLAG_Break                     ((uint16_t)0x0080)
+#define TIM_FLAG_CC1OF                     ((uint16_t)0x0200)
+#define TIM_FLAG_CC2OF                     ((uint16_t)0x0400)
+#define TIM_FLAG_CC3OF                     ((uint16_t)0x0800)
+#define TIM_FLAG_CC4OF                     ((uint16_t)0x1000)
+
+/* TIM_Legacy */
+#define TIM_DMABurstLength_1Byte           TIM_DMABurstLength_1Transfer
+#define TIM_DMABurstLength_2Bytes          TIM_DMABurstLength_2Transfers
+#define TIM_DMABurstLength_3Bytes          TIM_DMABurstLength_3Transfers
+#define TIM_DMABurstLength_4Bytes          TIM_DMABurstLength_4Transfers
+#define TIM_DMABurstLength_5Bytes          TIM_DMABurstLength_5Transfers
+#define TIM_DMABurstLength_6Bytes          TIM_DMABurstLength_6Transfers
+#define TIM_DMABurstLength_7Bytes          TIM_DMABurstLength_7Transfers
+#define TIM_DMABurstLength_8Bytes          TIM_DMABurstLength_8Transfers
+#define TIM_DMABurstLength_9Bytes          TIM_DMABurstLength_9Transfers
+#define TIM_DMABurstLength_10Bytes         TIM_DMABurstLength_10Transfers
+#define TIM_DMABurstLength_11Bytes         TIM_DMABurstLength_11Transfers
+#define TIM_DMABurstLength_12Bytes         TIM_DMABurstLength_12Transfers
+#define TIM_DMABurstLength_13Bytes         TIM_DMABurstLength_13Transfers
+#define TIM_DMABurstLength_14Bytes         TIM_DMABurstLength_14Transfers
+#define TIM_DMABurstLength_15Bytes         TIM_DMABurstLength_15Transfers
+#define TIM_DMABurstLength_16Bytes         TIM_DMABurstLength_16Transfers
+#define TIM_DMABurstLength_17Bytes         TIM_DMABurstLength_17Transfers
+#define TIM_DMABurstLength_18Bytes         TIM_DMABurstLength_18Transfers
+
+/* TIM_Supersede_Mode_OC1 */
+#define TIM_Supersede_Mode_OC1_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC1_L           ((uint16_t)0x0010)
+
+/* TIM_Supersede_Mode_OC2 */
+#define TIM_Supersede_Mode_OC2_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC2_L           ((uint16_t)0x0020)
+
+/* TIM_Supersede_Mode_OC3 */
+#define TIM_Supersede_Mode_OC3_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC3_L           ((uint16_t)0x0040)
+
+/* TIM_Supersede_Mode_OC4 */
+#define TIM_Supersede_Mode_OC4_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC4_L           ((uint16_t)0x0080)
+
+
+
+void       TIM_DeInit(TIM_TypeDef *TIMx);
+void       TIM_TimeBaseInit(TIM_TypeDef *TIMx, TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct);
+void       TIM_OC1Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_OC2Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_OC3Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_OC4Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_ICInit(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct);
+void       TIM_PWMIConfig(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct);
+void       TIM_BDTRConfig(TIM_TypeDef *TIMx, TIM_BDTRInitTypeDef *TIM_BDTRInitStruct);
+void       TIM_TimeBaseStructInit(TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct);
+void       TIM_OCStructInit(TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_ICStructInit(TIM_ICInitTypeDef *TIM_ICInitStruct);
+void       TIM_BDTRStructInit(TIM_BDTRInitTypeDef *TIM_BDTRInitStruct);
+void       TIM_Cmd(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_CtrlPWMOutputs(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_ITConfig(TIM_TypeDef *TIMx, uint16_t TIM_IT, FunctionalState NewState);
+void       TIM_GenerateEvent(TIM_TypeDef *TIMx, uint16_t TIM_EventSource);
+void       TIM_DMAConfig(TIM_TypeDef *TIMx, uint16_t TIM_DMABase, uint16_t TIM_DMABurstLength);
+void       TIM_DMACmd(TIM_TypeDef *TIMx, uint16_t TIM_DMASource, FunctionalState NewState);
+void       TIM_InternalClockConfig(TIM_TypeDef *TIMx);
+void       TIM_ITRxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource);
+void       TIM_TIxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_TIxExternalCLKSource,
+                                      uint16_t TIM_ICPolarity, uint16_t ICFilter);
+void       TIM_ETRClockMode1Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                                   uint16_t ExtTRGFilter);
+void       TIM_ETRClockMode2Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler,
+                                   uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter);
+void       TIM_ETRConfig(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                         uint16_t ExtTRGFilter);
+void       TIM_PrescalerConfig(TIM_TypeDef *TIMx, uint16_t Prescaler, uint16_t TIM_PSCReloadMode);
+void       TIM_CounterModeConfig(TIM_TypeDef *TIMx, uint16_t TIM_CounterMode);
+void       TIM_SelectInputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource);
+void       TIM_EncoderInterfaceConfig(TIM_TypeDef *TIMx, uint16_t TIM_EncoderMode,
+                                      uint16_t TIM_IC1Polarity, uint16_t TIM_IC2Polarity);
+void       TIM_ForcedOC1Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ForcedOC2Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ForcedOC3Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ForcedOC4Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ARRPreloadConfig(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_SelectCOM(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_SelectCCDMA(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_CCPreloadControl(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_OC1PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC2PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC3PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC4PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC1FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_OC2FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_OC3FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_OC4FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_ClearOC1Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_ClearOC2Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_ClearOC3Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_ClearOC4Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_OC1PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_OC1NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity);
+void       TIM_OC2PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_OC2NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity);
+void       TIM_OC3PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_OC3NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity);
+void       TIM_OC4PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_CCxCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCx);
+void       TIM_CCxNCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCxN);
+void       TIM_SelectOCxM(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_OCMode);
+void       TIM_UpdateDisableConfig(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_UpdateRequestConfig(TIM_TypeDef *TIMx, uint16_t TIM_UpdateSource);
+void       TIM_SelectHallSensor(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_SelectOnePulseMode(TIM_TypeDef *TIMx, uint16_t TIM_OPMode);
+void       TIM_SelectOutputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_TRGOSource);
+void       TIM_SelectSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_SlaveMode);
+void       TIM_SelectMasterSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_MasterSlaveMode);
+void       TIM_SetCounter(TIM_TypeDef *TIMx, uint16_t Counter);
+void       TIM_SetAutoreload(TIM_TypeDef *TIMx, uint16_t Autoreload);
+void       TIM_SetCompare1(TIM_TypeDef *TIMx, uint16_t Compare1);
+void       TIM_SetCompare2(TIM_TypeDef *TIMx, uint16_t Compare2);
+void       TIM_SetCompare3(TIM_TypeDef *TIMx, uint16_t Compare3);
+void       TIM_SetCompare4(TIM_TypeDef *TIMx, uint16_t Compare4);
+void       TIM_SetIC1Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetIC2Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetIC3Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetIC4Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetClockDivision(TIM_TypeDef *TIMx, uint16_t TIM_CKD);
+uint16_t   TIM_GetCapture1(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCapture2(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCapture3(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCapture4(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCounter(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetPrescaler(TIM_TypeDef *TIMx);
+FlagStatus TIM_GetFlagStatus(TIM_TypeDef *TIMx, uint16_t TIM_FLAG);
+void       TIM_ClearFlag(TIM_TypeDef *TIMx, uint16_t TIM_FLAG);
+ITStatus   TIM_GetITStatus(TIM_TypeDef *TIMx, uint16_t TIM_IT);
+void       TIM_ClearITPendingBit(TIM_TypeDef *TIMx, uint16_t TIM_IT);
+void       TIM_CaptureModeCmd(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_IndicateCaptureLevelCmd(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_OC12_SupersedeModeCmd(TIM_TypeDef *TIMx, uint16_t TIM_Supersede_Mode_OC1, uint16_t TIM_Supersede_Mode_OC2, FunctionalState NewState);
+void       TIM_OC34_SupersedeModeCmd(TIM_TypeDef *TIMx, uint16_t TIM_Supersede_Mode_OC3, uint16_t TIM_Supersede_Mode_OC4, FunctionalState NewState);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_usart.h
+++ b/Peripheral/ch32x035/inc/ch32x035_usart.h
@@ -1,0 +1,185 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_usart.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      USART firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_USART_H
+#define __CH32X035_USART_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* USART Init Structure definition */
+typedef struct
+{
+    uint32_t USART_BaudRate; /* This member configures the USART communication baud rate.
+                                The baud rate is computed using the following formula:
+                                 - IntegerDivider = ((PCLKx) / (16 * (USART_InitStruct->USART_BaudRate)))
+                                 - FractionalDivider = ((IntegerDivider - ((u32) IntegerDivider)) * 16) + 0.5 */
+
+    uint16_t USART_WordLength; /* Specifies the number of data bits transmitted or received in a frame.
+                                  This parameter can be a value of @ref USART_Word_Length */
+
+    uint16_t USART_StopBits; /* Specifies the number of stop bits transmitted.
+                                This parameter can be a value of @ref USART_Stop_Bits */
+
+    uint16_t USART_Parity; /* Specifies the parity mode.
+                              This parameter can be a value of @ref USART_Parity
+                              @note When parity is enabled, the computed parity is inserted
+                                    at the MSB position of the transmitted data (9th bit when
+                                    the word length is set to 9 data bits; 8th bit when the
+                                    word length is set to 8 data bits). */
+
+    uint16_t USART_Mode; /* Specifies wether the Receive or Transmit mode is enabled or disabled.
+                            This parameter can be a value of @ref USART_Mode */
+
+    uint16_t USART_HardwareFlowControl; /* Specifies wether the hardware flow control mode is enabled
+                                           or disabled.
+                                           This parameter can be a value of @ref USART_Hardware_Flow_Control */
+} USART_InitTypeDef;
+
+/* USART Clock Init Structure definition */
+typedef struct
+{
+    uint16_t USART_Clock; /* Specifies whether the USART clock is enabled or disabled.
+                             This parameter can be a value of @ref USART_Clock */
+
+    uint16_t USART_CPOL; /* Specifies the steady state value of the serial clock.
+                            This parameter can be a value of @ref USART_Clock_Polarity */
+
+    uint16_t USART_CPHA; /* Specifies the clock transition on which the bit capture is made.
+                            This parameter can be a value of @ref USART_Clock_Phase */
+
+    uint16_t USART_LastBit; /* Specifies whether the clock pulse corresponding to the last transmitted
+                               data bit (MSB) has to be output on the SCLK pin in synchronous mode.
+                               This parameter can be a value of @ref USART_Last_Bit */
+} USART_ClockInitTypeDef;
+
+/* USART_Word_Length */
+#define USART_WordLength_8b                  ((uint16_t)0x0000)
+#define USART_WordLength_9b                  ((uint16_t)0x1000)
+
+/* USART_Stop_Bits */
+#define USART_StopBits_1                     ((uint16_t)0x0000)
+#define USART_StopBits_0_5                   ((uint16_t)0x1000)
+#define USART_StopBits_2                     ((uint16_t)0x2000)
+#define USART_StopBits_1_5                   ((uint16_t)0x3000)
+
+/* USART_Parity */
+#define USART_Parity_No                      ((uint16_t)0x0000)
+#define USART_Parity_Even                    ((uint16_t)0x0400)
+#define USART_Parity_Odd                     ((uint16_t)0x0600)
+
+/* USART_Mode */
+#define USART_Mode_Rx                        ((uint16_t)0x0004)
+#define USART_Mode_Tx                        ((uint16_t)0x0008)
+
+/* USART_Hardware_Flow_Control */
+#define USART_HardwareFlowControl_None       ((uint16_t)0x0000)
+#define USART_HardwareFlowControl_RTS        ((uint16_t)0x0100)
+#define USART_HardwareFlowControl_CTS        ((uint16_t)0x0200)
+#define USART_HardwareFlowControl_RTS_CTS    ((uint16_t)0x0300)
+
+/* USART_Clock */
+#define USART_Clock_Disable                  ((uint16_t)0x0000)
+#define USART_Clock_Enable                   ((uint16_t)0x0800)
+
+/* USART_Clock_Polarity */
+#define USART_CPOL_Low                       ((uint16_t)0x0000)
+#define USART_CPOL_High                      ((uint16_t)0x0400)
+
+/* USART_Clock_Phase */
+#define USART_CPHA_1Edge                     ((uint16_t)0x0000)
+#define USART_CPHA_2Edge                     ((uint16_t)0x0200)
+
+/* USART_Last_Bit */
+#define USART_LastBit_Disable                ((uint16_t)0x0000)
+#define USART_LastBit_Enable                 ((uint16_t)0x0100)
+
+/* USART_Interrupt_definition */
+#define USART_IT_PE                          ((uint16_t)0x0028)
+#define USART_IT_TXE                         ((uint16_t)0x0727)
+#define USART_IT_TC                          ((uint16_t)0x0626)
+#define USART_IT_RXNE                        ((uint16_t)0x0525)
+#define USART_IT_ORE_RX                      ((uint16_t)0x0325)
+#define USART_IT_IDLE                        ((uint16_t)0x0424)
+#define USART_IT_LBD                         ((uint16_t)0x0846)
+#define USART_IT_CTS                         ((uint16_t)0x096A)
+#define USART_IT_ERR                         ((uint16_t)0x0060)
+#define USART_IT_ORE_ER                      ((uint16_t)0x0360)
+#define USART_IT_NE                          ((uint16_t)0x0260)
+#define USART_IT_FE                          ((uint16_t)0x0160)
+
+#define USART_IT_ORE                         USART_IT_ORE_ER
+
+/* USART_DMA_Requests */
+#define USART_DMAReq_Tx                      ((uint16_t)0x0080)
+#define USART_DMAReq_Rx                      ((uint16_t)0x0040)
+
+/* USART_WakeUp_methods */
+#define USART_WakeUp_IdleLine                ((uint16_t)0x0000)
+#define USART_WakeUp_AddressMark             ((uint16_t)0x0800)
+
+/* USART_LIN_Break_Detection_Length */
+#define USART_LINBreakDetectLength_10b       ((uint16_t)0x0000)
+#define USART_LINBreakDetectLength_11b       ((uint16_t)0x0020)
+
+/* USART_IrDA_Low_Power */
+#define USART_IrDAMode_LowPower              ((uint16_t)0x0004)
+#define USART_IrDAMode_Normal                ((uint16_t)0x0000)
+
+/* USART_Flags */
+#define USART_FLAG_CTS                       ((uint16_t)0x0200)
+#define USART_FLAG_LBD                       ((uint16_t)0x0100)
+#define USART_FLAG_TXE                       ((uint16_t)0x0080)
+#define USART_FLAG_TC                        ((uint16_t)0x0040)
+#define USART_FLAG_RXNE                      ((uint16_t)0x0020)
+#define USART_FLAG_IDLE                      ((uint16_t)0x0010)
+#define USART_FLAG_ORE                       ((uint16_t)0x0008)
+#define USART_FLAG_NE                        ((uint16_t)0x0004)
+#define USART_FLAG_FE                        ((uint16_t)0x0002)
+#define USART_FLAG_PE                        ((uint16_t)0x0001)
+
+void       USART_DeInit(USART_TypeDef *USARTx);
+void       USART_Init(USART_TypeDef *USARTx, USART_InitTypeDef *USART_InitStruct);
+void       USART_StructInit(USART_InitTypeDef *USART_InitStruct);
+void       USART_ClockInit(USART_TypeDef *USARTx, USART_ClockInitTypeDef *USART_ClockInitStruct);
+void       USART_ClockStructInit(USART_ClockInitTypeDef *USART_ClockInitStruct);
+void       USART_Cmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_ITConfig(USART_TypeDef *USARTx, uint16_t USART_IT, FunctionalState NewState);
+void       USART_DMACmd(USART_TypeDef *USARTx, uint16_t USART_DMAReq, FunctionalState NewState);
+void       USART_SetAddress(USART_TypeDef *USARTx, uint8_t USART_Address);
+void       USART_WakeUpConfig(USART_TypeDef *USARTx, uint16_t USART_WakeUp);
+void       USART_ReceiverWakeUpCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_LINBreakDetectLengthConfig(USART_TypeDef *USARTx, uint16_t USART_LINBreakDetectLength);
+void       USART_LINCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_SendData(USART_TypeDef *USARTx, uint16_t Data);
+uint16_t   USART_ReceiveData(USART_TypeDef *USARTx);
+void       USART_SendBreak(USART_TypeDef *USARTx);
+void       USART_SetGuardTime(USART_TypeDef *USARTx, uint8_t USART_GuardTime);
+void       USART_SetPrescaler(USART_TypeDef *USARTx, uint8_t USART_Prescaler);
+void       USART_SmartCardCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_SmartCardNACKCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_HalfDuplexCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_IrDAConfig(USART_TypeDef *USARTx, uint16_t USART_IrDAMode);
+void       USART_IrDACmd(USART_TypeDef *USARTx, FunctionalState NewState);
+FlagStatus USART_GetFlagStatus(USART_TypeDef *USARTx, uint16_t USART_FLAG);
+void       USART_ClearFlag(USART_TypeDef *USARTx, uint16_t USART_FLAG);
+ITStatus   USART_GetITStatus(USART_TypeDef *USARTx, uint16_t USART_IT);
+void       USART_ClearITPendingBit(USART_TypeDef *USARTx, uint16_t USART_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/inc/ch32x035_wwdg.h
+++ b/Peripheral/ch32x035/inc/ch32x035_wwdg.h
@@ -1,0 +1,41 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_wwdg.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file contains all the functions prototypes for the WWDG
+ *                      firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32X035_WWDG_H
+#define __CH32X035_WWDG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32x035.h"
+
+/* WWDG_Prescaler */
+#define WWDG_Prescaler_1    ((uint32_t)0x00000000)
+#define WWDG_Prescaler_2    ((uint32_t)0x00000080)
+#define WWDG_Prescaler_4    ((uint32_t)0x00000100)
+#define WWDG_Prescaler_8    ((uint32_t)0x00000180)
+
+void       WWDG_DeInit(void);
+void       WWDG_SetPrescaler(uint32_t WWDG_Prescaler);
+void       WWDG_SetWindowValue(uint8_t WindowValue);
+void       WWDG_EnableIT(void);
+void       WWDG_SetCounter(uint8_t Counter);
+void       WWDG_Enable(uint8_t Counter);
+FlagStatus WWDG_GetFlagStatus(void);
+void       WWDG_ClearFlag(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripheral/ch32x035/src/ch32x035_adc.c
+++ b/Peripheral/ch32x035/src/ch32x035_adc.c
@@ -1,0 +1,1125 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_adc.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the ADC firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_adc.h"
+#include "ch32x035_rcc.h"
+
+/* ADC DISCNUM mask */
+#define CTLR1_DISCNUM_Reset              ((uint32_t)0xFFFF1FFF)
+
+/* ADC DISCEN mask */
+#define CTLR1_DISCEN_Set                 ((uint32_t)0x00000800)
+#define CTLR1_DISCEN_Reset               ((uint32_t)0xFFFFF7FF)
+
+/* ADC JAUTO mask */
+#define CTLR1_JAUTO_Set                  ((uint32_t)0x00000400)
+#define CTLR1_JAUTO_Reset                ((uint32_t)0xFFFFFBFF)
+
+/* ADC JDISCEN mask */
+#define CTLR1_JDISCEN_Set                ((uint32_t)0x00001000)
+#define CTLR1_JDISCEN_Reset              ((uint32_t)0xFFFFEFFF)
+
+/* ADC AWDCH mask */
+#define CTLR1_AWDCH_Reset                ((uint32_t)0xFFFFFFE0)
+
+/* ADC Analog watchdog enable mode mask */
+#define CTLR1_AWDMode_Reset              ((uint32_t)0xFF3FFDFF)
+
+/* CTLR1 register Mask */
+#define CTLR1_CLEAR_Mask                 ((uint32_t)0xE0F0FEFF)
+
+/* ADC ADON mask */
+#define CTLR2_ADON_Set                   ((uint32_t)0x00000001)
+#define CTLR2_ADON_Reset                 ((uint32_t)0xFFFFFFFE)
+
+/* ADC DMA mask */
+#define CTLR2_DMA_Set                    ((uint32_t)0x00000100)
+#define CTLR2_DMA_Reset                  ((uint32_t)0xFFFFFEFF)
+
+/* ADC RSTCAL mask */
+#define CTLR2_RSTCAL_Set                 ((uint32_t)0x00000008)
+
+/* ADC CAL mask */
+#define CTLR2_CAL_Set                    ((uint32_t)0x00000004)
+
+/* ADC SWSTART mask */
+#define CTLR2_SWSTART_Set                ((uint32_t)0x00400000)
+
+/* ADC EXTTRIG mask */
+#define CTLR2_EXTTRIG_Set                ((uint32_t)0x00100000)
+#define CTLR2_EXTTRIG_Reset              ((uint32_t)0xFFEFFFFF)
+
+/* ADC Software start mask */
+#define CTLR2_EXTTRIG_SWSTART_Set        ((uint32_t)0x00500000)
+#define CTLR2_EXTTRIG_SWSTART_Reset      ((uint32_t)0xFFAFFFFF)
+
+/* ADC JEXTSEL mask */
+#define CTLR2_JEXTSEL_Reset              ((uint32_t)0xFFFF8FFF)
+
+/* ADC JEXTTRIG mask */
+#define CTLR2_JEXTTRIG_Set               ((uint32_t)0x00008000)
+#define CTLR2_JEXTTRIG_Reset             ((uint32_t)0xFFFF7FFF)
+
+/* ADC JSWSTART mask */
+#define CTLR2_JSWSTART_Set               ((uint32_t)0x00200000)
+
+/* ADC injected software start mask */
+#define CTLR2_JEXTTRIG_JSWSTART_Set      ((uint32_t)0x00208000)
+#define CTLR2_JEXTTRIG_JSWSTART_Reset    ((uint32_t)0xFFDF7FFF)
+
+/* ADC TSPD mask */
+#define CTLR2_TSVREFE_Set                ((uint32_t)0x00800000)
+#define CTLR2_TSVREFE_Reset              ((uint32_t)0xFF7FFFFF)
+
+/* CTLR2 register Mask */
+#define CTLR2_CLEAR_Mask                 ((uint32_t)0xFFF1F7FD)
+
+/* ADC SQx mask */
+#define RSQR3_SQ_Set                     ((uint32_t)0x0000001F)
+#define RSQR2_SQ_Set                     ((uint32_t)0x0000001F)
+#define RSQR1_SQ_Set                     ((uint32_t)0x0000001F)
+
+/* RSQR1 register Mask */
+#define RSQR1_CLEAR_Mask                 ((uint32_t)0xFF0FFFFF)
+
+/* ADC JSQx mask */
+#define ISQR_JSQ_Set                     ((uint32_t)0x0000001F)
+
+/* ADC JL mask */
+#define ISQR_JL_Set                      ((uint32_t)0x00300000)
+#define ISQR_JL_Reset                    ((uint32_t)0xFFCFFFFF)
+
+/* ADC SMPx mask */
+#define SAMPTR1_SMP_Set                  ((uint32_t)0x00000007)
+#define SAMPTR2_SMP_Set                  ((uint32_t)0x00000007)
+
+/* ADC IDATARx registers offset */
+#define IDATAR_Offset                    ((uint8_t)0x28)
+
+/* ADC1 RDATAR register base address */
+#define RDATAR_ADDRESS                   ((uint32_t)0x4001244C)
+
+/* ADC CLK */
+#define CTLR3_CLK_Mask                   ((uint32_t)0xFFFFFE00)
+
+/*********************************************************************
+ * @fn      ADC_DeInit
+ *
+ * @brief   Deinitializes the ADCx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *
+ * @return  none
+ */
+void ADC_DeInit(ADC_TypeDef *ADCx)
+{
+    if(ADCx == ADC1)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_Init
+ *
+ * @brief   Initializes the ADCx peripheral according to the specified
+ *        parameters in the ADC_InitStruct.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_InitStruct - pointer to an ADC_InitTypeDef structure that
+ *        contains the configuration information for the specified ADC
+ *        peripheral.
+ *
+ * @return  none
+ */
+void ADC_Init(ADC_TypeDef *ADCx, ADC_InitTypeDef *ADC_InitStruct)
+{
+    uint32_t tmpreg1 = 0;
+    uint8_t  tmpreg2 = 0;
+
+    tmpreg1 = ADCx->CTLR1;
+    tmpreg1 &= CTLR1_CLEAR_Mask;
+    tmpreg1 |= (uint32_t)(ADC_InitStruct->ADC_Mode | (uint32_t)ADC_InitStruct->ADC_OutputBuffer |
+                          (uint32_t)ADC_InitStruct->ADC_Pga | ((uint32_t)ADC_InitStruct->ADC_ScanConvMode << 8));
+    ADCx->CTLR1 = tmpreg1;
+
+    tmpreg1 = ADCx->CTLR2;
+    tmpreg1 &= CTLR2_CLEAR_Mask;
+    tmpreg1 |= (uint32_t)(ADC_InitStruct->ADC_DataAlign | ADC_InitStruct->ADC_ExternalTrigConv |
+                          ((uint32_t)ADC_InitStruct->ADC_ContinuousConvMode << 1));
+    ADCx->CTLR2 = tmpreg1;
+
+    tmpreg1 = ADCx->RSQR1;
+    tmpreg1 &= RSQR1_CLEAR_Mask;
+    tmpreg2 |= (uint8_t)(ADC_InitStruct->ADC_NbrOfChannel - (uint8_t)1);
+    tmpreg1 |= (uint32_t)tmpreg2 << 20;
+    ADCx->RSQR1 = tmpreg1;
+}
+
+/*********************************************************************
+ * @fn      ADC_StructInit
+ *
+ * @brief   Fills each ADC_InitStruct member with its default value.
+ *
+ * @param   ADC_InitStruct - pointer to an ADC_InitTypeDef structure that
+ *        contains the configuration information for the specified ADC
+ *        peripheral.
+ *
+ * @return  none
+ */
+void ADC_StructInit(ADC_InitTypeDef *ADC_InitStruct)
+{
+    ADC_InitStruct->ADC_Mode = ADC_Mode_Independent;
+    ADC_InitStruct->ADC_ScanConvMode = DISABLE;
+    ADC_InitStruct->ADC_ContinuousConvMode = DISABLE;
+    ADC_InitStruct->ADC_ExternalTrigConv = ADC_ExternalTrigConv_T1_CC1;
+    ADC_InitStruct->ADC_DataAlign = ADC_DataAlign_Right;
+    ADC_InitStruct->ADC_NbrOfChannel = 1;
+}
+
+/*********************************************************************
+ * @fn      ADC_Cmd
+ *
+ * @brief   Enables or disables the specified ADC peripheral.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void ADC_Cmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR2 |= CTLR2_ADON_Set;
+    }
+    else
+    {
+        ADCx->CTLR2 &= CTLR2_ADON_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_DMACmd
+ *
+ * @brief   Enables or disables the specified ADC DMA request.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void ADC_DMACmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR2 |= CTLR2_DMA_Set;
+    }
+    else
+    {
+        ADCx->CTLR2 &= CTLR2_DMA_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_ITConfig
+ *
+ * @brief   Enables or disables the specified ADC interrupts.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_IT - specifies the ADC interrupt sources to be enabled or disabled.
+ *            ADC_IT_EOC - End of conversion interrupt mask.
+ *            ADC_IT_AWD - Analog watchdog interrupt mask.
+ *            ADC_IT_JEOC - End of injected conversion interrupt mask.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void ADC_ITConfig(ADC_TypeDef *ADCx, uint16_t ADC_IT, FunctionalState NewState)
+{
+    uint8_t itmask = 0;
+
+    itmask = (uint8_t)ADC_IT;
+
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR1 |= itmask;
+    }
+    else
+    {
+        ADCx->CTLR1 &= (~(uint32_t)itmask);
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_SoftwareStartConvCmd
+ *
+ * @brief   Enables or disables the selected ADC software start conversion.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  None
+ */
+void ADC_SoftwareStartConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR2 |= CTLR2_EXTTRIG_SWSTART_Set;
+    }
+    else
+    {
+        ADCx->CTLR2 &= CTLR2_EXTTRIG_SWSTART_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_GetSoftwareStartConvStatus
+ *
+ * @brief   Gets the selected ADC Software start conversion Status.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *
+ * @return  FlagStatus - SET or RESET.
+ */
+
+FlagStatus ADC_GetSoftwareStartConvStatus(ADC_TypeDef *ADCx)
+{
+    FlagStatus bitstatus = RESET;
+
+    if((ADCx->CTLR2 & CTLR2_SWSTART_Set) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      ADC_DiscModeChannelCountConfig
+ *
+ * @brief   Configures the discontinuous mode for the selected ADC regular
+ *        group channel.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          Number - specifies the discontinuous mode regular channel
+ *            count value(1-8).
+ *
+ * @return  None
+ */
+void ADC_DiscModeChannelCountConfig(ADC_TypeDef *ADCx, uint8_t Number)
+{
+    uint32_t tmpreg1 = 0;
+    uint32_t tmpreg2 = 0;
+
+    tmpreg1 = ADCx->CTLR1;
+    tmpreg1 &= CTLR1_DISCNUM_Reset;
+    tmpreg2 = Number - 1;
+    tmpreg1 |= tmpreg2 << 13;
+    ADCx->CTLR1 = tmpreg1;
+}
+
+/*********************************************************************
+ * @fn      ADC_DiscModeCmd
+ *
+ * @brief   Enables or disables the discontinuous mode on regular group
+ *        channel for the specified ADC.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  None
+ */
+void ADC_DiscModeCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR1 |= CTLR1_DISCEN_Set;
+    }
+    else
+    {
+        ADCx->CTLR1 &= CTLR1_DISCEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_RegularChannelConfig
+ *
+ * @brief   Configures for the selected ADC regular channel its corresponding
+ *        rank in the sequencer and its sample time.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_Channel - the ADC channel to configure.
+ *            ADC_Channel_0 - ADC Channel0 selected.
+ *            ADC_Channel_1 - ADC Channel1 selected.
+ *            ADC_Channel_2 - ADC Channel2 selected.
+ *            ADC_Channel_3 - ADC Channel3 selected.
+ *            ADC_Channel_4 - ADC Channel4 selected.
+ *            ADC_Channel_5 - ADC Channel5 selected.
+ *            ADC_Channel_6 - ADC Channel6 selected.
+ *            ADC_Channel_7 - ADC Channel7 selected.
+ *            ADC_Channel_8 - ADC Channel8 selected.
+ *            ADC_Channel_9 - ADC Channel9 selected.
+ *            ADC_Channel_10 - ADC Channel10 selected.
+ *            ADC_Channel_11 - ADC Channel11 selected.
+ *            ADC_Channel_12 - ADC Channel12 selected.
+ *            ADC_Channel_13 - ADC Channel13 selected.
+ *            ADC_Channel_14 - ADC Channel14 selected.
+ *            ADC_Channel_15 - ADC Channel15 selected.
+ *          Rank - The rank in the regular group sequencer.
+ *            This parameter must be between 1 to 16.
+ *          ADC_SampleTime - The sample time value to be set for the selected channel.
+ *            ADC_SampleTime_4Cycles - Sample time equal to 4 cycles.
+ *            ADC_SampleTime_5Cycles - Sample time equal to 5 cycles.
+ *            ADC_SampleTime_6Cycles - Sample time equal to 6 cycles.
+ *            ADC_SampleTime_7Cycles - Sample time equal to 7 cycles.
+ *            ADC_SampleTime_8Cycles - Sample time equal to 8 cycles.
+ *            ADC_SampleTime_9Cycles - Sample time equal to 9 cycles.
+ *            ADC_SampleTime_10Cycles - Sample time equal to 10 cycles.
+ *            ADC_SampleTime_11Cycles - Sample time equal to 11 cycles.
+ *
+ * @return  None
+ */
+void ADC_RegularChannelConfig(ADC_TypeDef *ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime)
+{
+    uint32_t tmpreg1 = 0, tmpreg2 = 0;
+
+    if(ADC_Channel > ADC_Channel_9)
+    {
+        tmpreg1 = ADCx->SAMPTR1;
+        tmpreg2 = SAMPTR1_SMP_Set << (3 * (ADC_Channel - 10));
+        tmpreg1 &= ~tmpreg2;
+        tmpreg2 = (uint32_t)ADC_SampleTime << (3 * (ADC_Channel - 10));
+        tmpreg1 |= tmpreg2;
+        ADCx->SAMPTR1 = tmpreg1;
+    }
+    else
+    {
+        tmpreg1 = ADCx->SAMPTR2;
+        tmpreg2 = SAMPTR2_SMP_Set << (3 * ADC_Channel);
+        tmpreg1 &= ~tmpreg2;
+        tmpreg2 = (uint32_t)ADC_SampleTime << (3 * ADC_Channel);
+        tmpreg1 |= tmpreg2;
+        ADCx->SAMPTR2 = tmpreg1;
+    }
+
+    if(Rank < 7)
+    {
+        tmpreg1 = ADCx->RSQR3;
+        tmpreg2 = RSQR3_SQ_Set << (5 * (Rank - 1));
+        tmpreg1 &= ~tmpreg2;
+        tmpreg2 = (uint32_t)ADC_Channel << (5 * (Rank - 1));
+        tmpreg1 |= tmpreg2;
+        ADCx->RSQR3 = tmpreg1;
+    }
+    else if(Rank < 13)
+    {
+        tmpreg1 = ADCx->RSQR2;
+        tmpreg2 = RSQR2_SQ_Set << (5 * (Rank - 7));
+        tmpreg1 &= ~tmpreg2;
+        tmpreg2 = (uint32_t)ADC_Channel << (5 * (Rank - 7));
+        tmpreg1 |= tmpreg2;
+        ADCx->RSQR2 = tmpreg1;
+    }
+    else
+    {
+        tmpreg1 = ADCx->RSQR1;
+        tmpreg2 = RSQR1_SQ_Set << (5 * (Rank - 13));
+        tmpreg1 &= ~tmpreg2;
+        tmpreg2 = (uint32_t)ADC_Channel << (5 * (Rank - 13));
+        tmpreg1 |= tmpreg2;
+        ADCx->RSQR1 = tmpreg1;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_ExternalTrigConvCmd
+ *
+ * @brief   Enables or disables the ADCx conversion through external trigger.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  None
+ */
+void ADC_ExternalTrigConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR2 |= CTLR2_EXTTRIG_Set;
+    }
+    else
+    {
+        ADCx->CTLR2 &= CTLR2_EXTTRIG_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_GetConversionValue
+ *
+ * @brief   Returns the last ADCx conversion result data for regular channel.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *
+ * @return  ADCx->RDATAR - The Data conversion value.
+ */
+uint16_t ADC_GetConversionValue(ADC_TypeDef *ADCx)
+{
+    return (uint16_t)ADCx->RDATAR;
+}
+
+/*********************************************************************
+ * @fn      ADC_GetDualModeConversionValue
+ *
+ * @brief   Returns the last ADC1 conversion result data in dual mode.
+ *
+ * @return  RDATAR_ADDRESS - The Data conversion value.
+ */
+uint32_t ADC_GetDualModeConversionValue(void)
+{
+    return (*(__IO uint32_t *)RDATAR_ADDRESS);
+}
+
+/*********************************************************************
+ * @fn      ADC_AutoInjectedConvCmd
+ *
+ * @brief   Enables or disables the selected ADC automatic injected group
+ *        conversion after regular one.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  None
+ */
+void ADC_AutoInjectedConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR1 |= CTLR1_JAUTO_Set;
+    }
+    else
+    {
+        ADCx->CTLR1 &= CTLR1_JAUTO_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_InjectedDiscModeCmd
+ *
+ * @brief   Enables or disables the discontinuous mode for injected group
+ *        channel for the specified ADC.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  None
+ */
+void ADC_InjectedDiscModeCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR1 |= CTLR1_JDISCEN_Set;
+    }
+    else
+    {
+        ADCx->CTLR1 &= CTLR1_JDISCEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_ExternalTrigInjectedConvConfig
+ *
+ * @brief   Configures the ADCx external trigger for injected channels conversion.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_ExternalTrigInjecConv - specifies the ADC trigger to start
+ *        injected conversion.
+ *            ADC_ExternalTrigInjecConv_T1_CC3 - Timer1 TRGO event selected.
+ *            ADC_ExternalTrigInjecConv_T1_CC4 - Timer1 capture compare4 selected.
+ *            ADC_ExternalTrigInjecConv_T2_CC3 - Timer2 capture compare3 selected.
+ *            ADC_ExternalTrigInjecConv_T2_CC4 - Timer2 capture compare4 selected.
+ *            ADC_ExternalTrigInjecConv_T2_CC2 - Timer2 capture compare2 selected.
+ *            ADC_ExternalTrigInjecConv_T3_CC2 - Timer3 capture compare2 selected.
+ *            ADC_ExternalTrigInjecConv_ADC_ETRGREG - ADC ETRGREG selected.
+ *            ADC_ExternalTrigInjecConv_None: Injected conversion started
+ *        by software and not by external trigger.
+ *
+ * @return  None
+ */
+void ADC_ExternalTrigInjectedConvConfig(ADC_TypeDef *ADCx, uint32_t ADC_ExternalTrigInjecConv)
+{
+    uint32_t tmpreg = 0;
+
+    tmpreg = ADCx->CTLR2;
+    tmpreg &= CTLR2_JEXTSEL_Reset;
+    tmpreg |= ADC_ExternalTrigInjecConv;
+    ADCx->CTLR2 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      ADC_ExternalTrigInjectedConvCmd
+ *
+ * @brief   Enables or disables the ADCx injected channels conversion through
+ *        external trigger.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  None
+ */
+void ADC_ExternalTrigInjectedConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR2 |= CTLR2_JEXTTRIG_Set;
+    }
+    else
+    {
+        ADCx->CTLR2 &= CTLR2_JEXTTRIG_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_SoftwareStartInjectedConvCmd
+ *
+ * @brief   Enables or disables the selected ADC start of the injected
+ *        channels conversion.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  None
+ */
+void ADC_SoftwareStartInjectedConvCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        ADCx->CTLR2 |= CTLR2_JEXTTRIG_JSWSTART_Set;
+    }
+    else
+    {
+        ADCx->CTLR2 &= CTLR2_JEXTTRIG_JSWSTART_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_GetSoftwareStartInjectedConvCmdStatus
+ *
+ * @brief   Gets the selected ADC Software start injected conversion Status.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *
+ * @return  FlagStatus: SET or RESET.
+ */
+FlagStatus ADC_GetSoftwareStartInjectedConvCmdStatus(ADC_TypeDef *ADCx)
+{
+    FlagStatus bitstatus = RESET;
+
+    if((ADCx->CTLR2 & CTLR2_JSWSTART_Set) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      ADC_InjectedChannelConfig
+ *
+ * @brief   Configures for the selected ADC injected channel its corresponding
+ *        rank in the sequencer and its sample time.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_Channel - the ADC channel to configure.
+ *            ADC_Channel_0 - ADC Channel0 selected.
+ *            ADC_Channel_1 - ADC Channel1 selected.
+ *            ADC_Channel_2 - ADC Channel2 selected.
+ *            ADC_Channel_3 - ADC Channel3 selected.
+ *            ADC_Channel_4 - ADC Channel4 selected.
+ *            ADC_Channel_5 - ADC Channel5 selected.
+ *            ADC_Channel_6 - ADC Channel6 selected.
+ *            ADC_Channel_7 - ADC Channel7 selected.
+ *            ADC_Channel_8 - ADC Channel8 selected.
+ *            ADC_Channel_9 - ADC Channel9 selected.
+ *            ADC_Channel_10 - ADC Channel10 selected.
+ *            ADC_Channel_11 - ADC Channel11 selected.
+ *            ADC_Channel_12 - ADC Channel12 selected.
+ *            ADC_Channel_13 - ADC Channel13 selected.
+ *            ADC_Channel_14 - ADC Channel14 selected.
+ *            ADC_Channel_15 - ADC Channel15 selected.
+ *          Rank - The rank in the regular group sequencer.
+ *            This parameter must be between 1 to 4.
+ *          ADC_SampleTime - The sample time value to be set for the selected channel.
+ *            ADC_SampleTime_4Cycles - Sample time equal to 4 cycles.
+ *            ADC_SampleTime_5Cycles - Sample time equal to 5 cycles.
+ *            ADC_SampleTime_6Cycles - Sample time equal to 6 cycles.
+ *            ADC_SampleTime_7Cycles - Sample time equal to 7 cycles.
+ *            ADC_SampleTime_8Cycles - Sample time equal to 8 cycles.
+ *            ADC_SampleTime_9Cycles - Sample time equal to 9 cycles.
+ *            ADC_SampleTime_10Cycles - Sample time equal to 10 cycles.
+ *            ADC_SampleTime_11Cycles - Sample time equal to 11 cycles.
+ *
+ * @return  None
+ */
+void ADC_InjectedChannelConfig(ADC_TypeDef *ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime)
+{
+    uint32_t tmpreg1 = 0, tmpreg2 = 0, tmpreg3 = 0;
+
+    if(ADC_Channel > ADC_Channel_9)
+    {
+        tmpreg1 = ADCx->SAMPTR1;
+        tmpreg2 = SAMPTR1_SMP_Set << (3 * (ADC_Channel - 10));
+        tmpreg1 &= ~tmpreg2;
+        tmpreg2 = (uint32_t)ADC_SampleTime << (3 * (ADC_Channel - 10));
+        tmpreg1 |= tmpreg2;
+        ADCx->SAMPTR1 = tmpreg1;
+    }
+    else
+    {
+        tmpreg1 = ADCx->SAMPTR2;
+        tmpreg2 = SAMPTR2_SMP_Set << (3 * ADC_Channel);
+        tmpreg1 &= ~tmpreg2;
+        tmpreg2 = (uint32_t)ADC_SampleTime << (3 * ADC_Channel);
+        tmpreg1 |= tmpreg2;
+        ADCx->SAMPTR2 = tmpreg1;
+    }
+
+    tmpreg1 = ADCx->ISQR;
+    tmpreg3 = (tmpreg1 & ISQR_JL_Set) >> 20;
+    tmpreg2 = ISQR_JSQ_Set << (5 * (uint8_t)((Rank + 3) - (tmpreg3 + 1)));
+    tmpreg1 &= ~tmpreg2;
+    tmpreg2 = (uint32_t)ADC_Channel << (5 * (uint8_t)((Rank + 3) - (tmpreg3 + 1)));
+    tmpreg1 |= tmpreg2;
+    ADCx->ISQR = tmpreg1;
+}
+
+/*********************************************************************
+ * @fn      ADC_InjectedSequencerLengthConfig
+ *
+ * @brief   Configures the sequencer length for injected channels.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          Length - The sequencer length.
+ *            This parameter must be a number between 1 to 4.
+ *
+ * @return  None
+ */
+void ADC_InjectedSequencerLengthConfig(ADC_TypeDef *ADCx, uint8_t Length)
+{
+    uint32_t tmpreg1 = 0;
+    uint32_t tmpreg2 = 0;
+
+    tmpreg1 = ADCx->ISQR;
+    tmpreg1 &= ISQR_JL_Reset;
+    tmpreg2 = Length - 1;
+    tmpreg1 |= tmpreg2 << 20;
+    ADCx->ISQR = tmpreg1;
+}
+
+/*********************************************************************
+ * @fn      ADC_SetInjectedOffset
+ *
+ * @brief   Set the injected channels conversion value offset.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_InjectedChannel: the ADC injected channel to set its offset.
+ *            ADC_InjectedChannel_1 - Injected Channel1 selected.
+ *            ADC_InjectedChannel_2 - Injected Channel2 selected.
+ *            ADC_InjectedChannel_3 - Injected Channel3 selected.
+ *            ADC_InjectedChannel_4 - Injected Channel4 selected.
+ *          Offset - the offset value for the selected ADC injected channel.
+ *            This parameter must be a 12bit value.
+ *
+ * @return  None
+ */
+void ADC_SetInjectedOffset(ADC_TypeDef *ADCx, uint8_t ADC_InjectedChannel, uint16_t Offset)
+{
+    __IO uint32_t tmp = 0;
+
+    tmp = (uint32_t)ADCx;
+    tmp += ADC_InjectedChannel;
+
+    *(__IO uint32_t *)tmp = (uint32_t)Offset;
+}
+
+/*********************************************************************
+ * @fn      ADC_GetInjectedConversionValue
+ *
+ * @brief   Returns the ADC injected channel conversion result.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_InjectedChannel - the ADC injected channel to set its offset.
+ *            ADC_InjectedChannel_1 - Injected Channel1 selected.
+ *            ADC_InjectedChannel_2 - Injected Channel2 selected.
+ *            ADC_InjectedChannel_3 - Injected Channel3 selected.
+ *            ADC_InjectedChannel_4 - Injected Channel4 selected.
+ *
+ * @return  tmp - The Data conversion value.
+ */
+uint16_t ADC_GetInjectedConversionValue(ADC_TypeDef *ADCx, uint8_t ADC_InjectedChannel)
+{
+    __IO uint32_t tmp = 0;
+
+    tmp = (uint32_t)ADCx;
+    tmp += ADC_InjectedChannel + IDATAR_Offset;
+
+    return (uint16_t)(*(__IO uint32_t *)tmp);
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdogCmd
+ *
+ * @brief   Enables or disables the analog watchdog on single/all regular
+ *        or injected channels.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_AnalogWatchdog - the ADC analog watchdog configuration.
+ *            ADC_AnalogWatchdog_SingleRegEnable - Analog watchdog on a
+ *        single regular channel.
+ *            ADC_AnalogWatchdog_SingleInjecEnable - Analog watchdog on a
+ *        single injected channel.
+ *            ADC_AnalogWatchdog_SingleRegOrInjecEnable - Analog watchdog
+ *        on a single regular or injected channel.
+ *            ADC_AnalogWatchdog_AllRegEnable - Analog watchdog on  all
+ *        regular channel.
+ *            ADC_AnalogWatchdog_AllInjecEnable - Analog watchdog on  all
+ *        injected channel.
+ *            ADC_AnalogWatchdog_AllRegAllInjecEnable - Analog watchdog on
+ *        all regular and injected channels.
+ *            ADC_AnalogWatchdog_None - No channel guarded by the analog
+ *        watchdog.
+ *
+ * @return  none
+ */
+void ADC_AnalogWatchdogCmd(ADC_TypeDef *ADCx, uint32_t ADC_AnalogWatchdog)
+{
+    uint32_t tmpreg = 0;
+
+    tmpreg = ADCx->CTLR1;
+    tmpreg &= CTLR1_AWDMode_Reset;
+    tmpreg |= ADC_AnalogWatchdog;
+    ADCx->CTLR1 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdogThresholdsConfig
+ *
+ * @brief   Configures the high and low thresholds of the analog watchdog.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          HighThreshold - the ADC analog watchdog High threshold value.
+ *            This parameter must be a 12bit value.
+ *          LowThreshold - the ADC analog watchdog Low threshold value.
+ *            This parameter must be a 12bit value.
+ *
+ * @return  none
+ */
+void ADC_AnalogWatchdogThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold,
+                                        uint16_t LowThreshold)
+{
+    ADCx->WDHTR = HighThreshold;
+    ADCx->WDLTR = LowThreshold;
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdog1ThresholdsConfig
+ *
+ * @brief   Configures the high and low thresholds of the analog watchdog1.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          HighThreshold - the ADC analog watchdog1 High threshold value.
+ *            This parameter must be a 12bit value.
+ *          LowThreshold - the ADC analog watchdog1 Low threshold value.
+ *            This parameter must be a 12bit value.
+ *
+ * @return  none
+ */
+void ADC_AnalogWatchdog1ThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold,
+                                        uint16_t LowThreshold)
+{
+    ADCx->WDTR1 = (uint32_t)HighThreshold<<16;
+    ADCx->WDTR1 |= (uint32_t)LowThreshold;
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdog2ThresholdsConfig
+ *
+ * @brief   Configures the high and low thresholds of the analog watchdog2.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          HighThreshold - the ADC analog watchdog2 High threshold value.
+ *            This parameter must be a 12bit value.
+ *          LowThreshold - the ADC analog watchdog2 Low threshold value.
+ *            This parameter must be a 12bit value.
+ *
+ * @return  none
+ */
+void ADC_AnalogWatchdog2ThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold,
+                                        uint16_t LowThreshold)
+{
+    ADCx->WDTR2 = (uint32_t)HighThreshold<<16;
+    ADCx->WDTR2 |= (uint32_t)LowThreshold;
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdog3ThresholdsConfig
+ *
+ * @brief   Configures the high and low thresholds of the analog watchdog3.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          HighThreshold - the ADC analog watchdog3 High threshold value.
+ *            This parameter must be a 12bit value.
+ *          LowThreshold - the ADC analog watchdog3 Low threshold value.
+ *            This parameter must be a 12bit value.
+ *
+ * @return  none
+ */
+void ADC_AnalogWatchdog3ThresholdsConfig(ADC_TypeDef *ADCx, uint16_t HighThreshold,
+                                        uint16_t LowThreshold)
+{
+    ADCx->WDTR3 = (uint32_t)HighThreshold<<16;
+    ADCx->WDTR3 |= (uint32_t)LowThreshold;
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdogSingleChannelConfig
+ *
+ * @brief   Configures the analog watchdog guarded single channel.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_Channel - the ADC channel to configure.
+ *            ADC_Channel_0 - ADC Channel0 selected.
+ *            ADC_Channel_1 - ADC Channel1 selected.
+ *            ADC_Channel_2 - ADC Channel2 selected.
+ *            ADC_Channel_3 - ADC Channel3 selected.
+ *            ADC_Channel_4 - ADC Channel4 selected.
+ *            ADC_Channel_5 - ADC Channel5 selected.
+ *            ADC_Channel_6 - ADC Channel6 selected.
+ *            ADC_Channel_7 - ADC Channel7 selected.
+ *            ADC_Channel_8 - ADC Channel8 selected.
+ *            ADC_Channel_9 - ADC Channel9 selected.
+ *            ADC_Channel_10 - ADC Channel10 selected.
+ *            ADC_Channel_11 - ADC Channel11 selected.
+ *            ADC_Channel_12 - ADC Channel12 selected.
+ *            ADC_Channel_13 - ADC Channel13 selected.
+ *            ADC_Channel_14 - ADC Channel14 selected.
+ *            ADC_Channel_15 - ADC Channel15 selected.
+ *
+ * @return  None
+ */
+void ADC_AnalogWatchdogSingleChannelConfig(ADC_TypeDef *ADCx, uint8_t ADC_Channel)
+{
+    uint32_t tmpreg = 0;
+
+    tmpreg = ADCx->CTLR1;
+    tmpreg &= CTLR1_AWDCH_Reset;
+    tmpreg |= ADC_Channel;
+    ADCx->CTLR1 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      ADC_GetFlagStatus
+ *
+ * @brief   Checks whether the specified ADC flag is set or not.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_FLAG - specifies the flag to check.
+ *            ADC_FLAG_AWD - Analog watchdog flag.
+ *            ADC_FLAG_EOC - End of conversion flag.
+ *            ADC_FLAG_JEOC - End of injected group conversion flag.
+ *            ADC_FLAG_JSTRT - Start of injected group conversion flag.
+ *            ADC_FLAG_STRT - Start of regular group conversion flag.
+ *
+ * @return  FlagStatus: SET or RESET.
+ */
+FlagStatus ADC_GetFlagStatus(ADC_TypeDef *ADCx, uint8_t ADC_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+    if((ADCx->STATR & ADC_FLAG) != (uint8_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      ADC_ClearFlag
+ *
+ * @brief   Clears the ADCx's pending flags.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_FLAG - specifies the flag to clear.
+ *            ADC_FLAG_AWD - Analog watchdog flag.
+ *            ADC_FLAG_EOC - End of conversion flag.
+ *            ADC_FLAG_JEOC - End of injected group conversion flag.
+ *            ADC_FLAG_JSTRT - Start of injected group conversion flag.
+ *            ADC_FLAG_STRT - Start of regular group conversion flag.
+ *
+ * @return  none
+ */
+void ADC_ClearFlag(ADC_TypeDef *ADCx, uint8_t ADC_FLAG)
+{
+    ADCx->STATR = ~(uint32_t)ADC_FLAG;
+}
+
+/*********************************************************************
+ * @fn      ADC_GetITStatus
+ *
+ * @brief   Checks whether the specified ADC interrupt has occurred or not.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_IT - specifies the ADC interrupt source to check.
+ *            ADC_IT_EOC - End of conversion interrupt mask.
+ *            ADC_IT_AWD - Analog watchdog interrupt mask.
+ *            ADC_IT_JEOC - End of injected conversion interrupt mask.
+ *
+ * @return  FlagStatus: SET or RESET.
+ */
+ITStatus ADC_GetITStatus(ADC_TypeDef *ADCx, uint16_t ADC_IT)
+{
+    ITStatus bitstatus = RESET;
+    uint32_t itmask = 0, enablestatus = 0;
+
+    itmask = ADC_IT >> 8;
+    enablestatus = (ADCx->CTLR1 & (uint8_t)ADC_IT);
+
+    if(((ADCx->STATR & itmask) != (uint32_t)RESET) && enablestatus)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      ADC_ClearITPendingBit
+ *
+ * @brief   Clears the ADCx's interrupt pending bits.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_IT - specifies the ADC interrupt pending bit to clear.
+ *            ADC_IT_EOC - End of conversion interrupt mask.
+ *            ADC_IT_AWD - Analog watchdog interrupt mask.
+ *            ADC_IT_JEOC - End of injected conversion interrupt mask.
+ *
+ * @return  none
+ */
+void ADC_ClearITPendingBit(ADC_TypeDef *ADCx, uint16_t ADC_IT)
+{
+    uint8_t itmask = 0;
+
+    itmask = (uint8_t)(ADC_IT >> 8);
+    ADCx->STATR = ~(uint32_t)itmask;
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdogResetCmd
+ *
+ * @brief   Enables or disables the analog watchdog reset
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_AnalogWatchdog_x -  Analog watchdog X.
+ *            ADC_AnalogWatchdog_0_RST_EN.
+ *            ADC_AnalogWatchdog_1_RST_EN.
+ *            ADC_AnalogWatchdog_2_RST_EN.
+ *            ADC_AnalogWatchdog_3_RST_EN.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void ADC_AnalogWatchdogResetCmd(ADC_TypeDef *ADCx, uint32_t ADC_AnalogWatchdog_x, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+      ADCx->CTLR3 |= ADC_AnalogWatchdog_x;
+  }
+  else
+  {
+      ADCx->CTLR3 &= ~ADC_AnalogWatchdog_x;
+  }
+}
+
+/*********************************************************************
+ * @fn      ADC_AnalogWatchdogScanCmd
+ *
+ * @brief   Enable ADC clock duty cycle adjustment.
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void ADC_AnalogWatchdogScanCmd(ADC_TypeDef *ADCx, FunctionalState NewState)
+{
+    if (NewState != DISABLE)
+    {
+      ADCx->CTLR3 |= (1<<9);
+    }
+    else
+    {
+      ADCx->CTLR3 &= ~(1<<9);
+    }
+}
+
+/*********************************************************************
+ * @fn      ADC_CLKConfig
+ *
+ * @brief   Configures the PADC clock.
+ *          Note - ADC_CLK_Div_x > H_Level_Cycles_x
+ *
+ * @param   ADCx - where x can be 1 to select the ADC peripheral.
+ *          ADC_CLK_Div_x - defines the ADC clock divider.
+ *            ADC_CLK_Div4 - ADC clock = SYSCLK/4
+ *            ADC_CLK_Div5 - ADC clock = SYSCLK/5
+ *            ADC_CLK_Div6 - ADC clock = SYSCLK/6
+ *            ADC_CLK_Div7 - ADC clock = SYSCLK/7
+ *            ADC_CLK_Div8 - ADC clock = SYSCLK/8
+ *            ADC_CLK_Div9 - ADC clock = SYSCLK/9
+ *            ADC_CLK_Div10 - ADC clock = SYSCLK/10
+ *            ADC_CLK_Div11 - ADC clock = SYSCLK/11
+ *            ADC_CLK_Div12 - ADC clock = SYSCLK/12
+ *            ADC_CLK_Div13 - ADC clock = SYSCLK/13
+ *            ADC_CLK_Div14 - ADC clock = SYSCLK/14
+ *            ADC_CLK_Div15 - ADC clock = SYSCLK/15
+ *            ADC_CLK_Div16 - ADC clock = SYSCLK/16
+ * @return  none
+ */
+void ADC_CLKConfig(ADC_TypeDef *ADCx, uint32_t ADC_CLK_Div_x)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = ADCx->CTLR3;
+
+  tmpreg &= CTLR3_CLK_Mask;
+  tmpreg |= ADC_CLK_Div_x;
+  ADCx->CTLR3 = tmpreg;
+}
+

--- a/Peripheral/ch32x035/src/ch32x035_awu.c
+++ b/Peripheral/ch32x035/src/ch32x035_awu.c
@@ -1,0 +1,92 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_awu.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the AWU firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_awu.h"
+
+/* PSC registers bit mask */
+#define AWUPSC_MASK      ((uint32_t)0xFFFFFFF0)
+
+/* WR register bit mask */
+#define AWUWR_MASK       ((uint32_t)0xFFFFFFC0)
+
+/*********************************************************************
+ * @fn      AutoWakeUpCmd
+ *
+ * @brief   Enables or disables the Auto WakeUp functionality.
+ *
+ * @param   NewState - new state of the Auto WakeUp functionality
+ *        (ENABLE or DISABLE).
+ *
+ * @return  none
+ */
+void AutoWakeUpCmd(FunctionalState NewState)
+{
+    if(NewState)
+    {
+        AWU->CSR |= (1 << 1);
+    }
+    else
+    {
+        AWU->CSR &= ~(1 << 1);
+    }
+}
+
+/*********************************************************************
+ * @fn      AWU_SetPrescaler
+ *
+ * @brief   Sets the Auto Wake up Prescaler
+ *
+ * @param   AWU_Prescaler - specifies the Auto Wake up Prescaler
+ *            AWU_Prescaler_1 - AWU counter clock = LSI/1
+ *            AWU_Prescaler_2 - AWU counter clock = LSI/2
+ *            AWU_Prescaler_4 - AWU counter clock = LSI/4
+ *            AWU_Prescaler_8 - AWU counter clock = LSI/8
+ *            AWU_Prescaler_16 - AWU counter clock = LSI/16
+ *            AWU_Prescaler_32 - AWU counter clock = LSI/32
+ *            AWU_Prescaler_64 - AWU counter clock = LSI/64
+ *            AWU_Prescaler_128 - AWU counter clock = LSI/128
+ *            AWU_Prescaler_256 - AWU counter clock = LSI/256
+ *            AWU_Prescaler_512 - AWU counter clock = LSI/512
+ *            AWU_Prescaler_1024 - AWU counter clock = LSI/1024
+ *            AWU_Prescaler_2048 - AWU counter clock = LSI/2048
+ *            AWU_Prescaler_4096 - AWU counter clock = LSI/4096
+ *            AWU_Prescaler_10240 - AWU counter clock = LSI/10240
+ *            AWU_Prescaler_61440 - AWU counter clock = LSI/61440
+ *
+ * @return  none
+ */
+void AWU_SetPrescaler(uint32_t AWU_Prescaler)
+{
+    uint32_t tmpreg = 0;
+    tmpreg = AWU->PSC & AWUPSC_MASK;
+    tmpreg |= AWU_Prescaler;
+    AWU->PSC = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      AWU_SetWindowValue
+ *
+ * @brief   Sets the WWDG window value
+ *
+ * @param   WindowValue - specifies the window value to be compared to the
+ *        downcounter,which must be lower than 0x3F
+ *
+ * @return  none
+ */
+void AWU_SetWindowValue(uint8_t WindowValue)
+{
+    __IO uint32_t tmpreg = 0;
+
+    tmpreg = AWU->WR & AWUWR_MASK;
+    tmpreg |= WindowValue;
+
+    AWU->WR = tmpreg;
+}

--- a/Peripheral/ch32x035/src/ch32x035_dbgmcu.c
+++ b/Peripheral/ch32x035/src/ch32x035_dbgmcu.c
@@ -1,0 +1,119 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_dbgmcu.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the DBGMCU firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_dbgmcu.h"
+
+#define IDCODE_DEVID_MASK    ((uint32_t)0x0000FFFF)
+
+/*********************************************************************
+ * @fn      DBGMCU_GetREVID
+ *
+ * @brief   Returns the device revision identifier.
+ *
+ * @return  Revision identifier.
+ */
+uint32_t DBGMCU_GetREVID(void)
+{
+	return ((*(uint32_t *)0x1FFFF704) >> 16);
+}
+
+/*********************************************************************
+ * @fn      DBGMCU_GetDEVID
+ *
+ * @brief   Returns the device identifier.
+ *
+ * @return  Device identifier.
+ */
+uint32_t DBGMCU_GetDEVID(void)
+{
+	return ((*(uint32_t *)0x1FFFF704) & IDCODE_DEVID_MASK);
+}
+
+/*********************************************************************
+ * @fn      __get_DEBUG_CR
+ *
+ * @brief   Return the DEBUGE Control Register
+ *
+ * @return  DEBUGE Control value
+ */
+uint32_t __get_DEBUG_CR(void)
+{
+	uint32_t result;
+
+	__asm volatile("csrr %0,""0x7C0" : "=r"(result));
+	return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_DEBUG_CR
+ *
+ * @brief   Set the DEBUGE Control Register
+ *
+ * @param   value  - set DEBUGE Control value
+ *
+ * @return  none
+ */
+void __set_DEBUG_CR(uint32_t value)
+{
+	__asm volatile("csrw 0x7C0, %0" : : "r"(value));
+}
+
+
+/*********************************************************************
+ * @fn      DBGMCU_Config
+ *
+ * @brief   Configures the specified peripheral and low power mode behavior
+ *        when the MCU under Debug mode.
+ *
+ * @param   DBGMCU_Periph - specifies the peripheral and low power mode.
+ *            DBGMCU_IWDG_STOP - Debug IWDG stopped when Core is halted
+ *            DBGMCU_WWDG_STOP - Debug WWDG stopped when Core is halted
+ *            DBGMCU_TIM1_STOP - TIM1 counter stopped when Core is halted
+ *            DBGMCU_TIM2_STOP - TIM2 counter stopped when Core is halted
+ *            DBGMCU_TIM3_STOP - TIM3 counter stopped when Core is halted
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void DBGMCU_Config(uint32_t DBGMCU_Periph, FunctionalState NewState)
+{
+	uint32_t val;
+
+	if(NewState != DISABLE)
+	{
+		__set_DEBUG_CR(DBGMCU_Periph);
+	}
+	else
+	{
+		val = __get_DEBUG_CR();
+		val &= ~(uint32_t)DBGMCU_Periph;
+		__set_DEBUG_CR(val);
+	}
+
+}
+/*********************************************************************
+ * @fn      DBGMCU_GetCHIPID
+ *
+ * @brief   Returns the CHIP identifier.
+ *
+ * @return Device identifier.
+ *          ChipID List-
+ *	CH32X035R8T6-0x035006x1
+ *  CH32X035C8T6-0x035106x1
+ *  CH32X035F8U6-0x035E06x1
+ *  CH32X035G8U6-0x035606x1
+ *  CH32X035G8R6-0x035B06x1
+ *  CH32X035F7P6-0x035706x1
+ */
+uint32_t DBGMCU_GetCHIPID( void )
+{
+	return( *( uint32_t * )0x1FFFF704 );
+}

--- a/Peripheral/ch32x035/src/ch32x035_dma.c
+++ b/Peripheral/ch32x035/src/ch32x035_dma.c
@@ -1,0 +1,432 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_dma.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the DMA firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_dma.h"
+#include "ch32x035_rcc.h"
+
+/* DMA1 Channelx interrupt pending bit masks */
+#define DMA1_Channel1_IT_Mask    ((uint32_t)(DMA_GIF1 | DMA_TCIF1 | DMA_HTIF1 | DMA_TEIF1))
+#define DMA1_Channel2_IT_Mask    ((uint32_t)(DMA_GIF2 | DMA_TCIF2 | DMA_HTIF2 | DMA_TEIF2))
+#define DMA1_Channel3_IT_Mask    ((uint32_t)(DMA_GIF3 | DMA_TCIF3 | DMA_HTIF3 | DMA_TEIF3))
+#define DMA1_Channel4_IT_Mask    ((uint32_t)(DMA_GIF4 | DMA_TCIF4 | DMA_HTIF4 | DMA_TEIF4))
+#define DMA1_Channel5_IT_Mask    ((uint32_t)(DMA_GIF5 | DMA_TCIF5 | DMA_HTIF5 | DMA_TEIF5))
+#define DMA1_Channel6_IT_Mask    ((uint32_t)(DMA_GIF6 | DMA_TCIF6 | DMA_HTIF6 | DMA_TEIF6))
+#define DMA1_Channel7_IT_Mask    ((uint32_t)(DMA_GIF7 | DMA_TCIF7 | DMA_HTIF7 | DMA_TEIF7))
+#define DMA1_Channel8_IT_Mask    ((uint32_t)(DMA_GIF8 | DMA_TCIF8 | DMA_HTIF8 | DMA_TEIF8))
+
+/* DMA2 FLAG mask */
+#define FLAG_Mask                ((uint32_t)0x10000000)
+
+/* DMA registers Masks */
+#define CFGR_CLEAR_Mask          ((uint32_t)0xFFFF800F)
+
+/*********************************************************************
+ * @fn      DMA_DeInit
+ *
+ * @brief   Deinitializes the DMAy Channelx registers to their default
+ *        reset values.
+ *
+ * @param   DMAy_Channelx - here y can be 1 to select the DMA and x can be
+ *        1 to 8 for DMA1 to select the DMA Channel.
+ *
+ * @return  none
+ */
+void DMA_DeInit(DMA_Channel_TypeDef *DMAy_Channelx)
+{
+    DMAy_Channelx->CFGR &= (uint16_t)(~DMA_CFGR1_EN);
+    DMAy_Channelx->CFGR = 0;
+    DMAy_Channelx->CNTR = 0;
+    DMAy_Channelx->PADDR = 0;
+    DMAy_Channelx->MADDR = 0;
+    if(DMAy_Channelx == DMA1_Channel1)
+    {
+        DMA1->INTFCR |= DMA1_Channel1_IT_Mask;
+    }
+    else if(DMAy_Channelx == DMA1_Channel2)
+    {
+        DMA1->INTFCR |= DMA1_Channel2_IT_Mask;
+    }
+    else if(DMAy_Channelx == DMA1_Channel3)
+    {
+        DMA1->INTFCR |= DMA1_Channel3_IT_Mask;
+    }
+    else if(DMAy_Channelx == DMA1_Channel4)
+    {
+        DMA1->INTFCR |= DMA1_Channel4_IT_Mask;
+    }
+    else if(DMAy_Channelx == DMA1_Channel5)
+    {
+        DMA1->INTFCR |= DMA1_Channel5_IT_Mask;
+    }
+    else if(DMAy_Channelx == DMA1_Channel6)
+    {
+        DMA1->INTFCR |= DMA1_Channel6_IT_Mask;
+    }
+    else if(DMAy_Channelx == DMA1_Channel7)
+    {
+        DMA1->INTFCR |= DMA1_Channel7_IT_Mask;
+    }
+    else if(DMAy_Channelx == DMA1_Channel8)
+    {
+        DMA1->INTFCR |= DMA1_Channel8_IT_Mask;
+    }
+}
+
+/*********************************************************************
+ * @fn      DMA_Init
+ *
+ * @brief   Initializes the DMAy Channelx according to the specified
+ *        parameters in the DMA_InitStruct.
+ *
+ * @param   DMAy_Channelx - here y can be 1 to select the DMA and x can be
+ *        1 to 8 for DMA1 to select the DMA Channel.
+ *          DMA_InitStruct - pointer to a DMA_InitTypeDef structure that contains
+ *        contains the configuration information for the specified DMA Channel.
+ *
+ * @return  none
+ */
+void DMA_Init(DMA_Channel_TypeDef *DMAy_Channelx, DMA_InitTypeDef *DMA_InitStruct)
+{
+    uint32_t tmpreg = 0;
+
+    tmpreg = DMAy_Channelx->CFGR;
+    tmpreg &= CFGR_CLEAR_Mask;
+    tmpreg |= DMA_InitStruct->DMA_DIR | DMA_InitStruct->DMA_Mode |
+              DMA_InitStruct->DMA_PeripheralInc | DMA_InitStruct->DMA_MemoryInc |
+              DMA_InitStruct->DMA_PeripheralDataSize | DMA_InitStruct->DMA_MemoryDataSize |
+              DMA_InitStruct->DMA_Priority | DMA_InitStruct->DMA_M2M;
+
+    DMAy_Channelx->CFGR = tmpreg;
+    DMAy_Channelx->CNTR = DMA_InitStruct->DMA_BufferSize;
+    DMAy_Channelx->PADDR = DMA_InitStruct->DMA_PeripheralBaseAddr;
+    DMAy_Channelx->MADDR = DMA_InitStruct->DMA_MemoryBaseAddr;
+}
+
+/*********************************************************************
+ * @fn      DMA_StructInit
+ *
+ * @brief   Fills each DMA_InitStruct member with its default value.
+ *
+ * @param   DMAy_Channelx - here y can be 1 to select the DMA and x can be
+ *        1 to 8 for DMA1 to select the DMA Channel.
+ *          DMA_InitStruct - pointer to a DMA_InitTypeDef structure that contains
+ *        contains the configuration information for the specified DMA Channel.
+ *
+ * @return  none
+ */
+void DMA_StructInit(DMA_InitTypeDef *DMA_InitStruct)
+{
+    DMA_InitStruct->DMA_PeripheralBaseAddr = 0;
+    DMA_InitStruct->DMA_MemoryBaseAddr = 0;
+    DMA_InitStruct->DMA_DIR = DMA_DIR_PeripheralSRC;
+    DMA_InitStruct->DMA_BufferSize = 0;
+    DMA_InitStruct->DMA_PeripheralInc = DMA_PeripheralInc_Disable;
+    DMA_InitStruct->DMA_MemoryInc = DMA_MemoryInc_Disable;
+    DMA_InitStruct->DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
+    DMA_InitStruct->DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
+    DMA_InitStruct->DMA_Mode = DMA_Mode_Normal;
+    DMA_InitStruct->DMA_Priority = DMA_Priority_Low;
+    DMA_InitStruct->DMA_M2M = DMA_M2M_Disable;
+}
+
+/*********************************************************************
+ * @fn      DMA_Cmd
+ *
+ * @brief   Enables or disables the specified DMAy Channelx.
+ *
+ * @param   DMAy_Channelx - here y can be 1 to select the DMA and x can be
+ *        1 to 8 for DMA1 to select the DMA Channel.
+ *          NewState - new state of the DMAy Channelx(ENABLE or DISABLE).
+ *
+ * @return  none
+ */
+void DMA_Cmd(DMA_Channel_TypeDef *DMAy_Channelx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        DMAy_Channelx->CFGR |= DMA_CFGR1_EN;
+    }
+    else
+    {
+        DMAy_Channelx->CFGR &= (uint16_t)(~DMA_CFGR1_EN);
+    }
+}
+
+/*********************************************************************
+ * @fn      DMA_ITConfig
+ *
+ * @brief   Enables or disables the specified DMAy Channelx interrupts.
+ *
+ * @param   DMAy_Channelx - here y can be 1 to select the DMA and x can be
+ *        1 to 8 for DMA1 to select the DMA Channel.
+ *          DMA_IT - specifies the DMA interrupts sources to be enabled
+ *        or disabled.
+ *           DMA_IT_TC - Transfer complete interrupt mask
+ *           DMA_IT_HT - Half transfer interrupt mask
+ *           DMA_IT_TE -  Transfer error interrupt mask
+ *          NewState - new state of the DMAy Channelx(ENABLE or DISABLE).
+ *
+ * @return  none
+ */
+void DMA_ITConfig(DMA_Channel_TypeDef *DMAy_Channelx, uint32_t DMA_IT, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        DMAy_Channelx->CFGR |= DMA_IT;
+    }
+    else
+    {
+        DMAy_Channelx->CFGR &= ~DMA_IT;
+    }
+}
+
+/*********************************************************************
+ * @fn      DMA_SetCurrDataCounter
+ *
+ * @brief   Sets the number of data units in the current DMAy Channelx transfer.
+ *
+ * @param   DMAy_Channelx - here y can be 1 to select the DMA and x can be
+ *        1 to 8 for DMA1 to select the DMA Channel.
+ *          DataNumber - The number of data units in the current DMAy Channelx
+ *        transfer.
+ *
+ * @return  none
+ */
+void DMA_SetCurrDataCounter(DMA_Channel_TypeDef *DMAy_Channelx, uint16_t DataNumber)
+{
+    DMAy_Channelx->CNTR = DataNumber;
+}
+
+/*********************************************************************
+ * @fn      DMA_GetCurrDataCounter
+ *
+ * @brief   Returns the number of remaining data units in the current
+ *        DMAy Channelx transfer.
+ *
+ * @param   DMAy_Channelx - here y can be 1 to select the DMA and x can be
+ *        1 to 8 for DMA1 to select the DMA Channel.
+ *
+ * @return  DataNumber - The number of remaining data units in the current
+ *        DMAy Channelx transfer.
+ */
+uint16_t DMA_GetCurrDataCounter(DMA_Channel_TypeDef *DMAy_Channelx)
+{
+    return ((uint16_t)(DMAy_Channelx->CNTR));
+}
+
+/*********************************************************************
+ * @fn      DMA_GetFlagStatus
+ *
+ * @brief   Checks whether the specified DMAy Channelx flag is set or not.
+ *
+ * @param   DMAy_FLAG - specifies the flag to check.
+ *            DMA1_FLAG_GL1 - DMA1 Channel1 global flag.
+ *            DMA1_FLAG_TC1 - DMA1 Channel1 transfer complete flag.
+ *            DMA1_FLAG_HT1 - DMA1 Channel1 half transfer flag.
+ *            DMA1_FLAG_TE1 - DMA1 Channel1 transfer error flag.
+ *            DMA1_FLAG_GL2 - DMA1 Channel2 global flag.
+ *            DMA1_FLAG_TC2 - DMA1 Channel2 transfer complete flag.
+ *            DMA1_FLAG_HT2 - DMA1 Channel2 half transfer flag.
+ *            DMA1_FLAG_TE2 - DMA1 Channel2 transfer error flag.
+ *            DMA1_FLAG_GL3 - DMA1 Channel3 global flag.
+ *            DMA1_FLAG_TC3 - DMA1 Channel3 transfer complete flag.
+ *            DMA1_FLAG_HT3 - DMA1 Channel3 half transfer flag.
+ *            DMA1_FLAG_TE3 - DMA1 Channel3 transfer error flag.
+ *            DMA1_FLAG_GL4 - DMA1 Channel4 global flag.
+ *            DMA1_FLAG_TC4 - DMA1 Channel4 transfer complete flag.
+ *            DMA1_FLAG_HT4 - DMA1 Channel4 half transfer flag.
+ *            DMA1_FLAG_TE4 - DMA1 Channel4 transfer error flag.
+ *            DMA1_FLAG_GL5 - DMA1 Channel5 global flag.
+ *            DMA1_FLAG_TC5 - DMA1 Channel5 transfer complete flag.
+ *            DMA1_FLAG_HT5 - DMA1 Channel5 half transfer flag.
+ *            DMA1_FLAG_TE5 - DMA1 Channel5 transfer error flag.
+ *            DMA1_FLAG_GL6 - DMA1 Channel6 global flag.
+ *            DMA1_FLAG_TC6 - DMA1 Channel6 transfer complete flag.
+ *            DMA1_FLAG_HT6 - DMA1 Channel6 half transfer flag.
+ *            DMA1_FLAG_TE6 - DMA1 Channel6 transfer error flag.
+ *            DMA1_FLAG_GL7 - DMA1 Channel7 global flag.
+ *            DMA1_FLAG_TC7 - DMA1 Channel7 transfer complete flag.
+ *            DMA1_FLAG_HT7 - DMA1 Channel7 half transfer flag.
+ *            DMA1_FLAG_TE7 - DMA1 Channel7 transfer error flag.
+ *            DMA1_FLAG_GL8 - DMA1 Channel8 global flag.
+ *            DMA1_FLAG_TC8 - DMA1 Channel8 transfer complete flag.
+ *            DMA1_FLAG_HT8 - DMA1 Channel8 half transfer flag.
+ *            DMA1_FLAG_TE8 - DMA1 Channel8 transfer error flag.
+
+ * @return  The new state of DMAy_FLAG (SET or RESET).
+ */
+FlagStatus DMA_GetFlagStatus(uint32_t DMAy_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+    uint32_t   tmpreg = 0;
+
+    tmpreg = DMA1->INTFR;
+
+    if((tmpreg & DMAy_FLAG) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      DMA_ClearFlag
+ *
+ * @brief   Clears the DMAy Channelx's pending flags.
+ *
+ * @param   DMAy_FLAG - specifies the flag to check.
+ *            DMA1_FLAG_GL1 - DMA1 Channel1 global flag.
+ *            DMA1_FLAG_TC1 - DMA1 Channel1 transfer complete flag.
+ *            DMA1_FLAG_HT1 - DMA1 Channel1 half transfer flag.
+ *            DMA1_FLAG_TE1 - DMA1 Channel1 transfer error flag.
+ *            DMA1_FLAG_GL2 - DMA1 Channel2 global flag.
+ *            DMA1_FLAG_TC2 - DMA1 Channel2 transfer complete flag.
+ *            DMA1_FLAG_HT2 - DMA1 Channel2 half transfer flag.
+ *            DMA1_FLAG_TE2 - DMA1 Channel2 transfer error flag.
+ *            DMA1_FLAG_GL3 - DMA1 Channel3 global flag.
+ *            DMA1_FLAG_TC3 - DMA1 Channel3 transfer complete flag.
+ *            DMA1_FLAG_HT3 - DMA1 Channel3 half transfer flag.
+ *            DMA1_FLAG_TE3 - DMA1 Channel3 transfer error flag.
+ *            DMA1_FLAG_GL4 - DMA1 Channel4 global flag.
+ *            DMA1_FLAG_TC4 - DMA1 Channel4 transfer complete flag.
+ *            DMA1_FLAG_HT4 - DMA1 Channel4 half transfer flag.
+ *            DMA1_FLAG_TE4 - DMA1 Channel4 transfer error flag.
+ *            DMA1_FLAG_GL5 - DMA1 Channel5 global flag.
+ *            DMA1_FLAG_TC5 - DMA1 Channel5 transfer complete flag.
+ *            DMA1_FLAG_HT5 - DMA1 Channel5 half transfer flag.
+ *            DMA1_FLAG_TE5 - DMA1 Channel5 transfer error flag.
+ *            DMA1_FLAG_GL6 - DMA1 Channel6 global flag.
+ *            DMA1_FLAG_TC6 - DMA1 Channel6 transfer complete flag.
+ *            DMA1_FLAG_HT6 - DMA1 Channel6 half transfer flag.
+ *            DMA1_FLAG_TE6 - DMA1 Channel6 transfer error flag.
+ *            DMA1_FLAG_GL7 - DMA1 Channel7 global flag.
+ *            DMA1_FLAG_TC7 - DMA1 Channel7 transfer complete flag.
+ *            DMA1_FLAG_HT7 - DMA1 Channel7 half transfer flag.
+ *            DMA1_FLAG_TE7 - DMA1 Channel7 transfer error flag.
+ *            DMA1_FLAG_GL8 - DMA1 Channel8 global flag.
+ *            DMA1_FLAG_TC8 - DMA1 Channel8 transfer complete flag.
+ *            DMA1_FLAG_HT8 - DMA1 Channel8 half transfer flag.
+ *            DMA1_FLAG_TE8 - DMA1 Channel8 transfer error flag.
+ * @return  none
+ */
+void DMA_ClearFlag(uint32_t DMAy_FLAG)
+{
+    DMA1->INTFCR = DMAy_FLAG;
+}
+
+/*********************************************************************
+ * @fn      DMA_GetITStatus
+ *
+ * @brief   Checks whether the specified DMAy Channelx interrupt has
+ *        occurred or not.
+ *
+ * @param   DMAy_IT - specifies the DMAy interrupt source to check.
+ *            DMA1_IT_GL1 - DMA1 Channel1 global flag.
+ *            DMA1_IT_TC1 - DMA1 Channel1 transfer complete flag.
+ *            DMA1_IT_HT1 - DMA1 Channel1 half transfer flag.
+ *            DMA1_IT_TE1 - DMA1 Channel1 transfer error flag.
+ *            DMA1_IT_GL2 - DMA1 Channel2 global flag.
+ *            DMA1_IT_TC2 - DMA1 Channel2 transfer complete flag.
+ *            DMA1_IT_HT2 - DMA1 Channel2 half transfer flag.
+ *            DMA1_IT_TE2 - DMA1 Channel2 transfer error flag.
+ *            DMA1_IT_GL3 - DMA1 Channel3 global flag.
+ *            DMA1_IT_TC3 - DMA1 Channel3 transfer complete flag.
+ *            DMA1_IT_HT3 - DMA1 Channel3 half transfer flag.
+ *            DMA1_IT_TE3 - DMA1 Channel3 transfer error flag.
+ *            DMA1_IT_GL4 - DMA1 Channel4 global flag.
+ *            DMA1_IT_TC4 - DMA1 Channel4 transfer complete flag.
+ *            DMA1_IT_HT4 - DMA1 Channel4 half transfer flag.
+ *            DMA1_IT_TE4 - DMA1 Channel4 transfer error flag.
+ *            DMA1_IT_GL5 - DMA1 Channel5 global flag.
+ *            DMA1_IT_TC5 - DMA1 Channel5 transfer complete flag.
+ *            DMA1_IT_HT5 - DMA1 Channel5 half transfer flag.
+ *            DMA1_IT_TE5 - DMA1 Channel5 transfer error flag.
+ *            DMA1_IT_GL6 - DMA1 Channel6 global flag.
+ *            DMA1_IT_TC6 - DMA1 Channel6 transfer complete flag.
+ *            DMA1_IT_HT6 - DMA1 Channel6 half transfer flag.
+ *            DMA1_IT_TE6 - DMA1 Channel6 transfer error flag.
+ *            DMA1_IT_GL7 - DMA1 Channel7 global flag.
+ *            DMA1_IT_TC7 - DMA1 Channel7 transfer complete flag.
+ *            DMA1_IT_HT7 - DMA1 Channel7 half transfer flag.
+ *            DMA1_IT_TE7 - DMA1 Channel7 transfer error flag.
+ *            DMA1_IT_GL8 - DMA1 Channel8 global flag.
+ *            DMA1_IT_TC8 - DMA1 Channel8 transfer complete flag.
+ *            DMA1_IT_HT8 - DMA1 Channel8 half transfer flag.
+ *            DMA1_IT_TE8 - DMA1 Channel8 transfer error flag.
+ * @return  The new state of DMAy_IT (SET or RESET).
+ */
+ITStatus DMA_GetITStatus(uint32_t DMAy_IT)
+{
+    ITStatus bitstatus = RESET;
+    uint32_t tmpreg = 0;
+
+    tmpreg = DMA1->INTFR;
+
+    if((tmpreg & DMAy_IT) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      DMA_ClearITPendingBit
+ *
+ * @brief   Clears the DMAy Channelx's interrupt pending bits.
+ *
+ * @param   DMAy_IT - specifies the DMAy interrupt source to check.
+ *            DMA1_IT_GL1 - DMA1 Channel1 global flag.
+ *            DMA1_IT_TC1 - DMA1 Channel1 transfer complete flag.
+ *            DMA1_IT_HT1 - DMA1 Channel1 half transfer flag.
+ *            DMA1_IT_TE1 - DMA1 Channel1 transfer error flag.
+ *            DMA1_IT_GL2 - DMA1 Channel2 global flag.
+ *            DMA1_IT_TC2 - DMA1 Channel2 transfer complete flag.
+ *            DMA1_IT_HT2 - DMA1 Channel2 half transfer flag.
+ *            DMA1_IT_TE2 - DMA1 Channel2 transfer error flag.
+ *            DMA1_IT_GL3 - DMA1 Channel3 global flag.
+ *            DMA1_IT_TC3 - DMA1 Channel3 transfer complete flag.
+ *            DMA1_IT_HT3 - DMA1 Channel3 half transfer flag.
+ *            DMA1_IT_TE3 - DMA1 Channel3 transfer error flag.
+ *            DMA1_IT_GL4 - DMA1 Channel4 global flag.
+ *            DMA1_IT_TC4 - DMA1 Channel4 transfer complete flag.
+ *            DMA1_IT_HT4 - DMA1 Channel4 half transfer flag.
+ *            DMA1_IT_TE4 - DMA1 Channel4 transfer error flag.
+ *            DMA1_IT_GL5 - DMA1 Channel5 global flag.
+ *            DMA1_IT_TC5 - DMA1 Channel5 transfer complete flag.
+ *            DMA1_IT_HT5 - DMA1 Channel5 half transfer flag.
+ *            DMA1_IT_TE5 - DMA1 Channel5 transfer error flag.
+ *            DMA1_IT_GL6 - DMA1 Channel6 global flag.
+ *            DMA1_IT_TC6 - DMA1 Channel6 transfer complete flag.
+ *            DMA1_IT_HT6 - DMA1 Channel6 half transfer flag.
+ *            DMA1_IT_TE6 - DMA1 Channel6 transfer error flag.
+ *            DMA1_IT_GL7 - DMA1 Channel7 global flag.
+ *            DMA1_IT_TC7 - DMA1 Channel7 transfer complete flag.
+ *            DMA1_IT_HT7 - DMA1 Channel7 half transfer flag.
+ *            DMA1_IT_TE7 - DMA1 Channel7 transfer error flag.
+ *            DMA1_IT_GL8 - DMA1 Channel8 global flag.
+ *            DMA1_IT_TC8 - DMA1 Channel8 transfer complete flag.
+ *            DMA1_IT_HT8 - DMA1 Channel8 half transfer flag.
+ *            DMA1_IT_TE8 - DMA1 Channel8 transfer error flag.
+ * @return  none
+ */
+void DMA_ClearITPendingBit(uint32_t DMAy_IT)
+{
+    DMA1->INTFCR = DMAy_IT;
+}

--- a/Peripheral/ch32x035/src/ch32x035_exti.c
+++ b/Peripheral/ch32x035/src/ch32x035_exti.c
@@ -1,0 +1,182 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_exti.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the EXTI firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_exti.h"
+
+/* No interrupt selected */
+#define EXTI_LINENONE    ((uint32_t)0x00000)
+
+/*********************************************************************
+ * @fn      EXTI_DeInit
+ *
+ * @brief   Deinitializes the EXTI peripheral registers to their default
+ *        reset values.
+ *
+ * @return  none.
+ */
+void EXTI_DeInit(void)
+{
+    EXTI->INTENR = 0x00000000;
+    EXTI->EVENR = 0x00000000;
+    EXTI->RTENR = 0x00000000;
+    EXTI->FTENR = 0x00000000;
+    EXTI->INTFR = 0x000FFFFF;
+}
+
+/*********************************************************************
+ * @fn      EXTI_Init
+ *
+ * @brief   Initializes the EXTI peripheral according to the specified
+ *        parameters in the EXTI_InitStruct.
+ *
+ * @param   EXTI_InitStruct: pointer to a EXTI_InitTypeDef structure
+ *
+ * @return  none.
+ */
+void EXTI_Init(EXTI_InitTypeDef *EXTI_InitStruct)
+{
+    uint32_t tmp = 0;
+
+    tmp = (uint32_t)EXTI_BASE;
+    if(EXTI_InitStruct->EXTI_LineCmd != DISABLE)
+    {
+        EXTI->INTENR &= ~EXTI_InitStruct->EXTI_Line;
+        EXTI->EVENR &= ~EXTI_InitStruct->EXTI_Line;
+        tmp += EXTI_InitStruct->EXTI_Mode;
+        *(__IO uint32_t *)tmp |= EXTI_InitStruct->EXTI_Line;
+        EXTI->RTENR &= ~EXTI_InitStruct->EXTI_Line;
+        EXTI->FTENR &= ~EXTI_InitStruct->EXTI_Line;
+        if(EXTI_InitStruct->EXTI_Trigger == EXTI_Trigger_Rising_Falling)
+        {
+            EXTI->RTENR |= EXTI_InitStruct->EXTI_Line;
+            EXTI->FTENR |= EXTI_InitStruct->EXTI_Line;
+        }
+        else
+        {
+            tmp = (uint32_t)EXTI_BASE;
+            tmp += EXTI_InitStruct->EXTI_Trigger;
+            *(__IO uint32_t *)tmp |= EXTI_InitStruct->EXTI_Line;
+        }
+    }
+    else
+    {
+        tmp += EXTI_InitStruct->EXTI_Mode;
+        *(__IO uint32_t *)tmp &= ~EXTI_InitStruct->EXTI_Line;
+    }
+}
+
+/*********************************************************************
+ * @fn      EXTI_StructInit
+ *
+ * @brief   Fills each EXTI_InitStruct member with its reset value.
+ *
+ * @param   EXTI_InitStruct - pointer to a EXTI_InitTypeDef structure
+ *
+ * @return  none.
+ */
+void EXTI_StructInit(EXTI_InitTypeDef *EXTI_InitStruct)
+{
+    EXTI_InitStruct->EXTI_Line = EXTI_LINENONE;
+    EXTI_InitStruct->EXTI_Mode = EXTI_Mode_Interrupt;
+    EXTI_InitStruct->EXTI_Trigger = EXTI_Trigger_Falling;
+    EXTI_InitStruct->EXTI_LineCmd = DISABLE;
+}
+
+/*********************************************************************
+ * @fn      EXTI_GenerateSWInterrupt
+ *
+ * @brief   Generates a Software interrupt.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  none.
+ */
+void EXTI_GenerateSWInterrupt(uint32_t EXTI_Line)
+{
+    EXTI->SWIEVR |= EXTI_Line;
+}
+
+/*********************************************************************
+ * @fn      EXTI_GetFlagStatus
+ *
+ * @brief   Checks whether the specified EXTI line flag is set or not.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  The new state of EXTI_Line (SET or RESET).
+ */
+FlagStatus EXTI_GetFlagStatus(uint32_t EXTI_Line)
+{
+    FlagStatus bitstatus = RESET;
+    if((EXTI->INTFR & EXTI_Line) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      EXTI_ClearFlag
+ *
+ * @brief   Clears the EXTI's line pending flags.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  None
+ */
+void EXTI_ClearFlag(uint32_t EXTI_Line)
+{
+    EXTI->INTFR = EXTI_Line;
+}
+
+/*********************************************************************
+ * @fn      EXTI_GetITStatus
+ *
+ * @brief   Checks whether the specified EXTI line is asserted or not.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  The new state of EXTI_Line (SET or RESET).
+ */
+ITStatus EXTI_GetITStatus(uint32_t EXTI_Line)
+{
+    ITStatus bitstatus = RESET;
+    uint32_t enablestatus = 0;
+
+    enablestatus = EXTI->INTENR & EXTI_Line;
+    if(((EXTI->INTFR & EXTI_Line) != (uint32_t)RESET) && (enablestatus != (uint32_t)RESET))
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      EXTI_ClearITPendingBit
+ *
+ * @brief   Clears the EXTI's line pending bits.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  none
+ */
+void EXTI_ClearITPendingBit(uint32_t EXTI_Line)
+{
+    EXTI->INTFR = EXTI_Line;
+}

--- a/Peripheral/ch32x035/src/ch32x035_flash.c
+++ b/Peripheral/ch32x035/src/ch32x035_flash.c
@@ -1,0 +1,743 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_flash.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the FLASH firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_flash.h"
+
+/* Flash Access Control Register bits */
+#define ACR_LATENCY_Mask           ((uint32_t)0x00000038)
+
+/* Flash Control Register bits */
+#define CR_PER_Set                 ((uint32_t)0x00000002)
+#define CR_PER_Reset               ((uint32_t)0xFFFFFFFD)
+#define CR_MER_Set                 ((uint32_t)0x00000004)
+#define CR_MER_Reset               ((uint32_t)0xFFFFFFFB)
+#define CR_OPTPG_Set               ((uint32_t)0x00000010)
+#define CR_OPTPG_Reset             ((uint32_t)0xFFFFFFEF)
+#define CR_OPTER_Set               ((uint32_t)0x00000020)
+#define CR_OPTER_Reset             ((uint32_t)0xFFFFFFDF)
+#define CR_STRT_Set                ((uint32_t)0x00000040)
+#define CR_LOCK_Set                ((uint32_t)0x00000080)
+#define CR_FLOCK_Set               ((uint32_t)0x00008000)
+#define CR_PAGE_PG                 ((uint32_t)0x00010000)
+#define CR_PAGE_ER                 ((uint32_t)0x00020000)
+#define CR_BUF_LOAD                ((uint32_t)0x00040000)
+#define CR_BUF_RST                 ((uint32_t)0x00080000)
+#define CR_BER32                   ((uint32_t)0x00800000)
+
+/* FLASH Status Register bits */
+#define SR_BSY                     ((uint32_t)0x00000001)
+#define SR_WRPRTERR                ((uint32_t)0x00000010)
+#define SR_EOP                     ((uint32_t)0x00000020)
+
+/* FLASH Mask */
+#define RDPRT_Mask                 ((uint32_t)0x00000002)
+#define WRP0_Mask                  ((uint32_t)0x000000FF)
+#define WRP1_Mask                  ((uint32_t)0x0000FF00)
+#define WRP2_Mask                  ((uint32_t)0x00FF0000)
+#define WRP3_Mask                  ((uint32_t)0xFF000000)
+
+/* FLASH Keys */
+#define RDP_Key                    ((uint16_t)0x00A5)
+#define FLASH_KEY1                 ((uint32_t)0x45670123)
+#define FLASH_KEY2                 ((uint32_t)0xCDEF89AB)
+
+/* FLASH BANK address */
+#define FLASH_BANK1_END_ADDRESS    ((uint32_t)0x807FFFF)
+
+/* Delay definition */
+#define EraseTimeout               ((uint32_t)0x000B0000)
+#define ProgramTimeout             ((uint32_t)0x00005000)
+
+/********************************************************************************
+  * @fn            FLASH_SetLatency
+  *
+  * @brief         Sets the code latency value.
+  *
+  * @param         FLASH_Latency - specifies the FLASH Latency value.
+  *                    FLASH_Latency_0 - FLASH Zero Latency cycle
+  *                    FLASH_Latency_1 - FLASH One Latency cycle
+  *                    FLASH_Latency_2 - FLASH Two Latency cycles
+  *
+  * @return         None
+  */
+void FLASH_SetLatency(uint32_t FLASH_Latency)
+{
+    uint32_t tmpreg = 0;
+
+    tmpreg = FLASH->ACTLR;
+    tmpreg &= ACR_LATENCY_Mask;
+    tmpreg |= FLASH_Latency;
+    FLASH->ACTLR = tmpreg;
+}
+
+/********************************************************************************
+ * @fn             FLASH_Unlock
+ *
+ * @brief          Unlocks the FLASH Program Erase Controller.
+ *
+ * @return         None
+ */
+void FLASH_Unlock(void)
+{
+    /* Authorize the FPEC of Bank1 Access */
+    FLASH->KEYR = FLASH_KEY1;
+    FLASH->KEYR = FLASH_KEY2;
+}
+
+/********************************************************************************
+ * @fn             FLASH_Lock
+ *
+ * @brief          Locks the FLASH Program Erase Controller.
+ *
+ * @return         None
+ */
+void FLASH_Lock(void)
+{
+    FLASH->CTLR |= CR_LOCK_Set;
+}
+
+/********************************************************************************
+ * @fn             FLASH_ErasePage
+ *
+ * @brief          Erases a specified FLASH page(1KB).
+ *
+ * @param          Page_Address - The page address to be erased.
+ *
+ * @return         FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *                 FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+ */
+FLASH_Status FLASH_ErasePage(uint32_t Page_Address)
+{
+    FLASH_Status status = FLASH_COMPLETE;
+
+    status = FLASH_WaitForLastOperation(EraseTimeout);
+
+    if(status == FLASH_COMPLETE)
+    {
+        FLASH->CTLR |= CR_PER_Set;
+        FLASH->ADDR = Page_Address;
+        FLASH->CTLR |= CR_STRT_Set;
+
+        status = FLASH_WaitForLastOperation(EraseTimeout);
+
+        FLASH->CTLR &= CR_PER_Reset;
+    }
+
+    return status;
+}
+
+/********************************************************************************
+ * @fn             FLASH_EraseAllPages
+ *
+ * @brief          Erases all FLASH pages.
+ *
+ * @return         FLASH Status - The returned value can be:FLASH_BUSY, FLASH_ERROR_PG,
+ *                 FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+ */
+FLASH_Status FLASH_EraseAllPages(void)
+{
+    FLASH_Status status = FLASH_COMPLETE;
+
+    status = FLASH_WaitForLastOperation(EraseTimeout);
+    if(status == FLASH_COMPLETE)
+    {
+        FLASH->CTLR |= CR_MER_Set;
+        FLASH->CTLR |= CR_STRT_Set;
+
+        status = FLASH_WaitForLastOperation(EraseTimeout);
+
+        FLASH->CTLR &= CR_MER_Reset;
+    }
+
+    return status;
+}
+
+/********************************************************************************
+ * @fn             FLASH_EraseOptionBytes
+ *
+ * @brief          Erases the FLASH option bytes.
+ *
+ * @return         FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *                 FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+ */
+FLASH_Status FLASH_EraseOptionBytes(void)
+{
+    FLASH_Status status = FLASH_COMPLETE;
+
+    status = FLASH_WaitForLastOperation(EraseTimeout);
+    if(status == FLASH_COMPLETE)
+    {
+        FLASH_Unlock();
+
+        FLASH->OBKEYR = FLASH_KEY1;
+        FLASH->OBKEYR = FLASH_KEY2;
+
+        FLASH->CTLR |= CR_OPTER_Set;
+        FLASH->CTLR |= CR_STRT_Set;
+        status = FLASH_WaitForLastOperation(EraseTimeout);
+
+        FLASH->CTLR &= CR_OPTER_Reset;
+
+        FLASH_Lock();
+    }
+    return status;
+}
+
+/*********************************************************************
+ * @fn        FLASH_OptionBytePR
+ *
+ * @brief     Programs option bytes.
+ *
+ * @param     pbuf - data.
+ *
+ * @return    none
+ */
+void FLASH_OptionBytePR(u32* pbuf)
+{
+    uint8_t i;
+
+    FLASH_EraseOptionBytes();
+    FLASH_Unlock_Fast();
+    FLASH_BufReset();
+
+    for(i=0; i<4; i++)
+    {
+        FLASH_BufLoad((OB_BASE + 4*i), *pbuf++);
+    }
+
+    FLASH_ProgramPage_Fast(OB_BASE);
+    FLASH_Lock_Fast();
+}
+
+/*********************************************************************
+ * @fn      FLASH_EnableWriteProtection
+ *
+ * @brief   Write protects the desired sectors
+ *
+ * @param   FLASH_Sectors - specifies the address of the pages to be write protected.
+ *
+ * @return  FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *        FLASH_ERROR_WRP, FLASH_COMPLETE , FLASH_TIMEOUT or FLASH_RDP.
+ */
+FLASH_Status FLASH_EnableWriteProtection(uint32_t FLASH_Pages)
+{
+    uint8_t     WRP0_Data = 0xFF, WRP1_Data = 0xFF, WRP2_Data = 0xFF, WRP3_Data = 0xFF;
+    uint32_t buf[4];
+    uint8_t i;
+    FLASH_Status status = FLASH_COMPLETE;
+
+    if((FLASH->OBR & RDPRT_Mask) != (uint32_t)RESET)
+    {
+        status = FLASH_RDP;
+    }
+    else{
+        FLASH_Pages = (uint32_t)(~FLASH_Pages);
+        WRP0_Data = (uint8_t)(FLASH_Pages & WRP0_Mask);
+        WRP1_Data = (uint8_t)((FLASH_Pages & WRP1_Mask) >> 8);
+        WRP2_Data = (uint8_t)((FLASH_Pages & WRP2_Mask) >> 16);
+        WRP3_Data = (uint8_t)((FLASH_Pages & WRP3_Mask) >> 24);
+
+        status = FLASH_WaitForLastOperation(ProgramTimeout);
+
+        if(status == FLASH_COMPLETE)
+        {
+            for(i=0; i<4; i++){
+                buf[i] = *(uint32_t*)(OB_BASE + 4*i);
+            }
+
+            buf[2] = ((uint32_t)(((uint32_t)(WRP0_Data) & 0x00FF) + (((uint32_t)(~WRP0_Data) & 0x00FF) << 8) \
+                   + (((uint32_t)(WRP1_Data) & 0x00FF) << 16) + (((uint32_t)(~WRP1_Data) & 0x00FF) << 24)));
+            buf[3] = ((uint32_t)(((uint32_t)(WRP2_Data) & 0x00FF) + (((uint32_t)(~WRP2_Data) & 0x00FF) << 8) \
+                   + (((uint32_t)(WRP3_Data) & 0x00FF) << 16) + (((uint32_t)(~WRP3_Data) & 0x00FF) << 24)));
+
+            FLASH_OptionBytePR(buf);
+        }
+    }
+
+    return status;
+}
+
+/*********************************************************************
+ * @fn      FLASH_EnableReadOutProtection
+ *
+ * @brief   Enables the read out protection.
+ *
+ * @param   Newstate - new state of the ReadOut Protection(ENABLE or DISABLE).
+ *
+ * @return  FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *        FLASH_ERROR_WRP, FLASH_COMPLETE, FLASH_TIMEOUT or FLASH_RDP.
+ */
+FLASH_Status FLASH_EnableReadOutProtection(void)
+{
+    FLASH_Status status = FLASH_COMPLETE;
+    uint32_t buf[4];
+    uint8_t i;
+
+    if((FLASH->OBR & RDPRT_Mask) != (uint32_t)RESET)
+    {
+        status = FLASH_RDP;
+    }
+    else{
+        status = FLASH_WaitForLastOperation(EraseTimeout);
+        if(status == FLASH_COMPLETE)
+        {
+            for(i=0; i<4; i++){
+                buf[i] = *(uint32_t*)(OB_BASE + 4*i);
+            }
+
+            buf[0] = 0x000000FF + (buf[0] & 0xFFFF0000);
+            FLASH_OptionBytePR(buf);
+        }
+    }
+
+    return status;
+}
+
+/*********************************************************************
+ * @fn      FLASH_UserOptionByteConfig
+ *
+ * @brief   Programs the FLASH User Option Byte - IWDG_SW / RST_STOP / RST_STDBY.
+ *
+ * @param   OB_IWDG - Selects the IWDG mode
+ *            OB_IWDG_SW - Software IWDG selected
+ *            OB_IWDG_HW - Hardware IWDG selected
+ *          OB_STOP - Reset event when entering STOP mode.
+ *            OB_STOP_NoRST - No reset generated when entering in STOP
+ *            OB_STOP_RST - Reset generated when entering in STOP
+ *          OB_STDBY - Reset event when entering Standby mode.
+ *            OB_STDBY_NoRST - No reset generated when entering in STANDBY
+ *            OB_STDBY_RST - Reset generated when entering in STANDBY
+ *          OB_RST - Selects the reset IO mode and Ignore delay time
+ *            OB_RST_NoEN - Reset IO disable
+ *            OB_RST_EN_DT12ms - Reset IO enable and  Ignore delay time 12ms
+ *            OB_RST_EN_DT1ms - Reset IO enable and  Ignore delay time 1ms
+ *            OB_RST_EN_DT128us - Reset IO enable and  Ignore delay time 128us
+ *
+ * @return  FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *        FLASH_ERROR_WRP, FLASH_COMPLETE , FLASH_TIMEOUT or FLASH_RDP.
+ */
+FLASH_Status FLASH_UserOptionByteConfig(uint8_t OB_IWDG, uint8_t OB_STOP, uint8_t OB_STDBY, uint8_t OB_RST)
+{
+    FLASH_Status status = FLASH_COMPLETE;
+    uint8_t UserByte;
+    uint32_t buf[4];
+    uint8_t i;
+
+    if((FLASH->OBR & RDPRT_Mask) != (uint32_t)RESET)
+    {
+        status = FLASH_RDP;
+    }
+    else{
+        UserByte = OB_IWDG | (uint8_t)(OB_STOP | (uint8_t)(OB_STDBY | (uint8_t)(OB_RST | (uint8_t)0xE0)));
+
+        for(i=0; i<4; i++){
+            buf[i] = *(uint32_t*)(OB_BASE + 4*i);
+        }
+        buf[0] = ((uint32_t)((((uint32_t)(UserByte) & 0x00FF) << 16) + (((uint32_t)(~UserByte) & 0x00FF) << 24))) + 0x00005AA5;
+
+        FLASH_OptionBytePR(buf);
+    }
+
+    return status;
+}
+
+/*********************************************************************
+ * @fn      FLASH_GetUserOptionByte
+ *
+ * @brief   Returns the FLASH User Option Bytes values.
+ *
+ * @return  The FLASH User Option Bytes values:IWDG_SW(Bit0), RST_STOP(Bit1),
+ *          RST_STDBY(Bit2) ,RST_MOD(bit[4:3]) ,DATA0(bit[17:10]) and
+ *          DATA1(bit[25:18]).
+ */
+uint32_t FLASH_GetUserOptionByte(void)
+{
+    return (uint32_t)(FLASH->OBR >> 2);
+}
+
+/*********************************************************************
+ * @fn      FLASH_GetWriteProtectionOptionByte
+ *
+ * @brief   Returns the FLASH Write Protection Option Bytes Register value.
+ *
+ * @return  The FLASH Write Protection Option Bytes Register value.
+ */
+uint32_t FLASH_GetWriteProtectionOptionByte(void)
+{
+    return (uint32_t)(FLASH->WPR);
+}
+
+/*********************************************************************
+ * @fn      FLASH_GetReadOutProtectionStatus
+ *
+ * @brief   Checks whether the FLASH Read Out Protection Status is set or not.
+ *
+ * @return  FLASH ReadOut Protection Status(SET or RESET)
+ */
+FlagStatus FLASH_GetReadOutProtectionStatus(void)
+{
+    FlagStatus readoutstatus = RESET;
+    if((FLASH->OBR & RDPRT_Mask) != (uint32_t)RESET)
+    {
+        readoutstatus = SET;
+    }
+    else
+    {
+        readoutstatus = RESET;
+    }
+    return readoutstatus;
+}
+
+/*********************************************************************
+ * @fn      FLASH_ITConfig
+ *
+ * @brief   Enables or disables the specified FLASH interrupts.
+ *
+ * @param   FLASH_IT - specifies the FLASH interrupt sources to be enabled or disabled.
+ *            FLASH_IT_ERROR - FLASH Error Interrupt
+ *            FLASH_IT_EOP - FLASH end of operation Interrupt
+ *          NewState - new state of the specified Flash interrupts(ENABLE or DISABLE).
+ *
+ * @return  FLASH Prefetch Buffer Status (SET or RESET).
+ */
+void FLASH_ITConfig(uint32_t FLASH_IT, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        FLASH->CTLR |= FLASH_IT;
+    }
+    else
+    {
+        FLASH->CTLR &= ~(uint32_t)FLASH_IT;
+    }
+}
+
+/*********************************************************************
+ * @fn      FLASH_GetFlagStatus
+ *
+ * @brief   Checks whether the specified FLASH flag is set or not.
+ *
+ * @param   FLASH_FLAG - specifies the FLASH flag to check.
+ *            FLASH_FLAG_BSY - FLASH Busy flag
+ *            FLASH_FLAG_WRPRTERR - FLASH Write protected error flag
+ *            FLASH_FLAG_EOP - FLASH End of Operation flag
+ *            FLASH_FLAG_OPTERR - FLASH Option Byte error flag
+ *
+ * @return  The new state of FLASH_FLAG (SET or RESET).
+ */
+FlagStatus FLASH_GetFlagStatus(uint32_t FLASH_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+    if(FLASH_FLAG == FLASH_FLAG_OPTERR)
+    {
+        if((FLASH->OBR & FLASH_FLAG_OPTERR) != (uint32_t)RESET)
+        {
+            bitstatus = SET;
+        }
+        else
+        {
+            bitstatus = RESET;
+        }
+    }
+    else
+    {
+        if((FLASH->STATR & FLASH_FLAG) != (uint32_t)RESET)
+        {
+            bitstatus = SET;
+        }
+        else
+        {
+            bitstatus = RESET;
+        }
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      FLASH_ClearFlag
+ *
+ * @brief   Clears the FLASH's pending flags.
+ *
+ * @param   FLASH_FLAG - specifies the FLASH flags to clear.
+ *            FLASH_FLAG_WRPRTERR - FLASH Write protected error flag
+ *            FLASH_FLAG_EOP - FLASH End of Operation flag
+ *
+ * @return  none
+ */
+void FLASH_ClearFlag(uint32_t FLASH_FLAG)
+{
+    FLASH->STATR = FLASH_FLAG;
+}
+
+/*********************************************************************
+ * @fn      FLASH_GetStatus
+ *
+ * @brief   Returns the FLASH Status.
+ *
+ * @return  FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *        FLASH_ERROR_WRP or FLASH_COMPLETE.
+ */
+FLASH_Status FLASH_GetStatus(void)
+{
+    FLASH_Status flashstatus = FLASH_COMPLETE;
+
+    if((FLASH->STATR & FLASH_FLAG_BSY) == FLASH_FLAG_BSY)
+    {
+        flashstatus = FLASH_BUSY;
+    }
+    else
+    {
+        if((FLASH->STATR & FLASH_FLAG_WRPRTERR) != 0)
+        {
+            flashstatus = FLASH_ERROR_WRP;
+        }
+        else
+        {
+            flashstatus = FLASH_COMPLETE;
+        }
+    }
+    return flashstatus;
+}
+
+/*********************************************************************
+ * @fn      FLASH_GetBank1Status
+ *
+ * @brief   Returns the FLASH Bank1 Status.
+ *
+ * @return  FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *        FLASH_ERROR_WRP or FLASH_COMPLETE.
+ */
+FLASH_Status FLASH_GetBank1Status(void)
+{
+    FLASH_Status flashstatus = FLASH_COMPLETE;
+
+    if((FLASH->STATR & FLASH_FLAG_BANK1_BSY) == FLASH_FLAG_BSY)
+    {
+        flashstatus = FLASH_BUSY;
+    }
+    else
+    {
+        if((FLASH->STATR & FLASH_FLAG_BANK1_WRPRTERR) != 0)
+        {
+            flashstatus = FLASH_ERROR_WRP;
+        }
+        else
+        {
+            flashstatus = FLASH_COMPLETE;
+        }
+    }
+    return flashstatus;
+}
+
+/*********************************************************************
+ * @fn      FLASH_WaitForLastOperation
+ *
+ * @brief   Waits for a Flash operation to complete or a TIMEOUT to occur.
+ *
+ * @param   Timeout - FLASH programming Timeout
+ *
+ * @return  FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *        FLASH_ERROR_WRP or FLASH_COMPLETE.
+ */
+FLASH_Status FLASH_WaitForLastOperation(uint32_t Timeout)
+{
+    FLASH_Status status = FLASH_COMPLETE;
+
+    status = FLASH_GetBank1Status();
+    while((status == FLASH_BUSY) && (Timeout != 0x00))
+    {
+        status = FLASH_GetBank1Status();
+        Timeout--;
+    }
+    if(Timeout == 0x00)
+    {
+        status = FLASH_TIMEOUT;
+    }
+    return status;
+}
+
+/*********************************************************************
+ * @fn      FLASH_WaitForLastBank1Operation
+ *
+ * @brief   Waits for a Flash operation on Bank1 to complete or a TIMEOUT to occur.
+ *
+ * @param   Timeout - FLASH programming Timeout
+ *
+ * @return  FLASH Status - The returned value can be: FLASH_BUSY, FLASH_ERROR_PG,
+ *        FLASH_ERROR_WRP or FLASH_COMPLETE.
+ */
+FLASH_Status FLASH_WaitForLastBank1Operation(uint32_t Timeout)
+{
+    FLASH_Status status = FLASH_COMPLETE;
+
+    status = FLASH_GetBank1Status();
+    while((status == FLASH_FLAG_BANK1_BSY) && (Timeout != 0x00))
+    {
+        status = FLASH_GetBank1Status();
+        Timeout--;
+    }
+    if(Timeout == 0x00)
+    {
+        status = FLASH_TIMEOUT;
+    }
+    return status;
+}
+
+/*********************************************************************
+ * @fn      FLASH_Unlock_Fast
+ *
+ * @brief   Unlocks the Fast Program Erase Mode.
+ *
+ * @return  none
+ */
+void FLASH_Unlock_Fast(void)
+{
+    /* Authorize the FPEC of Bank1 Access */
+    FLASH->KEYR = FLASH_KEY1;
+    FLASH->KEYR = FLASH_KEY2;
+
+    /* Fast program mode unlock */
+    FLASH->MODEKEYR = FLASH_KEY1;
+    FLASH->MODEKEYR = FLASH_KEY2;
+}
+
+/*********************************************************************
+ * @fn      FLASH_Lock_Fast
+ *
+ * @brief   Locks the Fast Program Erase Mode.
+ *
+ * @return  none
+ */
+void FLASH_Lock_Fast(void)
+{
+    FLASH->CTLR |= CR_FLOCK_Set;
+}
+
+/*********************************************************************
+ * @fn      FLASH_BufReset
+ *
+ * @brief   Flash Buffer reset.
+ *
+ * @return  none
+ */
+void FLASH_BufReset(void)
+{
+    FLASH->CTLR |= CR_PAGE_PG;
+    FLASH->CTLR |= CR_BUF_RST;
+    while(FLASH->STATR & SR_BSY)
+        ;
+    FLASH->CTLR &= ~CR_PAGE_PG;
+}
+
+/*********************************************************************
+ * @fn      FLASH_BufLoad
+ *
+ * @brief   Flash Buffer load(4Byte).
+ *
+ * @param   Address - specifies the address to be programmed.
+ *          Data0 - specifies the data0 to be programmed.
+ *
+ * @return  none
+ */
+void FLASH_BufLoad(uint32_t Address, uint32_t Data0)
+{
+    FLASH->CTLR |= CR_PAGE_PG;
+    *(__IO uint32_t *)(Address) = Data0;
+    FLASH->CTLR |= CR_BUF_LOAD;
+    while(FLASH->STATR & SR_BSY)
+        ;
+    FLASH->CTLR &= ~CR_PAGE_PG;
+}
+
+/*********************************************************************
+ * @fn      FLASH_ErasePage_Fast
+ *
+ * @brief   Erases a specified FLASH page (1page = 256Byte).
+ *
+ * @param   Page_Address - The page address to be erased.
+ *
+ * @return  none
+ */
+void FLASH_ErasePage_Fast(uint32_t Page_Address)
+{
+    FLASH->CTLR |= CR_PAGE_ER;
+    FLASH->ADDR = Page_Address;
+    FLASH->CTLR |= CR_STRT_Set;
+    while(FLASH->STATR & SR_BSY)
+        ;
+    FLASH->CTLR &= ~CR_PAGE_ER;
+}
+
+/*********************************************************************
+ * @fn      FLASH_EraseBlock_32K_Fast
+ *
+ * @brief   Erases a specified FLASH Block (1Block = 32KByte).
+ *
+ * @param   Block_Address - The block address to be erased.
+ *
+ * @return  none
+ */
+void FLASH_EraseBlock_32K_Fast(uint32_t Block_Address)
+{
+    Block_Address &= 0xFFFF8000;
+
+    FLASH->CTLR |= CR_BER32;
+    FLASH->ADDR = Block_Address;
+    FLASH->CTLR |= CR_STRT_Set;
+    while(FLASH->STATR & SR_BSY)
+        ;
+    FLASH->CTLR &= ~CR_BER32;
+}
+
+/*********************************************************************
+ * @fn      FLASH_ProgramPage_Fast
+ *
+ * @brief   Program a specified FLASH page (1page = 256Byte).
+ *
+ * @param   Page_Address - The page address to be programed.
+ *
+ * @return  none
+ */
+void FLASH_ProgramPage_Fast(uint32_t Page_Address)
+{
+    FLASH->CTLR |= CR_PAGE_PG;
+    FLASH->ADDR = Page_Address;
+    FLASH->CTLR |= CR_STRT_Set;
+    while(FLASH->STATR & SR_BSY)
+        ;
+    FLASH->CTLR &= ~CR_PAGE_PG;
+}
+
+/*********************************************************************
+ * @fn      SystemReset_StartMode
+ *
+ * @brief   Start mode after system reset.
+ *
+ * @param   Mode - Start mode.
+ *            Start_Mode_USER - USER start after system reset
+ *            Start_Mode_BOOT - Boot start after system reset
+ * @return  none
+ */
+void SystemReset_StartMode(uint32_t Mode)
+{
+    FLASH_Unlock();
+
+    FLASH->BOOT_MODEKEYR = FLASH_KEY1;
+    FLASH->BOOT_MODEKEYR = FLASH_KEY2;
+
+    FLASH->STATR &= ~(1<<14);
+    if(Mode == Start_Mode_BOOT){
+        FLASH->STATR |= (1<<14);
+    }
+
+    FLASH_Lock();
+}

--- a/Peripheral/ch32x035/src/ch32x035_gpio.c
+++ b/Peripheral/ch32x035/src/ch32x035_gpio.c
@@ -1,0 +1,591 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_gpio.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the GPIO firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_gpio.h"
+#include "ch32x035_rcc.h"
+
+/* MASK */
+#define LSB_MASK                  ((uint16_t)0xFFFF)
+#define DBGAFR_POSITION_MASK      ((uint32_t)0x000F0000)
+#define DBGAFR_SWJCFG_MASK        ((uint32_t)0xF0FFFFFF)
+#define DBGAFR_TIM1RP_MASK        ((uint32_t)0x00400000)
+#define DBGAFR_LOCATION_MASK      ((uint32_t)0x00200000)
+#define DBGAFR_NUMBITS_MASK       ((uint32_t)0x00100000)
+
+volatile uint32_t CFGHR_tmpA = 0x44444444;
+volatile uint32_t CFGHR_tmpB = 0x44444444;
+volatile uint32_t CFGHR_tmpC = 0x44444444;
+
+/*********************************************************************
+ * @fn      GPIO_DeInit
+ *
+ * @brief   Deinitializes the GPIOx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *
+ * @return  none
+ */
+void GPIO_DeInit(GPIO_TypeDef *GPIOx)
+{
+    if(GPIOx == GPIOA)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOA, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOA, DISABLE);
+    }
+    else if(GPIOx == GPIOB)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOB, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOB, DISABLE);
+    }
+    else if(GPIOx == GPIOC)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOC, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOC, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_AFIODeInit
+ *
+ * @brief   Deinitializes the Alternate Functions (remap, event control
+ *        and EXTI configuration) registers to their default reset values.
+ *
+ * @return  none
+ */
+void GPIO_AFIODeInit(void)
+{
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_AFIO, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_AFIO, DISABLE);
+}
+
+/*********************************************************************
+ * @fn      GPIO_Init
+ *
+ * @brief   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *          Note - Only PA0--PA15 and PC16--PC17 support input pull-down
+ *
+ * @param   GPIO_InitStruct - pointer to a GPIO_InitTypeDef structure that
+ *        contains the configuration information for the specified GPIO peripheral.
+ *
+ * @return  none
+ */
+void GPIO_Init(GPIO_TypeDef *GPIOx, GPIO_InitTypeDef *GPIO_InitStruct)
+{
+    uint32_t currentmode = 0x00, currentpin = 0x00, pinpos = 0x00, pos = 0x00;
+    uint32_t tmpreg = 0x00, pinmask = 0x00;
+
+    currentmode = ((uint32_t)GPIO_InitStruct->GPIO_Mode) & ((uint32_t)0x0F);
+
+    if((((uint32_t)GPIO_InitStruct->GPIO_Mode) & ((uint32_t)0x10)) != 0x00)
+    {
+        currentmode |= (uint32_t)GPIO_InitStruct->GPIO_Speed;
+    }
+
+    if(((uint32_t)GPIO_InitStruct->GPIO_Pin & ((uint32_t)0x0000FF)) != 0x00)
+    {
+        tmpreg = GPIOx->CFGLR;
+
+        for(pinpos = 0x00; pinpos < 0x08; pinpos++)
+        {
+            pos = ((uint32_t)0x01) << pinpos;
+            currentpin = (GPIO_InitStruct->GPIO_Pin) & pos;
+
+            if(currentpin == pos)
+            {
+                pos = pinpos << 2;
+                pinmask = ((uint32_t)0x0F) << pos;
+                tmpreg &= ~pinmask;
+                tmpreg |= (currentmode << pos);
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPD)
+                {
+                    GPIOx->BCR = (((uint32_t)0x01) << pinpos);
+                }
+                else
+                {
+                    if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPU)
+                    {
+                        GPIOx->BSHR = (((uint32_t)0x01) << pinpos);
+                    }
+                }
+            }
+        }
+        GPIOx->CFGLR = tmpreg;
+    }
+
+    if(((uint32_t)GPIO_InitStruct->GPIO_Pin & ((uint32_t)0x00FF00)) != 0x00)
+    {
+        if(GPIOx == GPIOA)
+        {
+            tmpreg = CFGHR_tmpA;
+        }
+        else if(GPIOx == GPIOB)
+        {
+            tmpreg = CFGHR_tmpB;
+        }
+        else if(GPIOx == GPIOC)
+        {
+            tmpreg = CFGHR_tmpC;
+        }
+
+        for(pinpos = 0x00; pinpos < 0x08; pinpos++)
+        {
+            pos = (((uint32_t)0x01) << (pinpos + 0x08));
+            currentpin = ((GPIO_InitStruct->GPIO_Pin) & pos);
+
+            if(currentpin == pos)
+            {
+                pos = pinpos << 2;
+                pinmask = ((uint32_t)0x0F) << pos;
+                tmpreg &= ~pinmask;
+                tmpreg |= (currentmode << pos);
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPD)
+                {
+                    GPIOx->BCR = (((uint32_t)0x01) << (pinpos + 0x08));
+                }
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPU)
+                {
+                    GPIOx->BSHR = (((uint32_t)0x01) << (pinpos + 0x08));
+                }
+            }
+        }
+        GPIOx->CFGHR = tmpreg;
+
+        if(GPIOx == GPIOA)
+        {
+            CFGHR_tmpA = tmpreg;
+        }
+        else if(GPIOx == GPIOB)
+        {
+            CFGHR_tmpB = tmpreg;
+        }
+        else if(GPIOx == GPIOC)
+        {
+            CFGHR_tmpC = tmpreg;
+        }
+    }
+
+    if(GPIO_InitStruct->GPIO_Pin > 0x00FFFF)
+    {
+        tmpreg = GPIOx->CFGXR;
+
+        for(pinpos = 0x00; pinpos < 0x08; pinpos++)
+        {
+            pos = (((uint32_t)0x01) << (pinpos + 0x10));
+            currentpin = ((GPIO_InitStruct->GPIO_Pin) & pos);
+
+            if(currentpin == pos)
+            {
+                pos = pinpos << 2;
+                pinmask = ((uint32_t)0x0F) << pos;
+                tmpreg &= ~pinmask;
+                tmpreg |= (currentmode << pos);
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPD)
+                {
+                    GPIOx->BCR = (((uint32_t)0x01) << (pinpos + 0x10));
+                }
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPU)
+                {
+                    GPIOx->BSXR = (((uint32_t)0x01) << (pinpos));
+                }
+            }
+        }
+        GPIOx->CFGXR = tmpreg;
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_StructInit
+ *
+ * @brief   Fills each GPIO_InitStruct member with its default
+ *
+ * @param   GPIO_InitStruct - pointer to a GPIO_InitTypeDef structure
+ *      which will be initialized.
+ *
+ * @return  none
+ */
+void GPIO_StructInit(GPIO_InitTypeDef *GPIO_InitStruct)
+{
+    GPIO_InitStruct->GPIO_Pin = GPIO_Pin_All;
+    GPIO_InitStruct->GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStruct->GPIO_Mode = GPIO_Mode_IN_FLOATING;
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadInputDataBit
+ *
+ * @brief   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *
+ * @param    GPIO_Pin - specifies the port bit to read.
+ *             This parameter can be GPIO_Pin_x where x can be (0..23).
+ *
+ * @return  The input port pin value.
+ */
+uint8_t GPIO_ReadInputDataBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
+{
+    uint8_t bitstatus = 0x00;
+
+    if((GPIOx->INDR & GPIO_Pin) != (uint32_t)Bit_RESET)
+    {
+        bitstatus = (uint8_t)Bit_SET;
+    }
+    else
+    {
+        bitstatus = (uint8_t)Bit_RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadInputData
+ *
+ * @brief   Reads the specified GPIO input data port.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *
+ * @return  The output port pin value.
+ */
+uint32_t GPIO_ReadInputData(GPIO_TypeDef *GPIOx)
+{
+    uint32_t val;
+
+    val = ( uint32_t )GPIOx->INDR;
+
+    return ( val );
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadOutputDataBit
+ *
+ * @brief   Reads the specified output data port bit.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bit to read.
+ *            This parameter can be GPIO_Pin_x where x can be (0..23).
+ *
+ * @return  none
+ */
+uint8_t GPIO_ReadOutputDataBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
+{
+    uint8_t bitstatus = 0x00;
+
+    if((GPIOx->OUTDR & GPIO_Pin) != (uint32_t)Bit_RESET)
+    {
+        bitstatus = (uint8_t)Bit_SET;
+    }
+    else
+    {
+        bitstatus = (uint8_t)Bit_RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadOutputData
+ *
+ * @brief   Reads the specified GPIO output data port.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *
+ * @return  GPIO output port pin value.
+ */
+uint32_t GPIO_ReadOutputData(GPIO_TypeDef *GPIOx)
+{
+    uint32_t val;
+
+    val = ( uint32_t )GPIOx->OUTDR;
+
+    return ( val );
+}
+
+/*********************************************************************
+ * @fn      GPIO_SetBits
+ *
+ * @brief   Sets the selected data port bits.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bits to be written.
+ *            This parameter can be any combination of GPIO_Pin_x where x can be (0..23).
+ *
+ * @return  none
+ */
+void GPIO_SetBits(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
+{
+    if((GPIO_Pin & ((uint32_t)0x00FFFF)) != 0x00)
+    {
+        GPIOx->BSHR = GPIO_Pin;
+    }
+
+    if(GPIO_Pin > 0x00FFFF)
+    {
+        GPIOx->BSXR = (GPIO_Pin>>0x10);
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_ResetBits
+ *
+ * @brief   Clears the selected data port bits.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bits to be written.
+ *            This parameter can be any combination of GPIO_Pin_x where x can be (0..23).
+ *
+ * @return  none
+ */
+void GPIO_ResetBits(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
+{
+    GPIOx->BCR = GPIO_Pin;
+}
+
+/*********************************************************************
+ * @fn      GPIO_WriteBit
+ *
+ * @brief   Sets or clears the selected data port bit.
+ *
+ * @param   GPIO_Pin - specifies the port bit to be written.
+ *            This parameter can be one of GPIO_Pin_x where x can be (0..23).
+ *          BitVal - specifies the value to be written to the selected bit.
+ *            Bit_RESET - to clear the port pin.
+ *            Bit_SET - to set the port pin.
+ *
+ * @return  none
+ */
+void GPIO_WriteBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin, BitAction BitVal)
+{
+    if(BitVal != Bit_RESET)
+    {
+        if((GPIO_Pin & ((uint32_t)0x00FFFF)) != 0x00)
+        {
+            GPIOx->BSHR = GPIO_Pin;
+        }
+
+        if(GPIO_Pin > 0x00FFFF)
+        {
+            GPIOx->BSXR = (GPIO_Pin>>0x10);
+        }
+    }
+    else
+    {
+        GPIOx->BCR = GPIO_Pin;
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_Write
+ *
+ * @brief   Writes data to the specified GPIO data port.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *          PortVal - specifies the value to be written to the port output data register.
+ *
+ * @return  none
+ */
+void GPIO_Write(GPIO_TypeDef *GPIOx, uint32_t PortVal)
+{
+    GPIOx->OUTDR = PortVal;
+}
+
+/*********************************************************************
+ * @fn      GPIO_PinLockConfig
+ *
+ * @brief   Locks GPIO Pins configuration registers.
+ *
+ * @param   GPIOx - where x can be (A..C) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bit to be written.
+ *            This parameter can be any combination of GPIO_Pin_x where x can be (0..23).
+ *
+ * @return  none
+ */
+void GPIO_PinLockConfig(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
+{
+    uint32_t tmp = 0x01000000;
+
+    tmp |= GPIO_Pin;
+    GPIOx->LCKR = tmp;
+    GPIOx->LCKR = GPIO_Pin;
+    GPIOx->LCKR = tmp;
+    tmp = GPIOx->LCKR;
+    tmp = GPIOx->LCKR;
+}
+
+/*********************************************************************
+ * @fn      GPIO_PinRemapConfig
+ *
+ * @brief   Changes the mapping of the specified pin.
+ *
+ * @param   GPIO_Remap - selects the pin to remap.
+ *            GPIO_Remap_SPI1 - SPI1 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_SPI1 - SPI1 Partial2 Alternate Function mapping
+ *            GPIO_FullRemap_SPI1 - SPI1 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_I2C1 - I2C1 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_I2C1 - I2C1 Partial2 Alternate Function mapping
+ *            GPIO_PartialRemap3_I2C1 - I2C1 Partial3 Alternate Function mapping
+ *            GPIO_PartialRemap4_I2C1 - I2C1 Partial4 Alternate Function mapping
+ *            GPIO_FullRemap_I2C1 - I2C1 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_USART1 - USART1 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_USART1 - USART1 Partial2 Alternate Function mapping
+ *            GPIO_FullRemap_USART1 - USART1 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_USART2 - USART2 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_USART2 - USART2 Partial2 Alternate Function mapping
+ *            GPIO_PartialRemap3_USART2 - USART2 Partial3 Alternate Function mapping
+ *            GPIO_FullRemap_USART2 - USART2 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_USART3 - USART3 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_USART3 - USART3 Partial2 Alternate Function mapping
+ *            GPIO_FullRemap_USART3 - USART3 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_USART4 - USART4 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_USART4 - USART4 Partial2 Alternate Function mapping
+ *            GPIO_PartialRemap3_USART4 - USART4 Partial3 Alternate Function mapping
+ *            GPIO_PartialRemap4_USART4 - USART4 Partial4 Alternate Function mapping
+ *            GPIO_PartialRemap5_USART4 - USART4 Partial5 Alternate Function mapping
+ *            GPIO_PartialRemap6_USART4 - USART4 Partial6 Alternate Function mapping
+ *            GPIO_FullRemap_USART4 - USART4 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_TIM1 - TIM1 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_TIM1 - TIM1 Partial2 Alternate Function mapping
+ *            GPIO_PartialRemap3_TIM1 - TIM1 Partial3 Alternate Function mapping
+ *            GPIO_FullRemap_TIM1 - TIM1 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_TIM2 - TIM2 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_TIM2 - TIM2 Partial2 Alternate Function mapping
+ *            GPIO_PartialRemap3_TIM2 - TIM2 Partial3 Alternate Function mapping
+ *            GPIO_PartialRemap4_TIM2 - TIM2 Partial4 Alternate Function mapping
+ *            GPIO_PartialRemap5_TIM2 - TIM2 Partial5 Alternate Function mapping
+ *            GPIO_FullRemap_TIM2 - TIM2 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_TIM3 - TIM3 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_TIM3 - TIM3 Partial2 Alternate Function mapping
+ *            GPIO_FullRemap_TIM3 - TIM3 Full Alternate Function mapping
+ *            GPIO_Remap_PIOC - PIOC Alternate Function mapping
+ *            GPIO_Remap_SWJ_Disable - SDI Disabled (SDI)
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void GPIO_PinRemapConfig(uint32_t GPIO_Remap, FunctionalState NewState)
+{
+    uint32_t tmp = 0x00, tmp1 = 0x00, tmpreg = 0x00, tmpmask = 0x00;
+
+    tmpreg = AFIO->PCFR1;
+
+    tmpmask = (GPIO_Remap & DBGAFR_POSITION_MASK) >> 0x10;
+    tmp = GPIO_Remap & LSB_MASK;
+
+    /* Clear bit */
+    if((GPIO_Remap & 0x08000000) == 0x08000000) /* 3bit */
+    {
+        if((GPIO_Remap & (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) == (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) /* [26:24] SDI */
+        {
+            tmpreg &= DBGAFR_SWJCFG_MASK;
+            AFIO->PCFR1 &= DBGAFR_SWJCFG_MASK;
+        }
+        else if((GPIO_Remap & DBGAFR_TIM1RP_MASK) == DBGAFR_TIM1RP_MASK) /* [31:16] 3bit */
+        {
+            tmp1 = ((uint32_t)0x07) << 15;
+            tmpreg &= ~tmp1;
+
+            if(NewState != DISABLE)
+            {
+                tmpreg |= (tmp << 15);
+            }
+
+            AFIO->PCFR1 = tmpreg;
+            return;
+        }
+        else if((GPIO_Remap & (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) == DBGAFR_LOCATION_MASK) /* [31:16] 3bit */
+        {
+            tmp1 = ((uint32_t)0x07) << (tmpmask + 0x10);
+            tmpreg &= ~tmp1;
+        }
+        else /* [15:0] 3bit */
+        {
+            tmp1 = ((uint32_t)0x07) << tmpmask;
+            tmpreg &= ~tmp1;
+        }
+    }
+    else
+    {
+        if((GPIO_Remap & (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) == (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) /* [31:16] 2bit */
+        {
+            tmp1 = ((uint32_t)0x03) << (tmpmask + 0x10);
+            tmpreg &= ~tmp1;
+        }
+        else if((GPIO_Remap & DBGAFR_NUMBITS_MASK) == DBGAFR_NUMBITS_MASK) /* [15:0] 2bit */
+        {
+            tmp1 = ((uint32_t)0x03) << tmpmask;
+            tmpreg &= ~tmp1;
+        }
+        else /* [31:0] 1bit */
+        {
+            tmpreg &= ~(tmp << (((GPIO_Remap & 0x00FFFFFF ) >> 0x15) * 0x10));
+        }
+    }
+
+    /* Set bit */
+    if(NewState != DISABLE)
+    {
+        tmpreg |= (tmp << (((GPIO_Remap & 0x00FFFFFF )>> 0x15) * 0x10));
+    }
+
+    AFIO->PCFR1 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      GPIO_EXTILineConfig
+ *
+ * @brief   Selects the GPIO pin used as EXTI Line.
+ *
+ * @param   GPIO_PortSource - selects the GPIO port to be used as source for EXTI lines.
+ *            This parameter can be GPIO_PortSourceGPIOx where x can be (A..C).
+ *          GPIO_PinSource - specifies the EXTI line to be configured.
+ *            This parameter can be GPIO_PinSourcex where x can be (0..23).
+ *
+ * @return  none
+ */
+void GPIO_EXTILineConfig(uint8_t GPIO_PortSource, uint16_t GPIO_PinSource)
+{
+    uint32_t tmp = 0x00;
+
+    tmp = ((uint32_t)0x03) << (0x02 * (GPIO_PinSource & (uint8_t)0x0F));
+    AFIO->EXTICR[GPIO_PinSource >> 0x04] &= ~tmp;
+    AFIO->EXTICR[GPIO_PinSource >> 0x04] |= (((uint32_t)GPIO_PortSource) << (0x02 * (GPIO_PinSource & (uint8_t)0x0F)));
+}
+
+/*********************************************************************
+ * @fn      GPIO_IPD_Unused
+ *
+ * @brief   Configure unused GPIO as input pull-up.
+ *
+ * @param   none
+ *
+ * @return  none
+ */
+void GPIO_IPD_Unused(void)
+{
+    GPIO_InitTypeDef GPIO_InitStructure = {0};
+
+    /* All pull-up */
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC | RCC_APB2Periph_AFIO, ENABLE);
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_PWR, ENABLE);
+    GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_All;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
+
+    GPIO_Init(GPIOA, &GPIO_InitStructure);
+    GPIO_Init(GPIOB, &GPIO_InitStructure);
+    GPIO_Init(GPIOC, &GPIO_InitStructure);
+
+}
+

--- a/Peripheral/ch32x035/src/ch32x035_i2c.c
+++ b/Peripheral/ch32x035/src/ch32x035_i2c.c
@@ -1,0 +1,967 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_i2c.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the I2C firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_i2c.h"
+#include "ch32x035_rcc.h"
+
+/* I2C SPE mask */
+#define CTLR1_PE_Set             ((uint16_t)0x0001)
+#define CTLR1_PE_Reset           ((uint16_t)0xFFFE)
+
+/* I2C START mask */
+#define CTLR1_START_Set          ((uint16_t)0x0100)
+#define CTLR1_START_Reset        ((uint16_t)0xFEFF)
+
+/* I2C STOP mask */
+#define CTLR1_STOP_Set           ((uint16_t)0x0200)
+#define CTLR1_STOP_Reset         ((uint16_t)0xFDFF)
+
+/* I2C ACK mask */
+#define CTLR1_ACK_Set            ((uint16_t)0x0400)
+#define CTLR1_ACK_Reset          ((uint16_t)0xFBFF)
+
+/* I2C ENGC mask */
+#define CTLR1_ENGC_Set           ((uint16_t)0x0040)
+#define CTLR1_ENGC_Reset         ((uint16_t)0xFFBF)
+
+/* I2C SWRST mask */
+#define CTLR1_SWRST_Set          ((uint16_t)0x8000)
+#define CTLR1_SWRST_Reset        ((uint16_t)0x7FFF)
+
+/* I2C PEC mask */
+#define CTLR1_PEC_Set            ((uint16_t)0x1000)
+#define CTLR1_PEC_Reset          ((uint16_t)0xEFFF)
+
+/* I2C ENPEC mask */
+#define CTLR1_ENPEC_Set          ((uint16_t)0x0020)
+#define CTLR1_ENPEC_Reset        ((uint16_t)0xFFDF)
+
+/* I2C ENARP mask */
+#define CTLR1_ENARP_Set          ((uint16_t)0x0010)
+#define CTLR1_ENARP_Reset        ((uint16_t)0xFFEF)
+
+/* I2C NOSTRETCH mask */
+#define CTLR1_NOSTRETCH_Set      ((uint16_t)0x0080)
+#define CTLR1_NOSTRETCH_Reset    ((uint16_t)0xFF7F)
+
+/* I2C registers Masks */
+#define CTLR1_CLEAR_Mask         ((uint16_t)0xFBF5)
+
+/* I2C DMAEN mask */
+#define CTLR2_DMAEN_Set          ((uint16_t)0x0800)
+#define CTLR2_DMAEN_Reset        ((uint16_t)0xF7FF)
+
+/* I2C LAST mask */
+#define CTLR2_LAST_Set           ((uint16_t)0x1000)
+#define CTLR2_LAST_Reset         ((uint16_t)0xEFFF)
+
+/* I2C FREQ mask */
+#define CTLR2_FREQ_Reset         ((uint16_t)0xFFC0)
+
+/* I2C ADD0 mask */
+#define OADDR1_ADD0_Set          ((uint16_t)0x0001)
+#define OADDR1_ADD0_Reset        ((uint16_t)0xFFFE)
+
+/* I2C ENDUAL mask */
+#define OADDR2_ENDUAL_Set        ((uint16_t)0x0001)
+#define OADDR2_ENDUAL_Reset      ((uint16_t)0xFFFE)
+
+/* I2C ADD2 mask */
+#define OADDR2_ADD2_Reset        ((uint16_t)0xFF01)
+
+/* I2C F/S mask */
+#define CKCFGR_FS_Set            ((uint16_t)0x8000)
+
+/* I2C CCR mask */
+#define CKCFGR_CCR_Set           ((uint16_t)0x0FFF)
+
+/* I2C FLAG mask */
+#define FLAG_Mask                ((uint32_t)0x00FFFFFF)
+
+/* I2C Interrupt Enable mask */
+#define ITEN_Mask                ((uint32_t)0x07000000)
+
+/*********************************************************************
+ * @fn      I2C_DeInit
+ *
+ * @brief   Deinitializes the I2Cx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *
+ * @return  none
+ */
+void I2C_DeInit(I2C_TypeDef *I2Cx)
+{
+    if(I2Cx == I2C1)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_I2C1, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_I2C1, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_Init
+ *
+ * @brief   Initializes the I2Cx peripheral according to the specified
+ *        parameters in the I2C_InitStruct.
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_InitStruct - pointer to a I2C_InitTypeDef structure that
+ *        contains the configuration information for the specified I2C peripheral.
+ *
+ * @return  none
+ */
+void I2C_Init(I2C_TypeDef *I2Cx, I2C_InitTypeDef *I2C_InitStruct)
+{
+    uint16_t tmpreg = 0, freqrange = 0;
+    uint16_t result = 0x04;
+    uint32_t pclk1 = 8000000;
+
+    RCC_ClocksTypeDef rcc_clocks;
+
+    tmpreg = I2Cx->CTLR2;
+    tmpreg &= CTLR2_FREQ_Reset;
+    RCC_GetClocksFreq(&rcc_clocks);
+    pclk1 = rcc_clocks.PCLK1_Frequency;
+    freqrange = (uint16_t)(pclk1 / 1000000);
+    tmpreg |= freqrange;
+    I2Cx->CTLR2 = tmpreg;
+
+    I2Cx->CTLR1 &= CTLR1_PE_Reset;
+    tmpreg = 0;
+
+    if(I2C_InitStruct->I2C_ClockSpeed <= 100000)
+    {
+        result = (uint16_t)(pclk1 / (I2C_InitStruct->I2C_ClockSpeed << 1));
+
+        if(result < 0x04)
+        {
+            result = 0x04;
+        }
+
+        tmpreg |= result;
+    }
+    else
+    {
+        if(I2C_InitStruct->I2C_DutyCycle == I2C_DutyCycle_2)
+        {
+            result = (uint16_t)(pclk1 / (I2C_InitStruct->I2C_ClockSpeed * 3));
+        }
+        else
+        {
+            result = (uint16_t)(pclk1 / (I2C_InitStruct->I2C_ClockSpeed * 25));
+            result |= I2C_DutyCycle_16_9;
+        }
+
+        if((result & CKCFGR_CCR_Set) == 0)
+        {
+            result |= (uint16_t)0x0001;
+        }
+
+        tmpreg |= (uint16_t)(result | CKCFGR_FS_Set);
+    }
+
+    I2Cx->CKCFGR = tmpreg;
+    I2Cx->CTLR1 |= CTLR1_PE_Set;
+
+    tmpreg = I2Cx->CTLR1;
+    tmpreg &= CTLR1_CLEAR_Mask;
+    tmpreg |= (uint16_t)((uint32_t)I2C_InitStruct->I2C_Mode | I2C_InitStruct->I2C_Ack);
+    I2Cx->CTLR1 = tmpreg;
+
+    I2Cx->OADDR1 = (I2C_InitStruct->I2C_AcknowledgedAddress | I2C_InitStruct->I2C_OwnAddress1);
+}
+
+/*********************************************************************
+ * @fn      I2C_StructInit
+ *
+ * @brief   Fills each I2C_InitStruct member with its default value.
+ *
+ * @param   I2C_InitStruct - pointer to an I2C_InitTypeDef structure which
+ *        will be initialized.
+ *
+ * @return  none
+ */
+void I2C_StructInit(I2C_InitTypeDef *I2C_InitStruct)
+{
+    I2C_InitStruct->I2C_ClockSpeed = 5000;
+    I2C_InitStruct->I2C_Mode = I2C_Mode_I2C;
+    I2C_InitStruct->I2C_DutyCycle = I2C_DutyCycle_2;
+    I2C_InitStruct->I2C_OwnAddress1 = 0;
+    I2C_InitStruct->I2C_Ack = I2C_Ack_Disable;
+    I2C_InitStruct->I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit;
+}
+
+/*********************************************************************
+ * @fn      I2C_Cmd
+ *
+ * @brief   Enables or disables the specified I2C peripheral.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_Cmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_PE_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_PE_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_DMACmd
+ *
+ * @brief   Enables or disables the specified I2C DMA requests.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_DMACmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR2 |= CTLR2_DMAEN_Set;
+    }
+    else
+    {
+        I2Cx->CTLR2 &= CTLR2_DMAEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_DMALastTransferCmd
+ *
+ * @brief   Specifies if the next DMA transfer will be the last one.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_DMALastTransferCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR2 |= CTLR2_LAST_Set;
+    }
+    else
+    {
+        I2Cx->CTLR2 &= CTLR2_LAST_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GenerateSTART
+ *
+ * @brief   Generates I2Cx communication START condition.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_GenerateSTART(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_START_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_START_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GenerateSTOP
+ *
+ * @brief   Generates I2Cx communication STOP condition.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_GenerateSTOP(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_STOP_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_STOP_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_AcknowledgeConfig
+ *
+ * @brief   Enables or disables the specified I2C acknowledge feature.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_AcknowledgeConfig(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ACK_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ACK_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_OwnAddress2Config
+ *
+ * @brief   Configures the specified I2C own address2.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          Address - specifies the 7bit I2C own address2.
+ *
+ * @return  none
+ */
+void I2C_OwnAddress2Config(I2C_TypeDef *I2Cx, uint8_t Address)
+{
+    uint16_t tmpreg = 0;
+
+    tmpreg = I2Cx->OADDR2;
+    tmpreg &= OADDR2_ADD2_Reset;
+    tmpreg |= (uint16_t)((uint16_t)Address & (uint16_t)0x00FE);
+    I2Cx->OADDR2 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      I2C_DualAddressCmd
+ *
+ * @brief   Enables or disables the specified I2C dual addressing mode.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_DualAddressCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->OADDR2 |= OADDR2_ENDUAL_Set;
+    }
+    else
+    {
+        I2Cx->OADDR2 &= OADDR2_ENDUAL_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GeneralCallCmd
+ *
+ * @brief   Enables or disables the specified I2C general call feature.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_GeneralCallCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ENGC_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ENGC_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_ITConfig
+ *
+ * @brief   Enables or disables the specified I2C interrupts.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_IT - specifies the I2C interrupts sources to be enabled or disabled.
+ *            I2C_IT_BUF - Buffer interrupt mask.
+ *            I2C_IT_EVT - Event interrupt mask.
+ *            I2C_IT_ERR - Error interrupt mask.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_ITConfig(I2C_TypeDef *I2Cx, uint16_t I2C_IT, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR2 |= I2C_IT;
+    }
+    else
+    {
+        I2Cx->CTLR2 &= (uint16_t)~I2C_IT;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_SendData
+ *
+ * @brief   Sends a data byte through the I2Cx peripheral.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          Data - Byte to be transmitted.
+ *
+ * @return  none
+ */
+void I2C_SendData(I2C_TypeDef *I2Cx, uint8_t Data)
+{
+    I2Cx->DATAR = Data;
+}
+
+/*********************************************************************
+ * @fn      I2C_ReceiveData
+ *
+ * @brief   Returns the most recent received data by the I2Cx peripheral.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *
+ * @return  The value of the received data.
+ */
+uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
+{
+    return (uint8_t)I2Cx->DATAR;
+}
+
+/*********************************************************************
+ * @fn      I2C_Send7bitAddress
+ *
+ * @brief   Transmits the address byte to select the slave device.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          Address - specifies the slave address which will be transmitted.
+ *          I2C_Direction - specifies whether the I2C device will be a
+ *        Transmitter or a Receiver.
+ *            I2C_Direction_Transmitter - Transmitter mode.
+ *            I2C_Direction_Receiver - Receiver mode.
+ *
+ * @return  none
+ */
+void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction)
+{
+    if(I2C_Direction != I2C_Direction_Transmitter)
+    {
+        Address |= OADDR1_ADD0_Set;
+    }
+    else
+    {
+        Address &= OADDR1_ADD0_Reset;
+    }
+
+    I2Cx->DATAR = Address;
+}
+
+/*********************************************************************
+ * @fn      I2C_ReadRegister
+ *
+ * @brief   Reads the specified I2C register and returns its value.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_Register - specifies the register to read.
+ *            I2C_Register_CTLR1.
+ *            I2C_Register_CTLR2.
+ *            I2C_Register_OADDR1.
+ *            I2C_Register_OADDR2.
+ *            I2C_Register_DATAR.
+ *            I2C_Register_STAR1.
+ *            I2C_Register_STAR2.
+ *            I2C_Register_CKCFGR.
+ *            I2C_Register_RTR.
+ *
+ * @return  none
+ */
+uint16_t I2C_ReadRegister(I2C_TypeDef *I2Cx, uint8_t I2C_Register)
+{
+    __IO uint32_t tmp = 0;
+
+    tmp = (uint32_t)I2Cx;
+    tmp += I2C_Register;
+
+    return (*(__IO uint16_t *)tmp);
+}
+
+/*********************************************************************
+ * @fn      I2C_SoftwareResetCmd
+ *
+ * @brief   Enables or disables the specified I2C software reset.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_SoftwareResetCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_SWRST_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_SWRST_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_NACKPositionConfig
+ *
+ * @brief   Selects the specified I2C NACK position in master receiver mode.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_NACKPosition - specifies the NACK position.
+ *            I2C_NACKPosition_Next - indicates that the next byte will be
+ *        the last received byte.
+ *            I2C_NACKPosition_Current - indicates that current byte is the
+ *        last received byte.
+ *       Note-    
+ *          This function configures the same bit (POS) as I2C_PECPositionConfig() 
+ *          but is intended to be used in I2C mode while I2C_PECPositionConfig() 
+ *          is intended to used in SMBUS mode. 
+ * @return  none
+ */
+void I2C_NACKPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_NACKPosition)
+{
+    if(I2C_NACKPosition == I2C_NACKPosition_Next)
+    {
+        I2Cx->CTLR1 |= I2C_NACKPosition_Next;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= I2C_NACKPosition_Current;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_TransmitPEC
+ *
+ * @brief   Enables or disables the specified I2C PEC transfer.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_TransmitPEC(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_PEC_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_PEC_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_PECPositionConfig
+ *
+ * @brief   Selects the specified I2C PEC position.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_PECPosition - specifies the PEC position.
+ *            I2C_PECPosition_Next - indicates that the next byte is PEC.
+ *            I2C_PECPosition_Current - indicates that current byte is PEC.
+ *
+ * @return  none
+ */
+void I2C_PECPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_PECPosition)
+{
+    if(I2C_PECPosition == I2C_PECPosition_Next)
+    {
+        I2Cx->CTLR1 |= I2C_PECPosition_Next;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= I2C_PECPosition_Current;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_CalculatePEC
+ *
+ * @brief   Enables or disables the PEC value calculation of the transferred bytes.
+ *
+ * @param   I2Cx- where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_CalculatePEC(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ENPEC_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ENPEC_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GetPEC
+ *
+ * @brief   Returns the PEC value for the specified I2C.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *
+ * @return  The PEC value.
+ */
+uint8_t I2C_GetPEC(I2C_TypeDef *I2Cx)
+{
+    return ((I2Cx->STAR2) >> 8);
+}
+
+/*********************************************************************
+ * @fn      I2C_ARPCmd
+ *
+ * @brief   Enables or disables the specified I2C ARP.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *            NewState - ENABLE or DISABLE.
+ *
+ * @return  The PEC value.
+ */
+void I2C_ARPCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ENARP_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ENARP_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_StretchClockCmd
+ *
+ * @brief   Enables or disables the specified I2C Clock stretching.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_StretchClockCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState == DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_NOSTRETCH_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_NOSTRETCH_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_FastModeDutyCycleConfig
+ *
+ * @brief   Selects the specified I2C fast mode duty cycle.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_DutyCycle - specifies the fast mode duty cycle.
+ *            I2C_DutyCycle_2 - I2C fast mode Tlow/Thigh = 2.
+ *            I2C_DutyCycle_16_9 - I2C fast mode Tlow/Thigh = 16/9.
+ *
+ * @return  none
+ */
+void I2C_FastModeDutyCycleConfig(I2C_TypeDef *I2Cx, uint16_t I2C_DutyCycle)
+{
+    if(I2C_DutyCycle != I2C_DutyCycle_16_9)
+    {
+        I2Cx->CKCFGR &= I2C_DutyCycle_2;
+    }
+    else
+    {
+        I2Cx->CKCFGR |= I2C_DutyCycle_16_9;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_CheckEvent
+ *
+ * @brief   Checks whether the last I2Cx Event is equal to the one passed
+ *        as parameter.
+ *
+ * @param   I2Cx- where x can be 1 to select the I2C peripheral.
+ *          I2C_EVENT: specifies the event to be checked.
+ *             I2C_EVENT_SLAVE_TRANSMITTER_ADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_RECEIVER_ADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_TRANSMITTER_SECONDADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_RECEIVER_SECONDADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_BYTE_RECEIVED - EVT2.
+ *             (I2C_EVENT_SLAVE_BYTE_RECEIVED | I2C_FLAG_DUALF) - EVT2.
+ *             (I2C_EVENT_SLAVE_BYTE_RECEIVED | I2C_FLAG_GENCALL) - EVT2.
+ *             I2C_EVENT_SLAVE_BYTE_TRANSMITTED - EVT3.
+ *             (I2C_EVENT_SLAVE_BYTE_TRANSMITTED | I2C_FLAG_DUALF) - EVT3.
+ *             (I2C_EVENT_SLAVE_BYTE_TRANSMITTED | I2C_FLAG_GENCALL) - EVT3.
+ *             I2C_EVENT_SLAVE_ACK_FAILURE - EVT3_2.
+ *             I2C_EVENT_SLAVE_STOP_DETECTED - EVT4.
+ *             I2C_EVENT_MASTER_MODE_SELECT - EVT5.
+ *             I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED - EVT6.
+ *             I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED - EVT6.
+ *             I2C_EVENT_MASTER_BYTE_RECEIVED - EVT7.
+ *             I2C_EVENT_MASTER_BYTE_TRANSMITTING - EVT8.
+ *             I2C_EVENT_MASTER_BYTE_TRANSMITTED - EVT8_2.
+ *             I2C_EVENT_MASTER_MODE_ADDRESS10 - EVT9.
+ *
+ * @return  ErrorStatus - READY or NoREADY.
+ */
+ErrorStatus I2C_CheckEvent(I2C_TypeDef *I2Cx, uint32_t I2C_EVENT)
+{
+    uint32_t    lastevent = 0;
+    uint32_t    flag1 = 0, flag2 = 0;
+    ErrorStatus status = NoREADY;
+
+    flag1 = I2Cx->STAR1;
+    flag2 = I2Cx->STAR2;
+    flag2 = flag2 << 16;
+
+    lastevent = (flag1 | flag2) & FLAG_Mask;
+
+    if((lastevent & I2C_EVENT) == I2C_EVENT)
+    {
+        status = READY;
+    }
+    else
+    {
+        status = NoREADY;
+    }
+
+    return status;
+}
+
+/*********************************************************************
+ * @fn      I2C_GetLastEvent
+ *
+ * @brief   Returns the last I2Cx Event.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *
+ * @return  none
+ */
+uint32_t I2C_GetLastEvent(I2C_TypeDef *I2Cx)
+{
+    uint32_t lastevent = 0;
+    uint32_t flag1 = 0, flag2 = 0;
+
+    flag1 = I2Cx->STAR1;
+    flag2 = I2Cx->STAR2;
+    flag2 = flag2 << 16;
+    lastevent = (flag1 | flag2) & FLAG_Mask;
+
+    return lastevent;
+}
+
+/*********************************************************************
+ * @fn      I2C_GetFlagStatus
+ *
+ * @brief   Checks whether the last I2Cx Event is equal to the one passed
+ *        as parameter.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_FLAG - specifies the flag to check.
+ *            I2C_FLAG_DUALF - Dual flag (Slave mode).
+ *            I2C_FLAG_GENCALL - General call header flag (Slave mode).
+ *            I2C_FLAG_TRA - Transmitter/Receiver flag.
+ *            I2C_FLAG_BUSY - Bus busy flag.
+ *            I2C_FLAG_MSL - Master/Slave flag.
+ *            I2C_FLAG_PECERR - PEC error in reception flag.
+ *            I2C_FLAG_OVR - Overrun/Underrun flag (Slave mode).
+ *            I2C_FLAG_AF - Acknowledge failure flag.
+ *            I2C_FLAG_ARLO - Arbitration lost flag (Master mode).
+ *            I2C_FLAG_BERR - Bus error flag.
+ *            I2C_FLAG_TXE - Data register empty flag (Transmitter).
+ *            I2C_FLAG_RXNE- Data register not empty (Receiver) flag.
+ *            I2C_FLAG_STOPF - Stop detection flag (Slave mode).
+ *            I2C_FLAG_ADD10 - 10-bit header sent flag (Master mode).
+ *            I2C_FLAG_BTF - Byte transfer finished flag.
+ *            I2C_FLAG_ADDR - Address sent flag (Master mode) "ADSL"
+ *        Address matched flag (Slave mode)"ENDA".
+ *            I2C_FLAG_SB - Start bit flag (Master mode).
+ *
+ * @return  FlagStatus - SET or RESET.
+ */
+FlagStatus I2C_GetFlagStatus(I2C_TypeDef *I2Cx, uint32_t I2C_FLAG)
+{
+    FlagStatus    bitstatus = RESET;
+    __IO uint32_t i2creg = 0, i2cxbase = 0;
+
+    i2cxbase = (uint32_t)I2Cx;
+    i2creg = I2C_FLAG >> 28;
+    I2C_FLAG &= FLAG_Mask;
+
+    if(i2creg != 0)
+    {
+        i2cxbase += 0x14;
+    }
+    else
+    {
+        I2C_FLAG = (uint32_t)(I2C_FLAG >> 16);
+        i2cxbase += 0x18;
+    }
+
+    if(((*(__IO uint32_t *)i2cxbase) & I2C_FLAG) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      I2C_ClearFlag
+ *
+ * @brief   Clears the I2Cx's pending flags.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_FLAG - specifies the flag to clear.
+ *            I2C_FLAG_PECERR - PEC error in reception flag.
+ *            I2C_FLAG_OVR - Overrun/Underrun flag (Slave mode).
+ *            I2C_FLAG_AF - Acknowledge failure flag.
+ *            I2C_FLAG_ARLO - Arbitration lost flag (Master mode).
+ *            I2C_FLAG_BERR - Bus error flag.
+ *          Note-
+ *           - STOPF (STOP detection) is cleared by software sequence: a read operation 
+ *             to I2C_STAR1 register (I2C_GetFlagStatus()) followed by a write operation 
+ *             to I2C_CTLR1 register (I2C_Cmd() to re-enable the I2C peripheral).
+ *           - ADD10 (10-bit header sent) is cleared by software sequence: a read 
+ *             operation to I2C_SATR1 (I2C_GetFlagStatus()) followed by writing the 
+ *             second byte of the address in DATAR register.
+ *           - BTF (Byte Transfer Finished) is cleared by software sequence: a read 
+ *             operation to I2C_SATR1 register (I2C_GetFlagStatus()) followed by a 
+ *             read/write to I2C_DATAR register (I2C_SendData()).
+ *           - ADDR (Address sent) is cleared by software sequence: a read operation to 
+ *             I2C_SATR1 register (I2C_GetFlagStatus()) followed by a read operation to 
+ *             I2C_SATR2 register ((void)(I2Cx->SR2)).
+ *           - SB (Start Bit) is cleared software sequence: a read operation to I2C_STAR1
+ *             register (I2C_GetFlagStatus()) followed by a write operation to I2C_DATAR
+ *             register  (I2C_SendData()). 
+ * @return  none
+ */
+void I2C_ClearFlag(I2C_TypeDef *I2Cx, uint32_t I2C_FLAG)
+{
+    uint32_t flagpos = 0;
+
+    flagpos = I2C_FLAG & FLAG_Mask;
+    I2Cx->STAR1 = (uint16_t)~flagpos;
+}
+
+/*********************************************************************
+ * @fn      I2C_GetITStatus
+ *
+ * @brief   Checks whether the specified I2C interrupt has occurred or not.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          II2C_IT - specifies the interrupt source to check.
+ *            I2C_IT_PECERR - PEC error in reception flag.
+ *            I2C_IT_OVR - Overrun/Underrun flag (Slave mode).
+ *            I2C_IT_AF - Acknowledge failure flag.
+ *            I2C_IT_ARLO - Arbitration lost flag (Master mode).
+ *            I2C_IT_BERR - Bus error flag.
+ *            I2C_IT_TXE - Data register empty flag (Transmitter).
+ *            I2C_IT_RXNE - Data register not empty (Receiver) flag.
+ *            I2C_IT_STOPF - Stop detection flag (Slave mode).
+ *            I2C_IT_ADD10 - 10-bit header sent flag (Master mode).
+ *            I2C_IT_BTF - Byte transfer finished flag.
+ *            I2C_IT_ADDR - Address sent flag (Master mode) "ADSL"  Address matched
+ *        flag (Slave mode)"ENDAD".
+ *            I2C_IT_SB - Start bit flag (Master mode).
+ *
+ * @return  none
+ */
+ITStatus I2C_GetITStatus(I2C_TypeDef *I2Cx, uint32_t I2C_IT)
+{
+    ITStatus bitstatus = RESET;
+    uint32_t enablestatus = 0;
+
+    enablestatus = (uint32_t)(((I2C_IT & ITEN_Mask) >> 16) & (I2Cx->CTLR2));
+    I2C_IT &= FLAG_Mask;
+
+    if(((I2Cx->STAR1 & I2C_IT) != (uint32_t)RESET) && enablestatus)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      I2C_ClearITPendingBit
+ *
+ * @brief   Clears the I2Cx interrupt pending bits.
+ *
+ * @param   I2Cx - where x can be 1 to select the I2C peripheral.
+ *          I2C_IT - specifies the interrupt pending bit to clear.
+ *            I2C_IT_PECERR - PEC error in reception  interrupt.
+ *            I2C_IT_OVR - Overrun/Underrun interrupt (Slave mode).
+ *            I2C_IT_AF - Acknowledge failure interrupt.
+ *            I2C_IT_ARLO - Arbitration lost interrupt (Master mode).
+ *            I2C_IT_BERR - Bus error interrupt.
+ *          Note-
+ *           - STOPF (STOP detection) is cleared by software sequence: a read operation 
+ *             to I2C_STAR1 register (I2C_GetITStatus()) followed by a write operation to 
+ *             I2C_CTLR1 register (I2C_Cmd() to re-enable the I2C peripheral).
+ *           - ADD10 (10-bit header sent) is cleared by software sequence: a read 
+ *             operation to I2C_STAR1 (I2C_GetITStatus()) followed by writing the second 
+ *             byte of the address in I2C_DATAR register.
+ *           - BTF (Byte Transfer Finished) is cleared by software sequence: a read 
+ *             operation to I2C_STAR1 register (I2C_GetITStatus()) followed by a 
+ *             read/write to I2C_DATAR register (I2C_SendData()).
+ *           - ADDR (Address sent) is cleared by software sequence: a read operation to 
+ *             I2C_STAR1 register (I2C_GetITStatus()) followed by a read operation to 
+ *             I2C_STAR2 register ((void)(I2Cx->SR2)).
+ *           - SB (Start Bit) is cleared by software sequence: a read operation to 
+ *             I2C_STAR1 register (I2C_GetITStatus()) followed by a write operation to 
+ *             I2C_DATAR register (I2C_SendData()).
+ *
+ * @return  none
+ */
+void I2C_ClearITPendingBit(I2C_TypeDef *I2Cx, uint32_t I2C_IT)
+{
+    uint32_t flagpos = 0;
+
+    flagpos = I2C_IT & FLAG_Mask;
+    I2Cx->STAR1 = (uint16_t)~flagpos;
+}

--- a/Peripheral/ch32x035/src/ch32x035_iwdg.c
+++ b/Peripheral/ch32x035/src/ch32x035_iwdg.c
@@ -1,0 +1,122 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_iwdg.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the IWDG firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_iwdg.h"
+
+/* CTLR register bit mask */
+#define CTLR_KEY_Reload    ((uint16_t)0xAAAA)
+#define CTLR_KEY_Enable    ((uint16_t)0xCCCC)
+
+/*********************************************************************
+ * @fn      IWDG_WriteAccessCmd
+ *
+ * @brief   Enables or disables write access to IWDG_PSCR and IWDG_RLDR registers.
+ *
+ * @param   WDG_WriteAccess - new state of write access to IWDG_PSCR and
+ *        IWDG_RLDR registers.
+ *            IWDG_WriteAccess_Enable - Enable write access to IWDG_PSCR and
+ *        IWDG_RLDR registers.
+ *            IWDG_WriteAccess_Disable - Disable write access to IWDG_PSCR
+ *        and IWDG_RLDR registers.
+ *
+ * @return  none
+ */
+void IWDG_WriteAccessCmd(uint16_t IWDG_WriteAccess)
+{
+    IWDG->CTLR = IWDG_WriteAccess;
+}
+
+/*********************************************************************
+ * @fn      IWDG_SetPrescaler
+ *
+ * @brief   Sets IWDG Prescaler value.
+ *
+ * @param   IWDG_Prescaler - specifies the IWDG Prescaler value.
+ *             IWDG_Prescaler_4 - IWDG prescaler set to 4.
+ *             IWDG_Prescaler_8 - IWDG prescaler set to 8.
+ *             IWDG_Prescaler_16 - IWDG prescaler set to 16.
+ *             IWDG_Prescaler_32 - IWDG prescaler set to 32.
+ *             IWDG_Prescaler_64 - IWDG prescaler set to 64.
+ *             IWDG_Prescaler_128 - IWDG prescaler set to 128.
+ *             IWDG_Prescaler_256 - IWDG prescaler set to 256.
+ *
+ * @return  none
+ */
+void IWDG_SetPrescaler(uint8_t IWDG_Prescaler)
+{
+    IWDG->PSCR = IWDG_Prescaler;
+}
+
+/*********************************************************************
+ * @fn      IWDG_SetReload
+ *
+ * @brief   Sets IWDG Reload value.
+ *
+ * @param   Reload - specifies the IWDG Reload value.
+ *            This parameter must be a number between 0 and 0x0FFF.
+ *
+ * @return  none
+ */
+void IWDG_SetReload(uint16_t Reload)
+{
+    IWDG->RLDR = Reload;
+}
+
+/*********************************************************************
+ * @fn      IWDG_ReloadCounter
+ *
+ * @brief   Reloads IWDG counter with value defined in the reload register.
+ *
+ * @return  none
+ */
+void IWDG_ReloadCounter(void)
+{
+    IWDG->CTLR = CTLR_KEY_Reload;
+}
+
+/*********************************************************************
+ * @fn      IWDG_Enable
+ *
+ * @brief   Enables IWDG (write access to IWDG_PSCR and IWDG_RLDR registers disabled).
+ *
+ * @return  none
+ */
+void IWDG_Enable(void)
+{
+    IWDG->CTLR = CTLR_KEY_Enable;
+}
+
+/*********************************************************************
+ * @fn      IWDG_GetFlagStatus
+ *
+ * @brief   Checks whether the specified IWDG flag is set or not.
+ *
+ * @param   IWDG_FLAG - specifies the flag to check.
+ *            IWDG_FLAG_PVU - Prescaler Value Update on going.
+ *            IWDG_FLAG_RVU - Reload Value Update on going.
+ *
+ * @return  none
+ */
+FlagStatus IWDG_GetFlagStatus(uint16_t IWDG_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+    if((IWDG->STATR & IWDG_FLAG) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}

--- a/Peripheral/ch32x035/src/ch32x035_misc.c
+++ b/Peripheral/ch32x035/src/ch32x035_misc.c
@@ -1,0 +1,109 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_misc.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the miscellaneous firmware functions .
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_misc.h"
+
+__IO uint32_t NVIC_Priority_Group = 0;
+
+/*********************************************************************
+ * @fn      NVIC_PriorityGroupConfig
+ *
+ * @brief   Configures the priority grouping - pre-emption priority and subpriority.
+ *
+ * @param   NVIC_PriorityGroup - specifies the priority grouping bits length.
+ *            NVIC_PriorityGroup_0 - 0 bits for pre-emption priority
+ *                                   4 bits for subpriority
+ *            NVIC_PriorityGroup_1 - 1 bits for pre-emption priority
+ *                                   3 bits for subpriority
+ *            NVIC_PriorityGroup_2 - 2 bits for pre-emption priority
+ *                                   2 bits for subpriority
+ *            NVIC_PriorityGroup_3 - 3 bits for pre-emption priority
+ *                                   1 bits for subpriority
+ *            NVIC_PriorityGroup_4 - 4 bits for pre-emption priority
+ *                                   0 bits for subpriority
+ *
+ * @return  none
+ */
+void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup)
+{
+    NVIC_Priority_Group = NVIC_PriorityGroup;
+}
+
+/*********************************************************************
+ * @fn      NVIC_Init
+ *
+ * @brief   Initializes the NVIC peripheral according to the specified parameters in
+ *        the NVIC_InitStruct.
+ *
+ * @param   NVIC_InitStruct - pointer to a NVIC_InitTypeDef structure that contains the
+ *        configuration information for the specified NVIC peripheral.
+ *
+ * @return  none
+ */
+void NVIC_Init(NVIC_InitTypeDef *NVIC_InitStruct)
+{
+    uint8_t tmppre = 0;
+
+    if(NVIC_Priority_Group == NVIC_PriorityGroup_0)
+    {
+        NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, NVIC_InitStruct->NVIC_IRQChannelSubPriority << 4);
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_1)
+    {
+        if(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority == 1)
+        {
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (1 << 7) | (NVIC_InitStruct->NVIC_IRQChannelSubPriority << 4));
+        }
+        else
+        {
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (0 << 7) | (NVIC_InitStruct->NVIC_IRQChannelSubPriority << 4));
+        }
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_2)
+    {
+        if(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority <= 1)
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (4 * NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority);
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (0 << 7) | (tmppre << 4));
+        }
+        else
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (4 * (NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority - 2));
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (1 << 7) | (tmppre << 4));
+        }
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_3)
+    {
+        if(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority <= 3)
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (2 * NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority);
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (0 << 7) | (tmppre << 4));
+        }
+        else
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (2 * (NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority - 4));
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (1 << 7) | (tmppre << 4));
+        }
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_4)
+    {
+        NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority << 4);
+    }
+
+    if(NVIC_InitStruct->NVIC_IRQChannelCmd != DISABLE)
+    {
+        NVIC_EnableIRQ(NVIC_InitStruct->NVIC_IRQChannel);
+    }
+    else
+    {
+        NVIC_DisableIRQ(NVIC_InitStruct->NVIC_IRQChannel);
+    }
+}

--- a/Peripheral/ch32x035/src/ch32x035_opa.c
+++ b/Peripheral/ch32x035/src/ch32x035_opa.c
@@ -1,0 +1,319 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32x035_opa.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the OPA firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_opa.h"
+
+
+/* FLASH Keys */
+#define OPA_KEY1                 ((uint32_t)0x45670123)
+#define OPA_KEY2                 ((uint32_t)0xCDEF89AB)
+
+volatile uint32_t CTLR2_tmp = 0;
+
+/********************************************************************************
+ * @fn             OPA_Unlock
+ *
+ * @brief          Unlocks the OPA Controller.
+ *
+ * @return         None
+ */
+void OPA_Unlock(void)
+{
+    OPA->OPAKEY = OPA_KEY1;
+    OPA->OPAKEY = OPA_KEY2;
+}
+
+/********************************************************************************
+ * @fn             OPA_Lock
+ *
+ * @brief          Locks the OPA Controller.
+ *
+ * @return         None
+ */
+void OPA_Lock(void)
+{
+    OPA->CTLR1 |= (1<<31);
+}
+
+/********************************************************************************
+ * @fn             OPA_POLL_Unlock
+ *
+ * @brief          Unlocks the OPA POLL Controller.
+ *
+ * @return         None
+ */
+void OPA_POLL_Unlock(void)
+{
+    OPA->POLLKEY = OPA_KEY1;
+    OPA->POLLKEY = OPA_KEY2;
+}
+
+/********************************************************************************
+ * @fn             OPA_POLL_Lock
+ *
+ * @brief          Locks the OPA POLL Controller.
+ *
+ * @return         None
+ */
+void OPA_POLL_Lock(void)
+{
+    OPA->CFGR1 |= (1<<7);
+}
+
+/********************************************************************************
+ * @fn             OPA_CMP_Unlock
+ *
+ * @brief          Unlocks the CMP Controller.
+ *
+ * @return         None
+ */
+void OPA_CMP_Unlock(void)
+{
+    OPA->CMPKEY = OPA_KEY1;
+    OPA->CMPKEY = OPA_KEY2;
+}
+
+/********************************************************************************
+ * @fn             OPA_CMP_Lock
+ *
+ * @brief          Locks the CMP Controller.
+ *
+ * @return         None
+ */
+void OPA_CMP_Lock(void)
+{
+    CTLR2_tmp |= (1<<31);
+    OPA->CTLR2 = CTLR2_tmp;
+    CTLR2_tmp &= ~(1<<31);
+}
+
+/*********************************************************************
+ * @fn      OPA_Init
+ *
+ * @brief   Initializes the OPA peripheral according to the specified
+ *        parameters in the OPA_InitStruct.
+ *
+ * @param   OPA_InitStruct - pointer to a OPA_InitTypeDef structure
+ *
+ * @return  none
+ */
+void OPA_Init(OPA_InitTypeDef *OPA_InitStruct)
+{
+    uint16_t tmp0 = 0, tmp1 = 0;
+    uint32_t tmp2 = 0;
+
+    tmp0 = OPA->CFGR1;
+    tmp1 = OPA->CFGR2;
+    tmp2 = OPA->CTLR1;
+
+    if(OPA_InitStruct->OPA_NUM == OPA1)
+    {
+        tmp1 &= 0xFCFF;
+        tmp2 &= 0xFFFF0001;
+
+        tmp1 |= (OPA_InitStruct->POLL_NUM << 9);
+        tmp2 |= (OPA_InitStruct->Mode << 1) | (OPA_InitStruct->PSEL << 3)
+                | (OPA_InitStruct->FB << 5) | (OPA_InitStruct->NSEL << 6);
+    }
+    else if(OPA_InitStruct->OPA_NUM == OPA2)
+    {
+        tmp1 &= 0xF3FF;
+        tmp2 &= 0x0001FFFF;
+
+        tmp1 |= (OPA_InitStruct->POLL_NUM << 11);
+        tmp2 |= (OPA_InitStruct->Mode << 17) | (OPA_InitStruct->PSEL << 19)
+                | (OPA_InitStruct->FB << 21) | (OPA_InitStruct->NSEL << 22);
+    }
+
+    tmp0 |= (OPA_InitStruct->PSEL_POLL) | (OPA_InitStruct->BKIN_EN << 2)
+                     | (OPA_InitStruct->RST_EN << 4) | (OPA_InitStruct->BKIN_SEL << 6)
+                     | (OPA_InitStruct->OUT_IE << 8) | (OPA_InitStruct->CNT_IE << 10)
+                     | (OPA_InitStruct->NMI_IE << 11);
+    tmp1 |= OPA_InitStruct->OPA_POLL_Interval;
+
+    OPA->CFGR1 = tmp0;
+    OPA->CFGR2 = tmp1;
+    OPA->CTLR1 = tmp2;
+}
+
+/*********************************************************************
+ * @fn      OPA_StructInit
+ *
+ * @brief   Fills each OPA_StructInit member with its reset value.
+ *
+ * @param   OPA_StructInit - pointer to a OPA_InitTypeDef structure
+ *
+ * @return  none
+ */
+void OPA_StructInit(OPA_InitTypeDef *OPA_InitStruct)
+{
+    OPA_InitStruct->OPA_POLL_Interval = 0;
+    OPA_InitStruct->OPA_NUM = OPA1;
+    OPA_InitStruct->Mode = OUT_IO_OUT0;
+    OPA_InitStruct->PSEL = CHP0;
+    OPA_InitStruct->FB = FB_OFF;
+    OPA_InitStruct->NSEL = CHN0;
+    OPA_InitStruct->PSEL_POLL = CHP_OPA1_OFF_OPA2_OFF;
+    OPA_InitStruct->BKIN_EN = BKIN_OPA1_OFF_OPA2_OFF;
+    OPA_InitStruct->RST_EN = RST_OPA1_OFF_OPA2_OFF;
+    OPA_InitStruct->BKIN_SEL = BKIN_OPA1_TIM1_OPA2_TIM2;
+    OPA_InitStruct->OUT_IE = OUT_IE_OPA1_OFF_OPA2_OFF;
+    OPA_InitStruct->CNT_IE = CNT_IE_OFF;
+    OPA_InitStruct->NMI_IE = NMI_IE_OFF;
+    OPA_InitStruct->POLL_NUM = CHP_POLL_NUM_1;
+}
+
+/*********************************************************************
+ * @fn      OPA_Cmd
+ *
+ * @brief   Enables or disables the specified OPA peripheral.
+ *
+ * @param   OPA_NUM - Select OPA
+ *            NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void OPA_Cmd(OPA_Num_TypeDef OPA_NUM, FunctionalState NewState)
+{
+    if(NewState == ENABLE)
+    {
+        OPA->CTLR1 |= (uint32_t)(1 << (OPA_NUM*16));
+    }
+    else
+    {
+        OPA->CTLR1 &= ~(uint32_t)(1 << (OPA_NUM*16));
+    }
+}
+
+/*********************************************************************
+ * @fn      OPA_CMP_Init
+ *
+ * @brief   Initializes the CMP peripheral according to the specified
+ *        parameters in the CMP_InitTypeDef.
+ *
+ * @param   CMP_InitStruct - pointer to a CMP_InitTypeDef structure
+ *
+ * @return  none
+ */
+void OPA_CMP_Init(CMP_InitTypeDef *CMP_InitStruct)
+{
+    uint32_t tmp1 = 0;
+
+    tmp1 = CTLR2_tmp;
+
+    if(CMP_InitStruct->CMP_NUM == CMP1)
+    {
+        tmp1 &= 0xFFFFFFE1;
+        tmp1 |= (CMP_InitStruct->Mode << 1) | (CMP_InitStruct->NSEL << 2)
+                | (CMP_InitStruct->PSEL << 3) | (CMP_InitStruct->HYEN << 4);
+    }
+    else if(CMP_InitStruct->CMP_NUM == CMP2)
+    {
+        tmp1 &= 0xFFFFFC3F;
+        tmp1 |= (CMP_InitStruct->Mode << 6) | (CMP_InitStruct->NSEL << 7)
+                | (CMP_InitStruct->PSEL << 8) | (CMP_InitStruct->HYEN << 9);
+    }
+    else if(CMP_InitStruct->CMP_NUM == CMP3)
+    {
+        tmp1 &= 0xFFFF87FF;
+        tmp1 |= (CMP_InitStruct->Mode << 11) | (CMP_InitStruct->NSEL << 12)
+                | (CMP_InitStruct->PSEL << 13) | (CMP_InitStruct->HYEN << 14);
+    }
+
+    CTLR2_tmp = tmp1;
+    OPA->CTLR2 = tmp1;
+}
+
+/*********************************************************************
+ * @fn      OPA_CMP_StructInit
+ *
+ * @brief   Fills each OPA_CMP_StructInit member with its reset value.
+ *
+ * @param   CMP_StructInit - pointer to a OPA_CMP_StructInit structure
+ *
+ * @return  none
+ */
+void OPA_CMP_StructInit(CMP_InitTypeDef *CMP_InitStruct)
+{
+    CMP_InitStruct->CMP_NUM = CMP1;
+    CMP_InitStruct->Mode = OUT_IO_TIM2_CH1;
+    CMP_InitStruct->NSEL = CMP_CHN0;
+    CMP_InitStruct->PSEL = CMP_CHP1;
+    CMP_InitStruct->HYEN = CMP_HYEN1;
+}
+
+/*********************************************************************
+ * @fn      OPA_CMP_Cmd
+ *
+ * @brief   Enables or disables the specified CMP peripheral.
+ *
+ * @param   CMP_NUM - Select CMP
+ *            NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void OPA_CMP_Cmd(CMP_Num_TypeDef CMP_NUM, FunctionalState NewState)
+{
+    if(NewState == ENABLE)
+    {
+        CTLR2_tmp |= (uint32_t)(1 << (CMP_NUM*5));
+    }
+    else
+    {
+        CTLR2_tmp &= ~(uint32_t)(1 << (CMP_NUM*5));
+    }
+
+    OPA->CTLR2 = CTLR2_tmp;
+}
+
+/*********************************************************************
+ * @fn      OPA_GetFlagStatus
+ *
+ * @brief   Checks whether the OPA flag is set or not.
+ *
+ * @param   OPA_FLAG - specifies the SPI/I2S flag to check.
+ *            OPA_FLAG_OUT_OPA1 - OPA1 out flag
+ *            OPA_FLAG_OUT_OPA2 - OPA2 out flag
+ *            OPA_FLAG_OUT_CNT - OPA out flag rising edge of sampling data
+ *
+ * @return  FlagStatus: SET or RESET.
+ */
+FlagStatus OPA_GetFlagStatus(uint16_t OPA_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+    if((OPA->CFGR1 & OPA_FLAG) != (uint16_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      OPA_ClearFlag
+ *
+ * @brief   Clears the OPA flag.
+ *
+ * @param   OPA_FLAG - specifies the OPA flag to clear.
+ *            OPA_FLAG_OUT_OPA1 - OPA1 out flag
+ *            OPA_FLAG_OUT_OPA2 - OPA2 out flag
+ *            OPA_FLAG_OUT_CNT - OPA out flag rising edge of sampling data
+ * @return  none
+ */
+void OPA_ClearFlag(uint16_t OPA_FLAG)
+{
+    OPA->CFGR1 &= (uint16_t)~OPA_FLAG;
+}

--- a/Peripheral/ch32x035/src/ch32x035_pwr.c
+++ b/Peripheral/ch32x035/src/ch32x035_pwr.c
@@ -1,0 +1,130 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_pwr.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the PWR firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_pwr.h"
+#include "ch32x035_rcc.h"
+
+/* PWR registers bit mask */
+/* CTLR register bit mask */
+#define CTLR_DS_MASK     ((uint32_t)0xFFFFFFFD)
+#define CTLR_PLS_MASK    ((uint32_t)0xFFFFFF9F)
+
+/*********************************************************************
+ * @fn      PWR_DeInit
+ *
+ * @brief   Deinitializes the PWR peripheral registers to their default
+ *        reset values.
+ *
+ * @return  none
+ */
+void PWR_DeInit(void)
+{
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_PWR, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_PWR, DISABLE);
+}
+
+/*********************************************************************
+ * @fn      PWR_PVDLevelConfig
+ *
+ * @brief   Configures the voltage threshold detected by the Power Voltage
+ *        Detector(PVD).
+ *
+ * @param   PWR_PVDLevel - specifies the PVD detection level
+ *            PWR_PVDLevel_2V1 - PVD detection level set to 2.1V
+ *            PWR_PVDLevel_2V3 - PVD detection level set to 2.3V
+ *            PWR_PVDLevel_3V0 - PVD detection level set to 3.0V
+ *            PWR_PVDLevel_4V0 - PVD detection level set to 4.0V
+ *
+ * @return  none
+ */
+void PWR_PVDLevelConfig(uint32_t PWR_PVDLevel)
+{
+    uint32_t tmpreg = 0;
+    tmpreg = PWR->CTLR;
+    tmpreg &= CTLR_PLS_MASK;
+    tmpreg |= PWR_PVDLevel;
+    PWR->CTLR = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      PWR_EnterSTOPMode
+ *
+ * @brief   Enters STOP mode.
+ *
+ * @param   PWR_STOPEntry - specifies if STOP mode in entered with WFI or WFE instruction.
+ *            PWR_STOPEntry_WFI - enter STOP mode with WFI instruction
+ *            PWR_STOPEntry_WFE - enter STOP mode with WFE instruction
+ *
+ * @return  none
+ */
+void PWR_EnterSTOPMode(uint8_t PWR_STOPEntry)
+{
+    uint32_t tmpreg = 0;
+    tmpreg = PWR->CTLR;
+    tmpreg &= CTLR_DS_MASK;
+    PWR->CTLR = tmpreg;
+
+    NVIC->SCTLR |= (1 << 2);
+
+    if(PWR_STOPEntry == PWR_STOPEntry_WFI)
+    {
+        __WFI();
+    }
+    else
+    {
+        __WFE();
+    }
+
+    NVIC->SCTLR &= ~(1 << 2);
+}
+
+/*********************************************************************
+ * @fn      PWR_EnterSTANDBYMode
+ *
+ * @brief   Enters STANDBY mode.
+ *
+ * @return  none
+ */
+void PWR_EnterSTANDBYMode(void)
+{
+    PWR->CTLR |= PWR_CTLR_PDDS;
+    NVIC->SCTLR |= (1 << 2);
+
+    __WFI();
+}
+
+/*********************************************************************
+ * @fn      PWR_GetFlagStatus
+ *
+ * @brief   Checks whether the specified PWR flag is set or not.
+ *
+ * @param   PWR_FLAG - specifies the flag to check.
+ *            PWR_FLAG_PVDO - PVD Output
+ *            PWR_FLAG_FLASH - Flash low power flag
+ *
+ * @return  none
+ */
+FlagStatus PWR_GetFlagStatus(uint32_t PWR_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+    if((PWR->CSR & PWR_FLAG) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+

--- a/Peripheral/ch32x035/src/ch32x035_rcc.c
+++ b/Peripheral/ch32x035/src/ch32x035_rcc.c
@@ -1,0 +1,411 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_rcc.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the RCC firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "ch32x035_rcc.h"
+
+/* RCC registers bit mask */
+
+/* CTLR register bit mask */
+#define CTLR_HSITRIM_Mask           ((uint32_t)0xFFFFFF07)
+
+/* CFGR0 register bit mask */
+#define CFGR0_HPRE_Reset_Mask       ((uint32_t)0xFFFFFF0F)
+#define CFGR0_HPRE_Set_Mask         ((uint32_t)0x000000F0)
+
+/* RSTSCKR register bit mask */
+#define RSTSCKR_RMVF_Set            ((uint32_t)0x01000000)
+
+/* RCC Flag Mask */
+#define FLAG_Mask                   ((uint8_t)0x1F)
+
+/* CFGR0 register byte 4 (Bits[31:24]) base address */
+#define CFGR0_BYTE4_ADDRESS         ((uint32_t)0x40021007)
+
+
+static __I uint8_t APBAHBPrescTable[16] = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+
+/*********************************************************************
+ * @fn      RCC_DeInit
+ *
+ * @brief   Resets the RCC clock configuration to the default reset state.
+ *          Note-
+ *          HSE can not be stopped if it is used directly or through the PLL as system clock.
+ * @return  none
+ */
+void RCC_DeInit(void)
+{
+    RCC->CTLR |= (uint32_t)0x00000001;
+    RCC->CFGR0 |= (uint32_t)0x00000050;
+    RCC->CFGR0 &= (uint32_t)0xF8FFFF5F;
+}
+
+/*********************************************************************
+ * @fn      RCC_AdjustHSICalibrationValue
+ *
+ * @brief   Adjusts the Internal High Speed oscillator (HSI) calibration value.
+ *
+ * @param   HSICalibrationValue - specifies the calibration trimming value.
+ *                    This parameter must be a number between 0 and 0x1F.
+ *
+ * @return  none
+ */
+void RCC_AdjustHSICalibrationValue(uint8_t HSICalibrationValue)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CTLR;
+  tmpreg &= CTLR_HSITRIM_Mask;
+  tmpreg |= (uint32_t)HSICalibrationValue << 3;
+  RCC->CTLR = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_HSICmd
+ *
+ * @brief   Enables or disables the Internal High Speed oscillator (HSI).
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_HSICmd(FunctionalState NewState)
+{
+	if(NewState)
+	{
+		RCC->CTLR |= (1<<0);
+	}
+	else{
+		RCC->CTLR &= ~(1<<0);		
+	}
+}
+
+/*********************************************************************
+ * @fn      RCC_HCLKConfig
+ *
+ * @brief   Configures the AHB clock (HCLK).
+ *
+ * @param   RCC_SYSCLK - defines the AHB clock divider. This clock is derived from
+ *        the system clock (SYSCLK).
+ *            RCC_SYSCLK_Div1 - AHB clock = SYSCLK.
+ *            RCC_SYSCLK_Div2 - AHB clock = SYSCLK/2.
+ *            RCC_SYSCLK_Div3 - AHB clock = SYSCLK/3.
+ *            RCC_SYSCLK_Div4 - AHB clock = SYSCLK/4.
+ *            RCC_SYSCLK_Div5 - AHB clock = SYSCLK/5.
+ *            RCC_SYSCLK_Div6 - AHB clock = SYSCLK/6.
+ *            RCC_SYSCLK_Div7 - AHB clock = SYSCLK/7.
+ *            RCC_SYSCLK_Div8 - AHB clock = SYSCLK/8.
+ *            RCC_SYSCLK_Div16 - AHB clock = SYSCLK/16.
+ *            RCC_SYSCLK_Div32 - AHB clock = SYSCLK/32.
+ *            RCC_SYSCLK_Div64 - AHB clock = SYSCLK/64.
+ *            RCC_SYSCLK_Div128 - AHB clock = SYSCLK/128.
+ *            RCC_SYSCLK_Div256 - AHB clock = SYSCLK/256.
+ *
+ * @return  none
+ */
+void RCC_HCLKConfig(uint32_t RCC_SYSCLK)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CFGR0;
+  tmpreg &= CFGR0_HPRE_Reset_Mask;
+  tmpreg |= RCC_SYSCLK;
+  RCC->CFGR0 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_GetClocksFreq
+ *
+ * @brief   The result of this function could be not correct when using
+ *        fractional value for HSE crystal.
+ *
+ * @param   RCC_Clocks - pointer to a RCC_ClocksTypeDef structure which will hold
+ *        the clocks frequencies.
+ *
+ * @return  none
+ */
+void RCC_GetClocksFreq(RCC_ClocksTypeDef* RCC_Clocks)
+{
+    uint32_t tmp = 0, presc = 0;
+
+    RCC_Clocks->SYSCLK_Frequency = HSI_VALUE;
+
+    tmp = RCC->CFGR0 & CFGR0_HPRE_Set_Mask;
+    tmp = tmp >> 4;
+    presc = APBAHBPrescTable[tmp];
+
+    if(((RCC->CFGR0 & CFGR0_HPRE_Set_Mask) >> 4) < 8)
+    {
+        RCC_Clocks->HCLK_Frequency = RCC_Clocks->SYSCLK_Frequency / presc;
+    }
+    else
+    {
+        RCC_Clocks->HCLK_Frequency = RCC_Clocks->SYSCLK_Frequency >> presc;
+    }
+
+    RCC_Clocks->PCLK1_Frequency = RCC_Clocks->HCLK_Frequency;
+    RCC_Clocks->PCLK2_Frequency = RCC_Clocks->HCLK_Frequency;
+}
+
+/*********************************************************************
+ * @fn      RCC_AHBPeriphClockCmd
+ *
+ * @brief   Enables or disables the AHB peripheral clock.
+ *
+ * @param   RCC_AHBPeriph - specifies the AHB peripheral to gates its clock.
+ *            RCC_AHBPeriph_DMA1.
+ *            RCC_AHBPeriph_SRAM.
+ *            RCC_AHBPeriph_USBFS.
+ *            RCC_AHBPeriph_USBPD
+ *          Note-
+ *          SRAM  clock can be disabled only during sleep mode.
+ *          NewState: ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_AHBPeriphClockCmd(uint32_t RCC_AHBPeriph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->AHBPCENR |= RCC_AHBPeriph;
+  }
+  else
+  {
+    RCC->AHBPCENR &= ~RCC_AHBPeriph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB2PeriphClockCmd
+ *
+ * @brief   Enables or disables the High Speed APB (APB2) peripheral clock.
+ *
+ * @param   RCC_APB2Periph - specifies the APB2 peripheral to gates its clock.
+ *            RCC_APB2Periph_AFIO.
+ *            RCC_APB2Periph_GPIOA.
+ *            RCC_APB2Periph_GPIOB.
+ *            RCC_APB2Periph_GPIOC.
+ *            RCC_APB2Periph_ADC1.
+ *            RCC_APB2Periph_TIM1.
+ *            RCC_APB2Periph_SPI1.
+ *            RCC_APB2Periph_USART1.
+ *          NewState - ENABLE or DISABLE
+ *
+ * @return  none
+ */
+void RCC_APB2PeriphClockCmd(uint32_t RCC_APB2Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB2PCENR |= RCC_APB2Periph;
+  }
+  else
+  {
+    RCC->APB2PCENR &= ~RCC_APB2Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB1PeriphClockCmd
+ *
+ * @brief   Enables or disables the Low Speed APB (APB1) peripheral clock.
+ *
+ * @param   RCC_APB1Periph - specifies the APB1 peripheral to gates its clock.
+ *            RCC_APB1Periph_TIM2.
+ *            RCC_APB1Periph_TIM3.
+ *            RCC_APB1Periph_WWDG.
+ *            RCC_APB1Periph_USART2.
+ *            RCC_APB1Periph_USART3.
+ *            RCC_APB1Periph_USART4
+ *            RCC_APB1Periph_I2C1.
+ *            RCC_APB1Periph_PWR.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_APB1PeriphClockCmd(uint32_t RCC_APB1Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB1PCENR |= RCC_APB1Periph;
+  }
+  else
+  {
+    RCC->APB1PCENR &= ~RCC_APB1Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_AHBPeriphResetCmd
+ *
+ * @brief   Forces or releases AHB peripheral reset.
+ *
+ * @param   RCC_AHBPeriph - specifies the AHB peripheral to reset.
+ *            RCC_AHBPeriph_USBFS.
+ *            RCC_AHBPeriph_IO2W.
+ *            RCC_AHBPeriph_USBPD.
+ *          NewState: ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_AHBPeriphResetCmd(uint32_t RCC_AHBPeriph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->AHBPCENR |= RCC_AHBPeriph;
+  }
+  else
+  {
+    RCC->AHBPCENR &= ~RCC_AHBPeriph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB2PeriphResetCmd
+ *
+ * @brief   Forces or releases APB (APB2) peripheral reset.
+ *
+ * @param   RCC_APB2Periph - specifies the APB2 peripheral to reset.
+ *            RCC_APB2Periph_AFIO.
+ *            RCC_APB2Periph_GPIOA.
+ *            RCC_APB2Periph_GPIOB.
+ *            RCC_APB2Periph_GPIOC.
+ *            RCC_APB2Periph_ADC1.
+ *            RCC_APB2Periph_TIM1.
+ *            RCC_APB2Periph_SPI1.
+ *            RCC_APB2Periph_USART1.
+ *          NewState - ENABLE or DISABLE
+ *
+ * @return  none
+ */
+void RCC_APB2PeriphResetCmd(uint32_t RCC_APB2Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB2PRSTR |= RCC_APB2Periph;
+  }
+  else
+  {
+    RCC->APB2PRSTR &= ~RCC_APB2Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB1PeriphResetCmd
+ *
+ * @brief   Forces or releases APB (APB1) peripheral reset.
+ *
+ * @param   RCC_APB1Periph - specifies the APB1 peripheral to reset.
+ *            RCC_APB1Periph_TIM2.
+ *            RCC_APB1Periph_TIM3.
+ *            RCC_APB1Periph_WWDG.
+ *            RCC_APB1Periph_USART2.
+ *            RCC_APB1Periph_USART3.
+ *            RCC_APB1Periph_USART4
+ *            RCC_APB1Periph_I2C1.
+ *            RCC_APB1Periph_PWR.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_APB1PeriphResetCmd(uint32_t RCC_APB1Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB1PRSTR |= RCC_APB1Periph;
+  }
+  else
+  {
+    RCC->APB1PRSTR &= ~RCC_APB1Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_MCOConfig
+ *
+ * @brief   Selects the clock source to output on MCO pin.
+ *
+ * @param   RCC_MCO - specifies the clock source to output.
+ *            RCC_MCO_NoClock - No clock selected.
+ *            RCC_MCO_SYSCLK - System clock selected.
+ *            RCC_MCO_HSI - HSI oscillator clock selected.
+ *
+ * @return  none
+ */
+void RCC_MCOConfig(uint8_t RCC_MCO)
+{
+  *(__IO uint8_t *) CFGR0_BYTE4_ADDRESS = RCC_MCO;
+}
+
+/*********************************************************************
+ * @fn      RCC_GetFlagStatus
+ *
+ * @brief   Checks whether the specified RCC flag is set or not.
+ *
+ * @param   RCC_FLAG - specifies the flag to check.
+ *            RCC_FLAG_HSIRDY - HSI oscillator clock ready.
+ *            RCC_FLAG_OPARST - OPA reset.
+ *            RCC_FLAG_PINRST - Pin reset.
+ *            RCC_FLAG_PORRST - POR/PDR reset.
+ *            RCC_FLAG_SFTRST - Software reset.
+ *            RCC_FLAG_IWDGRST - Independent Watchdog reset.
+ *            RCC_FLAG_WWDGRST - Window Watchdog reset.
+ *            RCC_FLAG_LPWRRST - Low Power reset.
+ *
+ * @return  FlagStatus - SET or RESET.
+ */
+FlagStatus RCC_GetFlagStatus(uint8_t RCC_FLAG)
+{
+  uint32_t tmp = 0;
+  uint32_t statusreg = 0;
+	
+  FlagStatus bitstatus = RESET;
+  tmp = RCC_FLAG >> 5;
+	
+  if (tmp == 1)            
+  {
+    statusreg = RCC->CTLR;
+  }
+  else                    
+  {
+    statusreg = RCC->RSTSCKR;
+  }
+
+  tmp = RCC_FLAG & FLAG_Mask;
+	
+  if ((statusreg & ((uint32_t)1 << tmp)) != (uint32_t)RESET)
+  {
+    bitstatus = SET;
+  }
+  else
+  {
+    bitstatus = RESET;
+  }
+
+  return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      RCC_ClearFlag
+ *
+ * @brief   Clears the RCC reset flags.
+ *          Note-   
+ *          The reset flags are: RCC_FLAG_PINRST, RCC_FLAG_PORRST, RCC_FLAG_SFTRST,
+ *          RCC_FLAG_IWDGRST, RCC_FLAG_WWDGRST, RCC_FLAG_LPWRRST
+ * @return  none
+ */
+void RCC_ClearFlag(void)
+{
+  RCC->RSTSCKR |= RSTSCKR_RMVF_Set;
+}
+
+
+
+

--- a/Peripheral/ch32x035/src/ch32x035_spi.c
+++ b/Peripheral/ch32x035/src/ch32x035_spi.c
@@ -1,0 +1,506 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_spi.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the SPI firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_spi.h"
+#include "ch32x035_rcc.h"
+
+/* SPI SPE mask */
+#define CTLR1_SPE_Set         ((uint16_t)0x0040)
+#define CTLR1_SPE_Reset       ((uint16_t)0xFFBF)
+
+/* SPI CRCNext mask */
+#define CTLR1_CRCNext_Set     ((uint16_t)0x1000)
+
+/* SPI CRCEN mask */
+#define CTLR1_CRCEN_Set       ((uint16_t)0x2000)
+#define CTLR1_CRCEN_Reset     ((uint16_t)0xDFFF)
+
+/* SPI SSOE mask */
+#define CTLR2_SSOE_Set        ((uint16_t)0x0004)
+#define CTLR2_SSOE_Reset      ((uint16_t)0xFFFB)
+
+/* SPI registers Masks */
+#define CTLR1_CLEAR_Mask      ((uint16_t)0x3040)
+
+/*********************************************************************
+ * @fn      SPI_I2S_DeInit
+ *
+ * @brief   Deinitializes the SPIx peripheral registers to their default
+ *        reset values (Affects also the I2Ss).
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *
+ * @return  none
+ */
+void SPI_I2S_DeInit(SPI_TypeDef *SPIx)
+{
+    if(SPIx == SPI1)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_SPI1, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_SPI1, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_Init
+ *
+ * @brief   Initializes the SPIx peripheral according to the specified
+ *        parameters in the SPI_InitStruct.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          SPI_InitStruct - pointer to a SPI_InitTypeDef structure that
+ *        contains the configuration information for the specified SPI peripheral.
+ *
+ * @return  none
+ */
+void SPI_Init(SPI_TypeDef *SPIx, SPI_InitTypeDef *SPI_InitStruct)
+{
+    uint16_t tmpreg = 0;
+
+    tmpreg = SPIx->CTLR1;
+    tmpreg &= CTLR1_CLEAR_Mask;
+    tmpreg |= (uint16_t)((uint32_t)SPI_InitStruct->SPI_Direction | SPI_InitStruct->SPI_Mode |
+                         SPI_InitStruct->SPI_DataSize | SPI_InitStruct->SPI_CPOL |
+                         SPI_InitStruct->SPI_CPHA | SPI_InitStruct->SPI_NSS |
+                         SPI_InitStruct->SPI_BaudRatePrescaler | SPI_InitStruct->SPI_FirstBit);
+
+    SPIx->CTLR1 = tmpreg;
+    SPIx->CRCR = SPI_InitStruct->SPI_CRCPolynomial;
+}
+
+/*********************************************************************
+ * @fn      SPI_StructInit
+ *
+ * @brief   Fills each SPI_InitStruct member with its default value.
+ *
+ * @param   SPI_InitStruct - pointer to a SPI_InitTypeDef structure which
+ *        will be initialized.
+ *
+ * @return  none
+ */
+void SPI_StructInit(SPI_InitTypeDef *SPI_InitStruct)
+{
+    SPI_InitStruct->SPI_Direction = SPI_Direction_2Lines_FullDuplex;
+    SPI_InitStruct->SPI_Mode = SPI_Mode_Slave;
+    SPI_InitStruct->SPI_DataSize = SPI_DataSize_8b;
+    SPI_InitStruct->SPI_CPOL = SPI_CPOL_Low;
+    SPI_InitStruct->SPI_CPHA = SPI_CPHA_1Edge;
+    SPI_InitStruct->SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_2;
+    /*"SPI_FirstBit_LSB" not support SPI slave mode*/
+    SPI_InitStruct->SPI_FirstBit = SPI_FirstBit_MSB;
+    SPI_InitStruct->SPI_CRCPolynomial = 7;
+}
+
+/*********************************************************************
+ * @fn      SPI_Cmd
+ *
+ * @brief   Enables or disables the specified SPI peripheral.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void SPI_Cmd(SPI_TypeDef *SPIx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        SPIx->CTLR1 |= CTLR1_SPE_Set;
+    }
+    else
+    {
+        SPIx->CTLR1 &= CTLR1_SPE_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_ITConfig
+ *
+ * @brief   Enables or disables the specified SPI interrupts.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          SPI_I2S_IT - specifies the SPI interrupt source to be
+ *        enabled or disabled.
+ *            SPI_I2S_IT_TXE - Tx buffer empty interrupt mask.
+ *            SPI_I2S_IT_RXNE - Rx buffer not empty interrupt mask.
+ *            SPI_I2S_IT_ERR - Error interrupt mask.
+ *          NewState: ENABLE or DISABLE.
+ * @return  none
+ */
+void SPI_I2S_ITConfig(SPI_TypeDef *SPIx, uint8_t SPI_I2S_IT, FunctionalState NewState)
+{
+    uint16_t itpos = 0, itmask = 0;
+
+    itpos = SPI_I2S_IT >> 4;
+    itmask = (uint16_t)1 << (uint16_t)itpos;
+
+    if(NewState != DISABLE)
+    {
+        SPIx->CTLR2 |= itmask;
+    }
+    else
+    {
+        SPIx->CTLR2 &= (uint16_t)~itmask;
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_DMACmd
+ *
+ * @brief   Enables or disables the SPIxDMA interface.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          SPI_I2S_DMAReq - specifies the SPI DMA transfer request to
+ *        be enabled or disabled.
+ *            SPI_I2S_DMAReq_Tx - Tx buffer DMA transfer request.
+ *            SPI_I2S_DMAReq_Rx - Rx buffer DMA transfer request.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void SPI_I2S_DMACmd(SPI_TypeDef *SPIx, uint16_t SPI_I2S_DMAReq, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        SPIx->CTLR2 |= SPI_I2S_DMAReq;
+    }
+    else
+    {
+        SPIx->CTLR2 &= (uint16_t)~SPI_I2S_DMAReq;
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_SendData
+ *
+ * @brief   Transmits a Data through the SPIx peripheral.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          Data - Data to be transmitted.
+ *
+ * @return  none
+ */
+void SPI_I2S_SendData(SPI_TypeDef *SPIx, uint16_t Data)
+{
+    SPIx->DATAR = Data;
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_ReceiveData
+ *
+ * @brief   Returns the most recent received data by the SPIx peripheral.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          Data - Data to be transmitted.
+ *
+ * @return  SPIx->DATAR - The value of the received data.
+ */
+uint16_t SPI_I2S_ReceiveData(SPI_TypeDef *SPIx)
+{
+    return SPIx->DATAR;
+}
+
+/*********************************************************************
+ * @fn      SPI_NSSInternalSoftwareConfig
+ *
+ * @brief   Configures internally by software the NSS pin for the selected SPI.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          SPI_NSSInternalSoft -
+ *            SPI_NSSInternalSoft_Set - Set NSS pin internally.
+ *            SPI_NSSInternalSoft_Reset - Reset NSS pin internally.
+ *
+ * @return  none
+ */
+void SPI_NSSInternalSoftwareConfig(SPI_TypeDef *SPIx, uint16_t SPI_NSSInternalSoft)
+{
+    if(SPI_NSSInternalSoft != SPI_NSSInternalSoft_Reset)
+    {
+        SPIx->CTLR1 |= SPI_NSSInternalSoft_Set;
+    }
+    else
+    {
+        SPIx->CTLR1 &= SPI_NSSInternalSoft_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_SSOutputCmd
+ *
+ * @brief   Enables or disables the SS output for the selected SPI.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          NewState - new state of the SPIx SS output.
+ *
+ * @return  none
+ */
+void SPI_SSOutputCmd(SPI_TypeDef *SPIx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        SPIx->CTLR2 |= CTLR2_SSOE_Set;
+    }
+    else
+    {
+        SPIx->CTLR2 &= CTLR2_SSOE_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_DataSizeConfig
+ *
+ * @brief   Configures the data size for the selected SPI.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          SPI_DataSize - specifies the SPI data size.
+ *            SPI_DataSize_16b - Set data frame format to 16bit.
+ *            SPI_DataSize_8b - Set data frame format to 8bit.
+ *
+ * @return  none
+ */
+void SPI_DataSizeConfig(SPI_TypeDef *SPIx, uint16_t SPI_DataSize)
+{
+    SPIx->CTLR1 &= (uint16_t)~SPI_DataSize_16b;
+    SPIx->CTLR1 |= SPI_DataSize;
+}
+
+/*********************************************************************
+ * @fn      SPI_TransmitCRC
+ *
+ * @brief   Transmit the SPIx CRC value.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *
+ * @return  none
+ */
+void SPI_TransmitCRC(SPI_TypeDef *SPIx)
+{
+    SPIx->CTLR1 |= CTLR1_CRCNext_Set;
+}
+
+/*********************************************************************
+ * @fn      SPI_CalculateCRC
+ *
+ * @brief   Enables or disables the CRC value calculation of the transferred bytes.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          NewState - new state of the SPIx CRC value calculation.
+ *
+ * @return  none
+ */
+void SPI_CalculateCRC(SPI_TypeDef *SPIx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        SPIx->CTLR1 |= CTLR1_CRCEN_Set;
+    }
+    else
+    {
+        SPIx->CTLR1 &= CTLR1_CRCEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_GetCRC
+ *
+ * @brief   Returns the transmit or the receive CRC register value for the specified SPI.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          SPI_CRC - specifies the CRC register to be read.
+ *            SPI_CRC_Tx - Selects Tx CRC register.
+ *            SPI_CRC_Rx - Selects Rx CRC register.
+ *
+ * @return  crcreg: The selected CRC register value.
+ */
+uint16_t SPI_GetCRC(SPI_TypeDef *SPIx, uint8_t SPI_CRC)
+{
+    uint16_t crcreg = 0;
+
+    if(SPI_CRC != SPI_CRC_Rx)
+    {
+        crcreg = SPIx->TCRCR;
+    }
+    else
+    {
+        crcreg = SPIx->RCRCR;
+    }
+
+    return crcreg;
+}
+
+/*********************************************************************
+ * @fn      SPI_GetCRCPolynomial
+ *
+ * @brief   Returns the CRC Polynomial register value for the specified SPI.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *
+ * @return  SPIx->CRCR - The CRC Polynomial register value.
+ */
+uint16_t SPI_GetCRCPolynomial(SPI_TypeDef *SPIx)
+{
+    return SPIx->CRCR;
+}
+
+/*********************************************************************
+ * @fn      SPI_BiDirectionalLineConfig
+ *
+ * @brief   Selects the data transfer direction in bi-directional mode
+ *      for the specified SPI.
+ *
+ * @param   SPIx - where x can be 1 to select the SPI peripheral.
+ *          SPI_Direction - specifies the data transfer direction in
+ *        bi-directional mode.
+ *            SPI_Direction_Tx - Selects Tx transmission direction.
+ *            SPI_Direction_Rx - Selects Rx receive direction.
+ *
+ * @return  none
+ */
+void SPI_BiDirectionalLineConfig(SPI_TypeDef *SPIx, uint16_t SPI_Direction)
+{
+    if(SPI_Direction == SPI_Direction_Tx)
+    {
+        SPIx->CTLR1 |= SPI_Direction_Tx;
+    }
+    else
+    {
+        SPIx->CTLR1 &= SPI_Direction_Rx;
+    }
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_GetFlagStatus
+ *
+ * @brief   Checks whether the specified SPI/I2S flag is set or not.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          SPI_I2S_FLAG - specifies the SPI/I2S flag to check.
+ *            SPI_I2S_FLAG_TXE - Transmit buffer empty flag.
+ *            SPI_I2S_FLAG_RXNE - Receive buffer not empty flag.
+ *            SPI_I2S_FLAG_BSY - Busy flag.
+ *            SPI_I2S_FLAG_OVR - Overrun flag.
+ *            SPI_FLAG_MODF - Mode Fault flag.
+ *            SPI_FLAG_CRCERR - CRC Error flag.
+ *
+ * @return  FlagStatus: SET or RESET.
+ */
+FlagStatus SPI_I2S_GetFlagStatus(SPI_TypeDef *SPIx, uint16_t SPI_I2S_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+    if((SPIx->STATR & SPI_I2S_FLAG) != (uint16_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_ClearFlag
+ *
+ * @brief   Clears the SPIx CRC Error (CRCERR) flag.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          SPI_I2S_FLAG - specifies the SPI flag to clear.
+ *            SPI_FLAG_CRCERR - CRC Error flag.
+ *          Note-
+ *          - OVR (OverRun error) flag is cleared by software sequence: a read 
+ *          operation to SPI_DATAR register (SPI_I2S_ReceiveData()) followed by a read 
+ *          operation to SPI_STATR register (SPI_I2S_GetFlagStatus()).
+ *          - UDR (UnderRun error) flag is cleared by a read operation to 
+ *          SPI_STATR register (SPI_I2S_GetFlagStatus()).
+ *          - MODF (Mode Fault) flag is cleared by software sequence: a read/write 
+ *          operation to SPI_STATR register (SPI_I2S_GetFlagStatus()) followed by a 
+ *          write operation to SPI_CTLR1 register (SPI_Cmd() to enable the SPI).
+ * @return  FlagStatus: SET or RESET.
+ */
+void SPI_I2S_ClearFlag(SPI_TypeDef *SPIx, uint16_t SPI_I2S_FLAG)
+{
+    SPIx->STATR = (uint16_t)~SPI_I2S_FLAG;
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_GetITStatus
+ *
+ * @brief   Checks whether the specified SPI/I2S interrupt has occurred or not.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          SPI_I2S_IT - specifies the SPI/I2S interrupt source to check..
+ *            SPI_I2S_IT_TXE - Transmit buffer empty interrupt.
+ *            SPI_I2S_IT_RXNE - Receive buffer not empty interrupt.
+ *            SPI_I2S_IT_OVR - Overrun interrupt.
+ *            SPI_IT_MODF - Mode Fault interrupt.
+ *            SPI_IT_CRCERR - CRC Error interrupt.
+ *
+ * @return  FlagStatus: SET or RESET.
+ */
+ITStatus SPI_I2S_GetITStatus(SPI_TypeDef *SPIx, uint8_t SPI_I2S_IT)
+{
+    ITStatus bitstatus = RESET;
+    uint16_t itpos = 0, itmask = 0, enablestatus = 0;
+
+    itpos = 0x01 << (SPI_I2S_IT & 0x0F);
+    itmask = SPI_I2S_IT >> 4;
+    itmask = 0x01 << itmask;
+    enablestatus = (SPIx->CTLR2 & itmask);
+
+    if(((SPIx->STATR & itpos) != (uint16_t)RESET) && enablestatus)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      SPI_I2S_ClearITPendingBit
+ *
+ * @brief   Clears the SPIx CRC Error (CRCERR) interrupt pending bit.
+ *
+ * @param   SPIx - where x can be
+ *            - 1 in SPI mode.
+ *          SPI_I2S_IT - specifies the SPI interrupt pending bit to clear.
+ *            SPI_IT_CRCERR - CRC Error interrupt.
+ *         Note-
+ *         - OVR (OverRun Error) interrupt pending bit is cleared by software 
+ *         sequence: a read operation to SPI_DATAR register (SPI_I2S_ReceiveData()) 
+ *         followed by a read operation to SPI_STATR register (SPI_I2S_GetITStatus()).
+ *         - UDR (UnderRun Error) interrupt pending bit is cleared by a read 
+ *         operation to SPI_STATR register (SPI_I2S_GetITStatus()).
+ *         - MODF (Mode Fault) interrupt pending bit is cleared by software sequence:
+ *         a read/write operation to SPI_STATR register (SPI_I2S_GetITStatus()) 
+ *         followed by a write operation to SPI_CTLR1 register (SPI_Cmd() to enable 
+ *         the SPI).      
+ * @return  none
+ */
+void SPI_I2S_ClearITPendingBit(SPI_TypeDef *SPIx, uint8_t SPI_I2S_IT)
+{
+    uint16_t itpos = 0;
+
+    itpos = 0x01 << (SPI_I2S_IT & 0x0F);
+    SPIx->STATR = (uint16_t)~itpos;
+}

--- a/Peripheral/ch32x035/src/ch32x035_tim.c
+++ b/Peripheral/ch32x035/src/ch32x035_tim.c
@@ -1,0 +1,2457 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_tim.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the TIM firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_tim.h"
+#include "ch32x035_rcc.h"
+
+/* TIM registers bit mask */
+#define SMCFGR_ETR_Mask    ((uint16_t)0x00FF)
+#define CHCTLR_Offset      ((uint16_t)0x0018)
+#define CCER_CCE_Set       ((uint16_t)0x0001)
+#define CCER_CCNE_Set      ((uint16_t)0x0004)
+#define SPEC_OC12_Mask     ((uint16_t)0xFFCE)
+#define SPEC_OC34_Mask     ((uint16_t)0xFF3D)
+
+static void TI1_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI2_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI3_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI4_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+
+/*********************************************************************
+ * @fn      TIM_DeInit
+ *
+ * @brief   Deinitializes the TIMx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *
+ * @return  none
+ */
+void TIM_DeInit(TIM_TypeDef *TIMx)
+{
+    if(TIMx == TIM1)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM1, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM1, DISABLE);
+    }
+    else if(TIMx == TIM2)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM2, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM2, DISABLE);
+    }
+    else if(TIMx == TIM3)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM3, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM3, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_TimeBaseInit
+ *
+ * @brief   Initializes the TIMx Time Base Unit peripheral according to
+ *        the specified parameters in the TIM_TimeBaseInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_TimeBaseInitStruct - pointer to a TIM_TimeBaseInitTypeDef
+ *        structure.
+ *
+ * @return  none
+ */
+void TIM_TimeBaseInit(TIM_TypeDef *TIMx, TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct)
+{
+    uint16_t tmpcr1 = 0;
+
+    tmpcr1 = TIMx->CTLR1;
+
+    if((TIMx == TIM1) || (TIMx == TIM2))
+    {
+        tmpcr1 &= (uint16_t)(~((uint16_t)(TIM_DIR | TIM_CMS)));
+        tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_CounterMode;
+    }
+
+    tmpcr1 &= (uint16_t)(~((uint16_t)TIM_CTLR1_CKD));
+    tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_ClockDivision;
+
+    TIMx->CTLR1 = tmpcr1;
+    TIMx->ATRLR = TIM_TimeBaseInitStruct->TIM_Period;
+    TIMx->PSC = TIM_TimeBaseInitStruct->TIM_Prescaler;
+
+    if((TIMx == TIM1) || (TIMx == TIM2))
+    {
+        TIMx->RPTCR = TIM_TimeBaseInitStruct->TIM_RepetitionCounter;
+    }
+
+    TIMx->SWEVGR = TIM_PSCReloadMode_Immediate;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1Init
+ *
+ * @brief   Initializes the TIMx Channel1 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC1Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~(uint16_t)TIM_CC1E);
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR1;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC1M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC1S));
+    tmpccmrx |= TIM_OCInitStruct->TIM_OCMode;
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC1P));
+    tmpccer |= TIM_OCInitStruct->TIM_OCPolarity;
+    tmpccer |= TIM_OCInitStruct->TIM_OutputState;
+
+    if((TIMx == TIM1)  || (TIMx == TIM2))
+    {
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC1NP));
+        tmpccer |= TIM_OCInitStruct->TIM_OCNPolarity;
+
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC1NE));
+        tmpccer |= TIM_OCInitStruct->TIM_OutputNState;
+
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS1));
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS1N));
+
+        tmpcr2 |= TIM_OCInitStruct->TIM_OCIdleState;
+        tmpcr2 |= TIM_OCInitStruct->TIM_OCNIdleState;
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR1 = tmpccmrx;
+    TIMx->CH1CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2Init
+ *
+ * @brief   Initializes the TIMx Channel2 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC2Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~((uint16_t)TIM_CC2E));
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR1;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC2M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC2S));
+    tmpccmrx |= (uint16_t)(TIM_OCInitStruct->TIM_OCMode << 8);
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC2P));
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 4);
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 4);
+
+    if((TIMx == TIM1) || (TIMx == TIM2))
+    {
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC2NP));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCNPolarity << 4);
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC2NE));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputNState << 4);
+
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS2));
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS2N));
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 2);
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCNIdleState << 2);
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR1 = tmpccmrx;
+    TIMx->CH2CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3Init
+ *
+ * @brief   Initializes the TIMx Channel3 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC3Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~((uint16_t)TIM_CC3E));
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR2;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC3M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC3S));
+    tmpccmrx |= TIM_OCInitStruct->TIM_OCMode;
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC3P));
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 8);
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 8);
+
+    if((TIMx == TIM1) || (TIMx == TIM2))
+    {
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC3NP));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCNPolarity << 8);
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC3NE));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputNState << 8);
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS3));
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS3N));
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 4);
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCNIdleState << 4);
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR2 = tmpccmrx;
+    TIMx->CH3CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4Init
+ *
+ * @brief   Initializes the TIMx Channel4 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC4Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~((uint16_t)TIM_CC4E));
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR2;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC4M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC4S));
+    tmpccmrx |= (uint16_t)(TIM_OCInitStruct->TIM_OCMode << 8);
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC4P));
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 12);
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 12);
+
+    if((TIMx == TIM1) || (TIMx == TIM2))
+    {
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS4));
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 6);
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR2 = tmpccmrx;
+    TIMx->CH4CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_ICInit
+ *
+ * @brief   IInitializes the TIM peripheral according to the specified
+ *        parameters in the TIM_ICInitStruct.
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_ICInitStruct - pointer to a TIM_ICInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_ICInit(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct)
+{
+    if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_1)
+    {
+        TI1_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_2)
+    {
+        TI2_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_3)
+    {
+        TI3_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC3Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else
+    {
+        TI4_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC4Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_PWMIConfig
+ *
+ * @brief   Configures the TIM peripheral according to the specified
+ *        parameters in the TIM_ICInitStruct to measure an external
+ *        PWM signal.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_ICInitStruct - pointer to a TIM_ICInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_PWMIConfig(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct)
+{
+    uint16_t icoppositepolarity = TIM_ICPolarity_Rising;
+    uint16_t icoppositeselection = TIM_ICSelection_DirectTI;
+
+    if(TIM_ICInitStruct->TIM_ICPolarity == TIM_ICPolarity_Rising)
+    {
+        icoppositepolarity = TIM_ICPolarity_Falling;
+    }
+    else
+    {
+        icoppositepolarity = TIM_ICPolarity_Rising;
+    }
+
+    if(TIM_ICInitStruct->TIM_ICSelection == TIM_ICSelection_DirectTI)
+    {
+        icoppositeselection = TIM_ICSelection_IndirectTI;
+    }
+    else
+    {
+        icoppositeselection = TIM_ICSelection_DirectTI;
+    }
+
+    if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_1)
+    {
+        TI1_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity, TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+        TI2_Config(TIMx, icoppositepolarity, icoppositeselection, TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else
+    {
+        TI2_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity, TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+        TI1_Config(TIMx, icoppositepolarity, icoppositeselection, TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_BDTRConfig
+ *
+ * @brief   Configures the: Break feature, dead time, Lock level, the OSSI,
+ *      the OSSR State and the AOE(automatic output enable).
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_BDTRInitStruct - pointer to a TIM_BDTRInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_BDTRConfig(TIM_TypeDef *TIMx, TIM_BDTRInitTypeDef *TIM_BDTRInitStruct)
+{
+    TIMx->BDTR = (uint32_t)TIM_BDTRInitStruct->TIM_OSSRState | TIM_BDTRInitStruct->TIM_OSSIState |
+                 TIM_BDTRInitStruct->TIM_LOCKLevel | TIM_BDTRInitStruct->TIM_DeadTime |
+                 TIM_BDTRInitStruct->TIM_Break | TIM_BDTRInitStruct->TIM_BreakPolarity |
+                 TIM_BDTRInitStruct->TIM_AutomaticOutput;
+}
+
+/*********************************************************************
+ * @fn      TIM_TimeBaseStructInit
+ *
+ * @brief   Fills each TIM_TimeBaseInitStruct member with its default value.
+ *
+ * @param   TIM_TimeBaseInitStruct - pointer to a TIM_TimeBaseInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_TimeBaseStructInit(TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct)
+{
+    TIM_TimeBaseInitStruct->TIM_Period = 0xFFFF;
+    TIM_TimeBaseInitStruct->TIM_Prescaler = 0x0000;
+    TIM_TimeBaseInitStruct->TIM_ClockDivision = TIM_CKD_DIV1;
+    TIM_TimeBaseInitStruct->TIM_CounterMode = TIM_CounterMode_Up;
+    TIM_TimeBaseInitStruct->TIM_RepetitionCounter = 0x0000;
+}
+
+/*********************************************************************
+ * @fn      TIM_OCStructInit
+ *
+ * @brief   Fills each TIM_OCInitStruct member with its default value.
+ *
+ * @param   TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OCStructInit(TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    TIM_OCInitStruct->TIM_OCMode = TIM_OCMode_Timing;
+    TIM_OCInitStruct->TIM_OutputState = TIM_OutputState_Disable;
+    TIM_OCInitStruct->TIM_OutputNState = TIM_OutputNState_Disable;
+    TIM_OCInitStruct->TIM_Pulse = 0x0000;
+    TIM_OCInitStruct->TIM_OCPolarity = TIM_OCPolarity_High;
+    TIM_OCInitStruct->TIM_OCNPolarity = TIM_OCPolarity_High;
+    TIM_OCInitStruct->TIM_OCIdleState = TIM_OCIdleState_Reset;
+    TIM_OCInitStruct->TIM_OCNIdleState = TIM_OCNIdleState_Reset;
+}
+
+/*********************************************************************
+ * @fn      TIM_ICStructInit
+ *
+ * @brief   Fills each TIM_ICInitStruct member with its default value.
+ *
+ * @param   TIM_ICInitStruct - pointer to a TIM_ICInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_ICStructInit(TIM_ICInitTypeDef *TIM_ICInitStruct)
+{
+    TIM_ICInitStruct->TIM_Channel = TIM_Channel_1;
+    TIM_ICInitStruct->TIM_ICPolarity = TIM_ICPolarity_Rising;
+    TIM_ICInitStruct->TIM_ICSelection = TIM_ICSelection_DirectTI;
+    TIM_ICInitStruct->TIM_ICPrescaler = TIM_ICPSC_DIV1;
+    TIM_ICInitStruct->TIM_ICFilter = 0x00;
+}
+
+/*********************************************************************
+ * @fn      TIM_BDTRStructInit
+ *
+ * @brief   Fills each TIM_BDTRInitStruct member with its default value.
+ *
+ * @param   TIM_BDTRInitStruct - pointer to a TIM_BDTRInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_BDTRStructInit(TIM_BDTRInitTypeDef *TIM_BDTRInitStruct)
+{
+    TIM_BDTRInitStruct->TIM_OSSRState = TIM_OSSRState_Disable;
+    TIM_BDTRInitStruct->TIM_OSSIState = TIM_OSSIState_Disable;
+    TIM_BDTRInitStruct->TIM_LOCKLevel = TIM_LOCKLevel_OFF;
+    TIM_BDTRInitStruct->TIM_DeadTime = 0x00;
+    TIM_BDTRInitStruct->TIM_Break = TIM_Break_Disable;
+    TIM_BDTRInitStruct->TIM_BreakPolarity = TIM_BreakPolarity_Low;
+    TIM_BDTRInitStruct->TIM_AutomaticOutput = TIM_AutomaticOutput_Disable;
+}
+
+/*********************************************************************
+ * @fn      TIM_Cmd
+ *
+ * @brief   Enables or disables the specified TIM peripheral.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_Cmd(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR1 |= TIM_CEN;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t)(~((uint16_t)TIM_CEN));
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_CtrlPWMOutputs
+ *
+ * @brief   Enables or disables the TIM peripheral Main Outputs.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_CtrlPWMOutputs(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->BDTR |= TIM_MOE;
+    }
+    else
+    {
+        TIMx->BDTR &= (uint16_t)(~((uint16_t)TIM_MOE));
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_ITConfig
+ *
+ * @brief   Enables or disables the specified TIM interrupts.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_IT - specifies the TIM interrupts sources to be enabled or disabled.
+ *            TIM_IT_Update - TIM update Interrupt source.
+ *            TIM_IT_CC1 - TIM Capture Compare 1 Interrupt source.
+ *            TIM_IT_CC2 - TIM Capture Compare 2 Interrupt source
+ *            TIM_IT_CC3 - TIM Capture Compare 3 Interrupt source.
+ *            TIM_IT_CC4 - TIM Capture Compare 4 Interrupt source.
+ *            TIM_IT_COM - TIM Commutation Interrupt source.
+ *            TIM_IT_Trigger - TIM Trigger Interrupt source.
+ *            TIM_IT_Break - TIM Break Interrupt source.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_ITConfig(TIM_TypeDef *TIMx, uint16_t TIM_IT, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->DMAINTENR |= TIM_IT;
+    }
+    else
+    {
+        TIMx->DMAINTENR &= (uint16_t)~TIM_IT;
+    }
+}
+
+/*******************************************************************************
+ * @fn             TIM_GenerateEvent
+ *
+ * @brief          Configures the TIMx event to be generate by software.
+ *
+ * @param          TIMx: where x can be 1 to 3 to select the TIM peripheral.
+ *                 TIM_EventSource: specifies the event source.
+ *                 TIM_EventSource_Update: Timer update Event source.
+ *                 TIM_EventSource_CC1: Timer Capture Compare 1 Event source.
+ *                 TIM_EventSource_CC2: Timer Capture Compare 2 Event source.
+ *                 TIM_EventSource_CC3: Timer Capture Compare 3 Event source.
+ *                 TIM_EventSource_CC4: Timer Capture Compare 4 Event source.
+ *                 TIM_EventSource_COM: Timer COM event source.
+ *                 TIM_EventSource_Trigger: Timer Trigger Event source.
+ *                 TIM_EventSource_Break: Timer Break event source.
+ *
+ * @return None
+ */
+void TIM_GenerateEvent(TIM_TypeDef *TIMx, uint16_t TIM_EventSource)
+{
+    TIMx->SWEVGR = TIM_EventSource;
+}
+
+/*********************************************************************
+ * @fn      TIM_DMAConfig
+ *
+ * @brief   Configures the TIMx's DMA interface.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_DMABase: DMA Base address.
+ *            TIM_DMABase_CR.
+ *            TIM_DMABase_CR2.
+ *            TIM_DMABase_SMCR.
+ *            TIM_DMABase_DIER.
+ *            TIM1_DMABase_SR.
+ *            TIM_DMABase_EGR.
+ *            TIM_DMABase_CCMR1.
+ *            TIM_DMABase_CCMR2.
+ *            TIM_DMABase_CCER.
+ *            TIM_DMABase_CNT.
+ *            TIM_DMABase_PSC.
+ *            TIM_DMABase_CCR1.
+ *            TIM_DMABase_CCR2.
+ *            TIM_DMABase_CCR3.
+ *            TIM_DMABase_CCR4.
+ *            TIM_DMABase_BDTR.
+ *            TIM_DMABase_DCR.
+ *          TIM_DMABurstLength - DMA Burst length.
+ *            TIM_DMABurstLength_1Transfer.
+ *            TIM_DMABurstLength_18Transfers.
+ *
+ * @return  none
+ */
+void TIM_DMAConfig(TIM_TypeDef *TIMx, uint16_t TIM_DMABase, uint16_t TIM_DMABurstLength)
+{
+    TIMx->DMACFGR = TIM_DMABase | TIM_DMABurstLength;
+}
+
+/*********************************************************************
+ * @fn      TIM_DMACmd
+ *
+ * @brief   Enables or disables the TIMx's DMA Requests.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_DMASource - specifies the DMA Request sources.
+ *            TIM_DMA_Update - TIM update Interrupt source.
+ *            TIM_DMA_CC1 - TIM Capture Compare 1 DMA source.
+ *            TIM_DMA_CC2 - TIM Capture Compare 2 DMA source.
+ *            TIM_DMA_CC3 - TIM Capture Compare 3 DMA source.
+ *            TIM_DMA_CC4 - TIM Capture Compare 4 DMA source.
+ *            TIM_DMA_COM - TIM Commutation DMA source.
+ *            TIM_DMA_Trigger - TIM Trigger DMA source.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_DMACmd(TIM_TypeDef *TIMx, uint16_t TIM_DMASource, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->DMAINTENR |= TIM_DMASource;
+    }
+    else
+    {
+        TIMx->DMAINTENR &= (uint16_t)~TIM_DMASource;
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_InternalClockConfig
+ *
+ * @brief   Configures the TIMx internal Clock.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *
+ * @return  none
+ */
+void TIM_InternalClockConfig(TIM_TypeDef *TIMx)
+{
+    TIMx->SMCFGR &= (uint16_t)(~((uint16_t)TIM_SMS));
+}
+
+/*********************************************************************
+ * @fn      TIM_ITRxExternalClockConfig
+ *
+ * @brief   Configures the TIMx Internal Trigger as External Clock.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_InputTriggerSource: Trigger source.
+ *            TIM_TS_ITR0 - Internal Trigger 0.
+ *            TIM_TS_ITR1 - Internal Trigger 1.
+ *            TIM_TS_ITR2 - Internal Trigger 2.
+ *            TIM_TS_ITR3 - Internal Trigger 3.
+ *
+ * @return  none
+ */
+void TIM_ITRxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource)
+{
+    TIM_SelectInputTrigger(TIMx, TIM_InputTriggerSource);
+    TIMx->SMCFGR |= TIM_SlaveMode_External1;
+}
+
+/*********************************************************************
+ * @fn      TIM_TIxExternalClockConfig
+ *
+ * @brief   Configures the TIMx Trigger as External Clock.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_TIxExternalCLKSource - Trigger source.
+ *            TIM_TIxExternalCLK1Source_TI1ED - TI1 Edge Detector.
+ *            TIM_TIxExternalCLK1Source_TI1 - Filtered Timer Input 1.
+ *            TIM_TIxExternalCLK1Source_TI2 - Filtered Timer Input 2.
+ *          TIM_ICPolarity - specifies the TIx Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *             TIM_DMA_COM - TIM Commutation DMA source.
+ *             TIM_DMA_Trigger - TIM Trigger DMA source.
+ *          ICFilter - specifies the filter value.
+ *             This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_TIxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_TIxExternalCLKSource,
+                                uint16_t TIM_ICPolarity, uint16_t ICFilter)
+{
+    if(TIM_TIxExternalCLKSource == TIM_TIxExternalCLK1Source_TI2)
+    {
+        TI2_Config(TIMx, TIM_ICPolarity, TIM_ICSelection_DirectTI, ICFilter);
+    }
+    else
+    {
+        TI1_Config(TIMx, TIM_ICPolarity, TIM_ICSelection_DirectTI, ICFilter);
+    }
+
+    TIM_SelectInputTrigger(TIMx, TIM_TIxExternalCLKSource);
+    TIMx->SMCFGR |= TIM_SlaveMode_External1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ETRClockMode1Config
+ *
+ * @brief   Configures the External clock Mode1.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_ExtTRGPrescaler - The external Trigger Prescaler.
+ *            TIM_ExtTRGPSC_OFF - ETRP Prescaler OFF.
+ *            TIM_ExtTRGPSC_DIV2 - ETRP frequency divided by 2.
+ *            TIM_ExtTRGPSC_DIV4 - ETRP frequency divided by 4.
+ *            TIM_ExtTRGPSC_DIV8 - ETRP frequency divided by 8.
+ *          TIM_ExtTRGPolarity - The external Trigger Polarity.
+ *            TIM_ExtTRGPolarity_Inverted - active low or falling edge active.
+ *            TIM_ExtTRGPolarity_NonInverted - active high or rising edge active.
+ *          ExtTRGFilter - External Trigger Filter.
+ *             This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_ETRClockMode1Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                             uint16_t ExtTRGFilter)
+{
+    uint16_t tmpsmcr = 0;
+
+    TIM_ETRConfig(TIMx, TIM_ExtTRGPrescaler, TIM_ExtTRGPolarity, ExtTRGFilter);
+    tmpsmcr = TIMx->SMCFGR;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_SMS));
+    tmpsmcr |= TIM_SlaveMode_External1;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_TS));
+    tmpsmcr |= TIM_TS_ETRF;
+    TIMx->SMCFGR = tmpsmcr;
+}
+
+/*********************************************************************
+ * @fn      TIM_ETRClockMode2Config
+ *
+ * @brief   Configures the External clock Mode2.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_ExtTRGPrescaler - The external Trigger Prescaler.
+ *            TIM_ExtTRGPSC_OFF - ETRP Prescaler OFF.
+ *            TIM_ExtTRGPSC_DIV2 - ETRP frequency divided by 2.
+ *            TIM_ExtTRGPSC_DIV4 - ETRP frequency divided by 4.
+ *            TIM_ExtTRGPSC_DIV8 - ETRP frequency divided by 8.
+ *          TIM_ExtTRGPolarity - The external Trigger Polarity.
+ *            TIM_ExtTRGPolarity_Inverted - active low or falling edge active.
+ *            TIM_ExtTRGPolarity_NonInverted - active high or rising edge active.
+ *          ExtTRGFilter - External Trigger Filter.
+ *            This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_ETRClockMode2Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler,
+                             uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter)
+{
+    TIM_ETRConfig(TIMx, TIM_ExtTRGPrescaler, TIM_ExtTRGPolarity, ExtTRGFilter);
+    TIMx->SMCFGR |= TIM_ECE;
+}
+
+/*********************************************************************
+ * @fn      TIM_ETRConfig
+ *
+ * @brief   Configures the TIMx External Trigger (ETR).
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_ExtTRGPrescaler - The external Trigger Prescaler.
+ *            TIM_ExtTRGPSC_OFF - ETRP Prescaler OFF.
+ *            TIM_ExtTRGPSC_DIV2 - ETRP frequency divided by 2.
+ *            TIM_ExtTRGPSC_DIV4 - ETRP frequency divided by 4.
+ *            TIM_ExtTRGPSC_DIV8 - ETRP frequency divided by 8.
+ *          TIM_ExtTRGPolarity - The external Trigger Polarity.
+ *            TIM_ExtTRGPolarity_Inverted - active low or falling edge active.
+ *            TIM_ExtTRGPolarity_NonInverted - active high or rising edge active.
+ *          ExtTRGFilter - External Trigger Filter.
+ *            This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_ETRConfig(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                   uint16_t ExtTRGFilter)
+{
+    uint16_t tmpsmcr = 0;
+
+    tmpsmcr = TIMx->SMCFGR;
+    tmpsmcr &= SMCFGR_ETR_Mask;
+    tmpsmcr |= (uint16_t)(TIM_ExtTRGPrescaler | (uint16_t)(TIM_ExtTRGPolarity | (uint16_t)(ExtTRGFilter << (uint16_t)8)));
+    TIMx->SMCFGR = tmpsmcr;
+}
+
+/*********************************************************************
+ * @fn      TIM_PrescalerConfig
+ *
+ * @brief   Configures the TIMx Prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          Prescaler - specifies the Prescaler Register value.
+ *          TIM_PSCReloadMode - specifies the TIM Prescaler Reload mode.
+ *            TIM_PSCReloadMode - specifies the TIM Prescaler Reload mode.
+ *            TIM_PSCReloadMode_Update - The Prescaler is loaded at the update event.
+ *            TIM_PSCReloadMode_Immediate - The Prescaler is loaded immediately.
+ *
+ * @return  none
+ */
+void TIM_PrescalerConfig(TIM_TypeDef *TIMx, uint16_t Prescaler, uint16_t TIM_PSCReloadMode)
+{
+    TIMx->PSC = Prescaler;
+    TIMx->SWEVGR = TIM_PSCReloadMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_CounterModeConfig
+ *
+ * @brief   Specifies the TIMx Counter Mode to be used.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_CounterMode - specifies the Counter Mode to be used.
+ *            TIM_CounterMode_Up - TIM Up Counting Mode.
+ *            TIM_CounterMode_Down - TIM Down Counting Mode.
+ *            TIM_CounterMode_CenterAligned1 - TIM Center Aligned Mode1.
+ *            TIM_CounterMode_CenterAligned2 - TIM Center Aligned Mode2.
+ *            TIM_CounterMode_CenterAligned3 - TIM Center Aligned Mode3.
+ *
+ * @return  none
+ */
+void TIM_CounterModeConfig(TIM_TypeDef *TIMx, uint16_t TIM_CounterMode)
+{
+    uint16_t tmpcr1 = 0;
+
+    tmpcr1 = TIMx->CTLR1;
+    tmpcr1 &= (uint16_t)(~((uint16_t)(TIM_DIR | TIM_CMS)));
+    tmpcr1 |= TIM_CounterMode;
+    TIMx->CTLR1 = tmpcr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectInputTrigger
+ *
+ * @brief   Selects the Input Trigger source.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_InputTriggerSource - The Input Trigger source.
+ *            TIM_TS_ITR0 - Internal Trigger 0.
+ *            TIM_TS_ITR1 - Internal Trigger 1.
+ *            TIM_TS_ITR2 - Internal Trigger 2.
+ *            TIM_TS_ITR3 - Internal Trigger 3.
+ *            TIM_TS_TI1F_ED - TI1 Edge Detector.
+ *            TIM_TS_TI1FP1 - Filtered Timer Input 1.
+ *            TIM_TS_TI2FP2 - Filtered Timer Input 2.
+ *            TIM_TS_ETRF - External Trigger input.
+ *
+ * @return  none
+ */
+void TIM_SelectInputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource)
+{
+    uint16_t tmpsmcr = 0;
+
+    tmpsmcr = TIMx->SMCFGR;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_TS));
+    tmpsmcr |= TIM_InputTriggerSource;
+    TIMx->SMCFGR = tmpsmcr;
+}
+
+/*********************************************************************
+ * @fn      TIM_EncoderInterfaceConfig
+ *
+ * @brief   Configures the TIMx Encoder Interface.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_EncoderMode - specifies the TIMx Encoder Mode.
+ *            TIM_EncoderMode_TI1 - Counter counts on TI1FP1 edge depending
+ *        on TI2FP2 level.
+ *            TIM_EncoderMode_TI2 - Counter counts on TI2FP2 edge depending
+ *        on TI1FP1 level.
+ *            TIM_EncoderMode_TI12 - Counter counts on both TI1FP1 and
+ *        TI2FP2 edges depending.
+ *          TIM_IC1Polarity - specifies the IC1 Polarity.
+ *            TIM_ICPolarity_Falling - IC Falling edge.
+ *            TTIM_ICPolarity_Rising - IC Rising edge.
+ *          TIM_IC2Polarity - specifies the IC2 Polarity.
+ *            TIM_ICPolarity_Falling - IC Falling edge.
+ *            TIM_ICPolarity_Rising - IC Rising edge.
+ *
+ * @return  none
+ */
+void TIM_EncoderInterfaceConfig(TIM_TypeDef *TIMx, uint16_t TIM_EncoderMode,
+                                uint16_t TIM_IC1Polarity, uint16_t TIM_IC2Polarity)
+{
+    uint16_t tmpsmcr = 0;
+    uint16_t tmpccmr1 = 0;
+    uint16_t tmpccer = 0;
+
+    tmpsmcr = TIMx->SMCFGR;
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccer = TIMx->CCER;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_SMS));
+    tmpsmcr |= TIM_EncoderMode;
+    tmpccmr1 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC1S)) & (uint16_t)(~((uint16_t)TIM_CC2S)));
+    tmpccmr1 |= TIM_CC1S_0 | TIM_CC2S_0;
+    tmpccer &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC1P)) & ((uint16_t) ~((uint16_t)TIM_CC2P)));
+    tmpccer |= (uint16_t)(TIM_IC1Polarity | (uint16_t)(TIM_IC2Polarity << (uint16_t)4));
+    TIMx->SMCFGR = tmpsmcr;
+    TIMx->CHCTLR1 = tmpccmr1;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC1Config
+ *
+ * @brief   Forces the TIMx output 1 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC1REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC1REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC1Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1M);
+    tmpccmr1 |= TIM_ForcedAction;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC2Config
+ *
+ * @brief   Forces the TIMx output 2 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC2REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC2REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC2Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2M);
+    tmpccmr1 |= (uint16_t)(TIM_ForcedAction << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC3Config
+ *
+ * @brief   Forces the TIMx output 3 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC3REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC3REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC3Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3M);
+    tmpccmr2 |= TIM_ForcedAction;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC4Config
+ *
+ * @brief   Forces the TIMx output 4 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC4REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC4REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC4Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4M);
+    tmpccmr2 |= (uint16_t)(TIM_ForcedAction << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ARRPreloadConfig
+ *
+ * @brief   Enables or disables TIMx peripheral Preload register on ARR.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_ARRPreloadConfig(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR1 |= TIM_ARPE;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_ARPE);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectCOM
+ *
+ * @brief   Selects the TIM peripheral Commutation event.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_SelectCOM(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_CCUS;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_CCUS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectCCDMA
+ *
+ * @brief   Selects the TIMx peripheral Capture Compare DMA source.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_SelectCCDMA(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_CCDS;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_CCDS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_CCPreloadControl
+ *
+ * @brief   DSets or Resets the TIM peripheral Capture Compare Preload Control bit.
+ *        reset values (Affects also the I2Ss).
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_CCPreloadControl(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_CCPC;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_CCPC);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR1.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC1PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1PE);
+    tmpccmr1 |= TIM_OCPreload;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR2.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC2PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2PE);
+    tmpccmr1 |= (uint16_t)(TIM_OCPreload << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR3.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC3PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3PE);
+    tmpccmr2 |= TIM_OCPreload;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR4.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC4PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4PE);
+    tmpccmr2 |= (uint16_t)(TIM_OCPreload << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 1 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC1FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1FE);
+    tmpccmr1 |= TIM_OCFast;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 2 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC2FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2FE);
+    tmpccmr1 |= (uint16_t)(TIM_OCFast << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 3 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC3FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3FE);
+    tmpccmr2 |= TIM_OCFast;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 4 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC4FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4FE);
+    tmpccmr2 |= (uint16_t)(TIM_OCFast << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC1Ref
+ *
+ * @brief   Clears or safeguards the OCREF1 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC1Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1CE);
+    tmpccmr1 |= TIM_OCClear;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC2Ref
+ *
+ * @brief   Clears or safeguards the OCREF2 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC2Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2CE);
+    tmpccmr1 |= (uint16_t)(TIM_OCClear << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC3Ref
+ *
+ * @brief   Clears or safeguards the OCREF3 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC3Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3CE);
+    tmpccmr2 |= TIM_OCClear;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC4Ref
+ *
+ * @brief   Clears or safeguards the OCREF4 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC4Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4CE);
+    tmpccmr2 |= (uint16_t)(TIM_OCClear << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1PolarityConfig
+ *
+ * @brief   Configures the TIMx channel 1 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCPolarity - specifies the OC1 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC1PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC1P);
+    tmpccer |= TIM_OCPolarity;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1NPolarityConfig
+ *
+ * @brief   Configures the TIMx channel 1 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCNPolarity - specifies the OC1N Polarity.
+ *            TIM_OCNPolarity_High - Output Compare active high.
+ *            TIM_OCNPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC1NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC1NP);
+    tmpccer |= TIM_OCNPolarity;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2PolarityConfig
+ *
+ * @brief   Configures the TIMx channel 2 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 3 to select the TIM peripheral.
+ *          TIM_OCPolarity - specifies the OC2 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC2PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC2P);
+    tmpccer |= (uint16_t)(TIM_OCPolarity << 4);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2NPolarityConfig
+ *
+ * @brief   Configures the TIMx channel 2 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCNPolarity - specifies the OC1N Polarity.
+ *            TIM_OCNPolarity_High - Output Compare active high.
+ *            TIM_OCNPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC2NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC2NP);
+    tmpccer |= (uint16_t)(TIM_OCNPolarity << 4);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3PolarityConfig
+ *
+ * @brief   Configures the TIMx Channel 3 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          TIM_OCPolarit - specifies the OC3 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC3PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC3P);
+    tmpccer |= (uint16_t)(TIM_OCPolarity << 8);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3NPolarityConfig
+ *
+ * @brief   Configures the TIMx Channel 3N polarity.
+ *
+ * @param   TIMx - where x can be 1 to 2 to select the TIM peripheral.
+ *          TIM_OCNPolarity - specifies the OC2N Polarity.
+ *            TIM_OCNPolarity_High - Output Compare active high.
+ *            TIM_OCNPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC3NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC3NP);
+    tmpccer |= (uint16_t)(TIM_OCNPolarity << 8);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4PolarityConfig
+ *
+ * @brief   Configures the TIMx Channel 4 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          TIM_OCPolarit - specifies the OC3 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC4PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC4P);
+    tmpccer |= (uint16_t)(TIM_OCPolarity << 12);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_CCxCmd
+ *
+ * @brief   Enables or disables the TIM Capture Compare Channel x.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_Channel - specifies the TIM Channel.
+ *            TIM_Channel_1 - TIM Channel 1.
+ *            TIM_Channel_2 - TIM Channel 2.
+ *            TIM_Channel_3 - TIM Channel 3.
+ *            TIM_Channel_4 - TIM Channel 4.
+ *          TIM_CCx - specifies the TIM Channel CCxE bit new state.
+ *            TIM_CCx_Enable.
+ *            TIM_CCx_Disable.
+ *
+ * @return  none
+ */
+void TIM_CCxCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCx)
+{
+    uint16_t tmp = 0;
+
+    tmp = CCER_CCE_Set << TIM_Channel;
+    TIMx->CCER &= (uint16_t)~tmp;
+    TIMx->CCER |= (uint16_t)(TIM_CCx << TIM_Channel);
+}
+
+/*********************************************************************
+ * @fn      TIM_CCxNCmd
+ *
+ * @brief   Enables or disables the TIM Capture Compare Channel xN.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          TIM_Channel - specifies the TIM Channel.
+ *            TIM_Channel_1 - TIM Channel 1.
+ *            TIM_Channel_2 - TIM Channel 2.
+ *            TIM_Channel_3 - TIM Channel 3.
+ *          TIM_CCxN - specifies the TIM Channel CCxNE bit new state.
+ *            TIM_CCxN_Enable.
+ *            TIM_CCxN_Disable.
+ *
+ * @return  none
+ */
+void TIM_CCxNCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCxN)
+{
+    uint16_t tmp = 0;
+
+    tmp = CCER_CCNE_Set << TIM_Channel;
+    TIMx->CCER &= (uint16_t)~tmp;
+    TIMx->CCER |= (uint16_t)(TIM_CCxN << TIM_Channel);
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectOCxM
+ *
+ * @brief   Selects the TIM Output Compare Mode.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_Channel - specifies the TIM Channel.
+ *            TIM_Channel_1 - TIM Channel 1.
+ *            TIM_Channel_2 - TIM Channel 2.
+ *            TIM_Channel_3 - TIM Channel 3.
+ *            TIM_Channel_4 - TIM Channel 4.
+ *          TIM_OCMode - specifies the TIM Output Compare Mode.
+ *            TIM_OCMode_Timing.
+ *            TIM_OCMode_Active.
+ *            TIM_OCMode_Toggle.
+ *            TIM_OCMode_PWM1.
+ *            TIM_OCMode_PWM2.
+ *            TIM_ForcedAction_Active.
+ *            TIM_ForcedAction_InActive.
+ *
+ * @return  none
+ */
+void TIM_SelectOCxM(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_OCMode)
+{
+    uint32_t tmp = 0;
+    uint16_t tmp1 = 0;
+
+    tmp = (uint32_t)TIMx;
+    tmp += CHCTLR_Offset;
+    tmp1 = CCER_CCE_Set << (uint16_t)TIM_Channel;
+    TIMx->CCER &= (uint16_t)~tmp1;
+
+    if((TIM_Channel == TIM_Channel_1) || (TIM_Channel == TIM_Channel_3))
+    {
+        tmp += (TIM_Channel >> 1);
+        *(__IO uint32_t *)tmp &= (uint32_t) ~((uint32_t)TIM_OC1M);
+        *(__IO uint32_t *)tmp |= TIM_OCMode;
+    }
+    else
+    {
+        tmp += (uint16_t)(TIM_Channel - (uint16_t)4) >> (uint16_t)1;
+        *(__IO uint32_t *)tmp &= (uint32_t) ~((uint32_t)TIM_OC2M);
+        *(__IO uint32_t *)tmp |= (uint16_t)(TIM_OCMode << 8);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_UpdateDisableConfig
+ *
+ * @brief   Enables or Disables the TIMx Update event.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_UpdateDisableConfig(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR1 |= TIM_UDIS;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_UDIS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_UpdateRequestConfig
+ *
+ * @brief   Configures the TIMx Update Request Interrupt source.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_UpdateSource - specifies the Update source.
+ *            TIM_UpdateSource_Regular.
+ *            TIM_UpdateSource_Global.
+ *
+ * @return  none
+ */
+void TIM_UpdateRequestConfig(TIM_TypeDef *TIMx, uint16_t TIM_UpdateSource)
+{
+    if(TIM_UpdateSource != TIM_UpdateSource_Global)
+    {
+        TIMx->CTLR1 |= TIM_URS;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_URS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectHallSensor
+ *
+ * @brief   Enables or disables the TIMx's Hall sensor interface.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_SelectHallSensor(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_TI1S;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_TI1S);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectOnePulseMode
+ *
+ * @brief   Selects the TIMx's One Pulse Mode.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_OPMode - specifies the OPM Mode to be used.
+ *            TIM_OPMode_Single.
+ *            TIM_OPMode_Repetitive.
+ *
+ * @return  none
+ */
+void TIM_SelectOnePulseMode(TIM_TypeDef *TIMx, uint16_t TIM_OPMode)
+{
+    TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_OPM);
+    TIMx->CTLR1 |= TIM_OPMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectOutputTrigger
+ *
+ * @brief   Selects the TIMx Trigger Output Mode.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_TRGOSource - specifies the Trigger Output source.
+ *            TIM_TRGOSource_Reset -  The UG bit in the TIM_EGR register is
+ *        used as the trigger output (TRGO).
+ *            TIM_TRGOSource_Enable - The Counter Enable CEN is used as the
+ *        trigger output (TRGO).
+ *            TIM_TRGOSource_Update - The update event is selected as the
+ *        trigger output (TRGO).
+ *            TIM_TRGOSource_OC1 - The trigger output sends a positive pulse
+ *        when the CC1IF flag is to be set, as soon as a capture or compare match occurs (TRGO).
+ *            TIM_TRGOSource_OC1Ref - OC1REF signal is used as the trigger output (TRGO).
+ *            TIM_TRGOSource_OC2Ref - OC2REF signal is used as the trigger output (TRGO).
+ *            TIM_TRGOSource_OC3Ref - OC3REF signal is used as the trigger output (TRGO).
+ *            TIM_TRGOSource_OC4Ref - OC4REF signal is used as the trigger output (TRGO).
+ *
+ * @return  none
+ */
+void TIM_SelectOutputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_TRGOSource)
+{
+    TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_MMS);
+    TIMx->CTLR2 |= TIM_TRGOSource;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectSlaveMode
+ *
+ * @brief   Selects the TIMx Slave Mode.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_SlaveMode - specifies the Timer Slave Mode.
+ *            TIM_SlaveMode_Reset - Rising edge of the selected trigger
+ *        signal (TRGI) re-initializes.
+ *            TIM_SlaveMode_Gated - The counter clock is enabled when the
+ *        trigger signal (TRGI) is high.
+ *            TIM_SlaveMode_Trigger - The counter starts at a rising edge
+ *        of the trigger TRGI.
+ *            TIM_SlaveMode_External1 - Rising edges of the selected trigger
+ *        (TRGI) clock the counter.
+ *
+ * @return  none
+ */
+void TIM_SelectSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_SlaveMode)
+{
+    TIMx->SMCFGR &= (uint16_t) ~((uint16_t)TIM_SMS);
+    TIMx->SMCFGR |= TIM_SlaveMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectMasterSlaveMode
+ *
+ * @brief   Sets or Resets the TIMx Master/Slave Mode.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_MasterSlaveMode - specifies the Timer Master Slave Mode.
+ *            TIM_MasterSlaveMode_Enable - synchronization between the current
+ *        timer and its slaves (through TRGO).
+ *            TIM_MasterSlaveMode_Disable - No action.
+ *
+ * @return  none
+ */
+void TIM_SelectMasterSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_MasterSlaveMode)
+{
+    TIMx->SMCFGR &= (uint16_t) ~((uint16_t)TIM_MSM);
+    TIMx->SMCFGR |= TIM_MasterSlaveMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCounter
+ *
+ * @brief   Sets the TIMx Counter Register value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          Counter - specifies the Counter register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCounter(TIM_TypeDef *TIMx, uint16_t Counter)
+{
+    TIMx->CNT = Counter;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetAutoreload
+ *
+ * @brief   Sets the TIMx Autoreload Register value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          Autoreload - specifies the Autoreload register new value.
+ *
+ * @return  none
+ */
+void TIM_SetAutoreload(TIM_TypeDef *TIMx, uint16_t Autoreload)
+{
+    TIMx->ATRLR = Autoreload;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare1
+ *
+ * @brief   Sets the TIMx Capture Compare1 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare1(TIM_TypeDef *TIMx, uint16_t Compare1)
+{
+    TIMx->CH1CVR = Compare1;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare2
+ *
+ * @brief   Sets the TIMx Capture Compare2 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare2(TIM_TypeDef *TIMx, uint16_t Compare2)
+{
+    TIMx->CH2CVR = Compare2;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare3
+ *
+ * @brief   Sets the TIMx Capture Compare3 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare3(TIM_TypeDef *TIMx, uint16_t Compare3)
+{
+    TIMx->CH3CVR = Compare3;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare4
+ *
+ * @brief   Sets the TIMx Capture Compare4 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare4(TIM_TypeDef *TIMx, uint16_t Compare4)
+{
+    TIMx->CH4CVR = Compare4;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC1Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 1 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC1Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR1 &= (uint16_t) ~((uint16_t)TIM_IC1PSC);
+    TIMx->CHCTLR1 |= TIM_ICPSC;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC2Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 2 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC2Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR1 &= (uint16_t) ~((uint16_t)TIM_IC2PSC);
+    TIMx->CHCTLR1 |= (uint16_t)(TIM_ICPSC << 8);
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC3Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 3 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC3Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR2 &= (uint16_t) ~((uint16_t)TIM_IC3PSC);
+    TIMx->CHCTLR2 |= TIM_ICPSC;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC4Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 4 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC4Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR2 &= (uint16_t) ~((uint16_t)TIM_IC4PSC);
+    TIMx->CHCTLR2 |= (uint16_t)(TIM_ICPSC << 8);
+}
+
+/*********************************************************************
+ * @fn      TIM_SetClockDivision
+ *
+ * @brief   Sets the TIMx Clock Division value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_CKD - specifies the clock division value.
+ *            TIM_CKD_DIV1 - TDTS = Tck_tim.
+ *            TIM_CKD_DIV2 - TDTS = 2*Tck_tim.
+ *            TIM_CKD_DIV4 - TDTS = 4*Tck_tim.
+ *
+ * @return  none
+ */
+void TIM_SetClockDivision(TIM_TypeDef *TIMx, uint16_t TIM_CKD)
+{
+    TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_CTLR1_CKD);
+    TIMx->CTLR1 |= TIM_CKD;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture1
+ *
+ * @brief   Gets the TIMx Input Capture 1 value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *
+ * @return  TIMx->CH1CVR - Capture Compare 1 Register value.
+ */
+uint16_t TIM_GetCapture1(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH1CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture2
+ *
+ * @brief   Gets the TIMx Input Capture 2 value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *
+ * @return  TIMx->CH2CVR - Capture Compare 2 Register value.
+ */
+uint16_t TIM_GetCapture2(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH2CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture3
+ *
+ * @brief   Gets the TIMx Input Capture 3 value.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *
+ * @return  TIMx->CH3CVR - Capture Compare 3 Register value.
+ */
+uint16_t TIM_GetCapture3(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH3CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture4
+ *
+ * @brief   Gets the TIMx Input Capture 4 value.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *
+ * @return  TIMx->CH4CVR - Capture Compare 4 Register value.
+ */
+uint16_t TIM_GetCapture4(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH4CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCounter
+ *
+ * @brief   Gets the TIMx Counter value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *
+ * @return  TIMx->CNT - Counter Register value.
+ */
+uint16_t TIM_GetCounter(TIM_TypeDef *TIMx)
+{
+    return TIMx->CNT;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetPrescaler
+ *
+ * @brief   Gets the TIMx Prescaler value.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *
+ * @return  TIMx->PSC - Prescaler Register value.
+ */
+uint16_t TIM_GetPrescaler(TIM_TypeDef *TIMx)
+{
+    return TIMx->PSC;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetFlagStatus
+ *
+ * @brief   Checks whether the specified TIM flag is set or not.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_FLAG - specifies the flag to check.
+ *            TIM_FLAG_Update - TIM update Flag.
+ *            TIM_FLAG_CC1 - TIM Capture Compare 1 Flag.
+ *            TIM_FLAG_CC2 - TIM Capture Compare 2 Flag.
+ *            TIM_FLAG_CC3 - TIM Capture Compare 3 Flag.
+ *            TIM_FLAG_CC4 - TIM Capture Compare 4 Flag.
+ *            TIM_FLAG_COM - TIM Commutation Flag.
+ *            TIM_FLAG_Trigger - TIM Trigger Flag.
+ *            TIM_FLAG_Break - TIM Break Flag.
+ *            TIM_FLAG_CC1OF - TIM Capture Compare 1 overcapture Flag.
+ *            TIM_FLAG_CC2OF - TIM Capture Compare 2 overcapture Flag.
+ *            TIM_FLAG_CC3OF - TIM Capture Compare 3 overcapture Flag.
+ *            TIM_FLAG_CC4OF - TIM Capture Compare 4 overcapture Flag.
+ *
+ * @return  none
+ */
+FlagStatus TIM_GetFlagStatus(TIM_TypeDef *TIMx, uint16_t TIM_FLAG)
+{
+    ITStatus bitstatus = RESET;
+
+    if((TIMx->INTFR & TIM_FLAG) != (uint16_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearFlag
+ *
+ * @brief   Clears the TIMx's pending flags.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_FLAG - specifies the flag to check.
+ *            TIM_FLAG_Update - TIM update Flag.
+ *            TIM_FLAG_CC1 - TIM Capture Compare 1 Flag.
+ *            TIM_FLAG_CC2 - TIM Capture Compare 2 Flag.
+ *            TIM_FLAG_CC3 - TIM Capture Compare 3 Flag.
+ *            TIM_FLAG_CC4 - TIM Capture Compare 4 Flag.
+ *            TIM_FLAG_COM - TIM Commutation Flag.
+ *            TIM_FLAG_Trigger - TIM Trigger Flag.
+ *            TIM_FLAG_Break - TIM Break Flag.
+ *            TIM_FLAG_CC1OF - TIM Capture Compare 1 overcapture Flag.
+ *            TIM_FLAG_CC2OF - TIM Capture Compare 2 overcapture Flag.
+ *            TIM_FLAG_CC3OF - TIM Capture Compare 3 overcapture Flag.
+ *            TIM_FLAG_CC4OF - TIM Capture Compare 4 overcapture Flag.
+ *
+ * @return  none
+ */
+void TIM_ClearFlag(TIM_TypeDef *TIMx, uint16_t TIM_FLAG)
+{
+    TIMx->INTFR = (uint16_t)~TIM_FLAG;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetITStatus
+ *
+ * @brief   Checks whether the TIM interrupt has occurred or not.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_IT - specifies the TIM interrupt source to check.
+ *            TIM_IT_Update - TIM update Interrupt source.
+ *            TIM_IT_CC1 - TIM Capture Compare 1 Interrupt source.
+ *            TIM_IT_CC2 - TIM Capture Compare 2 Interrupt source.
+ *            TIM_IT_CC3 - TIM Capture Compare 3 Interrupt source.
+ *            TIM_IT_CC4 - TIM Capture Compare 4 Interrupt source.
+ *            TIM_IT_COM - TIM Commutation Interrupt source.
+ *            TIM_IT_Trigger - TIM Trigger Interrupt source.
+ *            TIM_IT_Break - TIM Break Interrupt source.
+ *
+ * @return  none
+ */
+ITStatus TIM_GetITStatus(TIM_TypeDef *TIMx, uint16_t TIM_IT)
+{
+    ITStatus bitstatus = RESET;
+    uint16_t itstatus = 0x0, itenable = 0x0;
+
+    itstatus = TIMx->INTFR & TIM_IT;
+
+    itenable = TIMx->DMAINTENR & TIM_IT;
+    if((itstatus != (uint16_t)RESET) && (itenable != (uint16_t)RESET))
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearITPendingBit
+ *
+ * @brief   Clears the TIMx's interrupt pending bits.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_IT - specifies the TIM interrupt source to check.
+ *            TIM_IT_Update - TIM update Interrupt source.
+ *            TIM_IT_CC1 - TIM Capture Compare 1 Interrupt source.
+ *            TIM_IT_CC2 - TIM Capture Compare 2 Interrupt source.
+ *            TIM_IT_CC3 - TIM Capture Compare 3 Interrupt source.
+ *            TIM_IT_CC4 - TIM Capture Compare 4 Interrupt source.
+ *            TIM_IT_COM - TIM Commutation Interrupt source.
+ *            TIM_IT_Trigger - TIM Trigger Interrupt source.
+ *            TIM_IT_Break - TIM Break Interrupt source.
+ *
+ * @return  none
+ */
+void TIM_ClearITPendingBit(TIM_TypeDef *TIMx, uint16_t TIM_IT)
+{
+    TIMx->INTFR = (uint16_t)~TIM_IT;
+}
+
+/*********************************************************************
+ * @fn      TI1_Config
+ *
+ * @brief   Configure the TI1 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI1_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr1 = 0, tmpccer = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC1E);
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccer = TIMx->CCER;
+    tmpccmr1 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC1S)) & ((uint16_t) ~((uint16_t)TIM_IC1F)));
+    tmpccmr1 |= (uint16_t)(TIM_ICSelection | (uint16_t)(TIM_ICFilter << (uint16_t)4));
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC1P));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC1E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC1P | TIM_CC1NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC1E);
+    }
+
+    TIMx->CHCTLR1 = tmpccmr1;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TI2_Config
+ *
+ * @brief   Configure the TI2 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI2_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr1 = 0, tmpccer = 0, tmp = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC2E);
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccer = TIMx->CCER;
+    tmp = (uint16_t)(TIM_ICPolarity << 4);
+    tmpccmr1 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC2S)) & ((uint16_t) ~((uint16_t)TIM_IC2F)));
+    tmpccmr1 |= (uint16_t)(TIM_ICFilter << 12);
+    tmpccmr1 |= (uint16_t)(TIM_ICSelection << 8);
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC2P));
+        tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CC2E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC2P | TIM_CC2NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC2E);
+    }
+
+    TIMx->CHCTLR1 = tmpccmr1;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TI3_Config
+ *
+ * @brief   Configure the TI3 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI3_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr2 = 0, tmpccer = 0, tmp = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC3E);
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccer = TIMx->CCER;
+    tmp = (uint16_t)(TIM_ICPolarity << 8);
+    tmpccmr2 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC3S)) & ((uint16_t) ~((uint16_t)TIM_IC3F)));
+    tmpccmr2 |= (uint16_t)(TIM_ICSelection | (uint16_t)(TIM_ICFilter << (uint16_t)4));
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC3P));
+        tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CC3E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC3P | TIM_CC3NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC3E);
+    }
+
+    TIMx->CHCTLR2 = tmpccmr2;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TI4_Config
+ *
+ * @brief   Configure the TI4 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI4_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr2 = 0, tmpccer = 0, tmp = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC4E);
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccer = TIMx->CCER;
+    tmp = (uint16_t)(TIM_ICPolarity << 12);
+    tmpccmr2 &= (uint16_t)((uint16_t)(~(uint16_t)TIM_CC4S) & ((uint16_t) ~((uint16_t)TIM_IC4F)));
+    tmpccmr2 |= (uint16_t)(TIM_ICSelection << 8);
+    tmpccmr2 |= (uint16_t)(TIM_ICFilter << 12);
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC4P));
+        tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CC4E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC3P | TIM_CC4NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC4E);
+    }
+
+    TIMx->CHCTLR2 = tmpccmr2;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_CaptureModeCmd
+ *
+ * @brief   Enables or disables the TIM capture over mode.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_CaptureModeCmd(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState)
+    {
+        TIMx->CTLR1 |= (1<<14);
+    }
+    else{
+        TIMx->CTLR1 &= ~(1<<14);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_IndicateCaptureLevelCmd
+ *
+ * @brief   Enables or disables the TIMx capture level indication.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_IndicateCaptureLevelCmd(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState)
+    {
+        TIMx->CTLR1 |= (1<<15);
+    }
+    else{
+        TIMx->CTLR1 &= ~(1<<15);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_OC12_SupersedeModeCmd
+ *
+ * @brief   Enables or disables the TIMx Channel (1 and 2) supersede mode.
+ *
+ * @param   TIMx - where x can be 1 to 3 select the TIM peripheral.
+ *          TIM_Supersede_Mode_OC1 - Channel 1 Supersede Mode invalid level.
+ *            TIM_Supersede_Mode_OC1_H - Invalid level is high level.
+ *            TIM_Supersede_Mode_OC1_L - Invalid level is low level.
+ *          TIM_Supersede_Mode_OC2 - Channel 2 Supersede Mode invalid level.
+ *            TIM_Supersede_Mode_OC2_H - Invalid level is high level.
+ *            TIM_Supersede_Mode_OC2_L - Invalid level is low level.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_OC12_SupersedeModeCmd(TIM_TypeDef *TIMx, uint16_t TIM_Supersede_Mode_OC1, uint16_t TIM_Supersede_Mode_OC2,
+                              FunctionalState NewState)
+{
+    uint32_t tmpreg = 0;
+
+    tmpreg = TIMx->SPEC;
+
+    tmpreg &= SPEC_OC12_Mask;
+    tmpreg |= TIM_Supersede_Mode_OC1 | TIM_Supersede_Mode_OC2;
+
+
+    if(NewState)
+    {
+        tmpreg |= (1<<0);
+    }
+
+    TIMx->SPEC = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC34_SupersedeModeCmd
+ *
+ * @brief   Enables or disables the TIMx Channel (3 and 4) supersede mode.
+ *
+ * @param   TIMx - where x can be 1 to 2 select the TIM peripheral.
+ *          TIM_Supersede_Mode_OC3 - Channel 3 Supersede Mode invalid level.
+ *            TIM_Supersede_Mode_OC3_H - Invalid level is high level.
+ *            TIM_Supersede_Mode_OC3_L - Invalid level is low level.
+ *          TIM_Supersede_Mode_OC4 - Channel 4 Supersede Mode invalid level.
+ *            TIM_Supersede_Mode_OC4_H - Invalid level is high level.
+ *            TIM_Supersede_Mode_OC4_L - Invalid level is low level.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_OC34_SupersedeModeCmd(TIM_TypeDef *TIMx, uint16_t TIM_Supersede_Mode_OC3, uint16_t TIM_Supersede_Mode_OC4,
+                              FunctionalState NewState)
+{
+    uint32_t tmpreg = 0;
+
+    tmpreg = TIMx->SPEC;
+
+    tmpreg &= SPEC_OC34_Mask;
+    tmpreg |= TIM_Supersede_Mode_OC3 | TIM_Supersede_Mode_OC4;
+
+
+    if(NewState)
+    {
+        tmpreg |= (1<<1);
+    }
+
+    TIMx->SPEC = tmpreg;
+}

--- a/Peripheral/ch32x035/src/ch32x035_usart.c
+++ b/Peripheral/ch32x035/src/ch32x035_usart.c
@@ -1,0 +1,743 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_usart.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the USART firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_usart.h"
+#include "ch32x035_rcc.h"
+
+/* USART_Private_Defines */
+#define CTLR1_UE_Set              ((uint16_t)0x2000) /* USART Enable Mask */
+#define CTLR1_UE_Reset            ((uint16_t)0xDFFF) /* USART Disable Mask */
+
+#define CTLR1_WAKE_Mask           ((uint16_t)0xF7FF) /* USART WakeUp Method Mask */
+
+#define CTLR1_RWU_Set             ((uint16_t)0x0002) /* USART mute mode Enable Mask */
+#define CTLR1_RWU_Reset           ((uint16_t)0xFFFD) /* USART mute mode Enable Mask */
+#define CTLR1_SBK_Set             ((uint16_t)0x0001) /* USART Break Character send Mask */
+#define CTLR1_CLEAR_Mask          ((uint16_t)0xE9F3) /* USART CR1 Mask */
+#define CTLR2_Address_Mask        ((uint16_t)0xFFF0) /* USART address Mask */
+
+#define CTLR2_LINEN_Set           ((uint16_t)0x4000) /* USART LIN Enable Mask */
+#define CTLR2_LINEN_Reset         ((uint16_t)0xBFFF) /* USART LIN Disable Mask */
+
+#define CTLR2_LBDL_Mask           ((uint16_t)0xFFDF) /* USART LIN Break detection Mask */
+#define CTLR2_STOP_CLEAR_Mask     ((uint16_t)0xCFFF) /* USART CR2 STOP Bits Mask */
+#define CTLR2_CLOCK_CLEAR_Mask    ((uint16_t)0xF0FF) /* USART CR2 Clock Mask */
+
+#define CTLR3_SCEN_Set            ((uint16_t)0x0020) /* USART SC Enable Mask */
+#define CTLR3_SCEN_Reset          ((uint16_t)0xFFDF) /* USART SC Disable Mask */
+
+#define CTLR3_NACK_Set            ((uint16_t)0x0010) /* USART SC NACK Enable Mask */
+#define CTLR3_NACK_Reset          ((uint16_t)0xFFEF) /* USART SC NACK Disable Mask */
+
+#define CTLR3_HDSEL_Set           ((uint16_t)0x0008) /* USART Half-Duplex Enable Mask */
+#define CTLR3_HDSEL_Reset         ((uint16_t)0xFFF7) /* USART Half-Duplex Disable Mask */
+
+#define CTLR3_IRLP_Mask           ((uint16_t)0xFFFB) /* USART IrDA LowPower mode Mask */
+#define CTLR3_CLEAR_Mask          ((uint16_t)0xFCFF) /* USART CR3 Mask */
+
+#define CTLR3_IREN_Set            ((uint16_t)0x0002) /* USART IrDA Enable Mask */
+#define CTLR3_IREN_Reset          ((uint16_t)0xFFFD) /* USART IrDA Disable Mask */
+#define GPR_LSB_Mask              ((uint16_t)0x00FF) /* Guard Time Register LSB Mask */
+#define GPR_MSB_Mask              ((uint16_t)0xFF00) /* Guard Time Register MSB Mask */
+#define IT_Mask                   ((uint16_t)0x001F) /* USART Interrupt Mask */
+
+/*********************************************************************
+ * @fn      USART_DeInit
+ *
+ * @brief   Deinitializes the USARTx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   USARTx - where x can be 1, 2 , 3 or 4 to select the UART peripheral.
+ *
+ * @return  none
+ */
+void USART_DeInit(USART_TypeDef *USARTx)
+{
+    if(USARTx == USART1)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_USART1, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_USART1, DISABLE);
+    }
+    else if(USARTx == USART2)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART2, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART2, DISABLE);
+    }
+    else if(USARTx == USART3)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART3, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART3, DISABLE);
+    }
+    else if(USARTx == USART4)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART4, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART4, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_Init
+ *
+ * @brief   Initializes the USARTx peripheral according to the specified
+ *        parameters in the USART_InitStruct.
+ *
+ * @param   USARTx - where x can be 1, 2 , 3 or 4 to select the UART peripheral.
+ *          USART_InitStruct - pointer to a USART_InitTypeDef structure
+ *        that contains the configuration information for the specified
+ *        USART peripheral.
+ *
+ * @return  none
+ */
+void USART_Init(USART_TypeDef *USARTx, USART_InitTypeDef *USART_InitStruct)
+{
+    uint32_t          tmpreg = 0x00, apbclock = 0x00;
+    uint32_t          integerdivider = 0x00;
+    uint32_t          fractionaldivider = 0x00;
+    uint32_t          usartxbase = 0;
+    RCC_ClocksTypeDef RCC_ClocksStatus;
+
+    if(USART_InitStruct->USART_HardwareFlowControl != USART_HardwareFlowControl_None)
+    {
+    }
+
+    usartxbase = (uint32_t)USARTx;
+    tmpreg = USARTx->CTLR2;
+    tmpreg &= CTLR2_STOP_CLEAR_Mask;
+    tmpreg |= (uint32_t)USART_InitStruct->USART_StopBits;
+
+    USARTx->CTLR2 = (uint16_t)tmpreg;
+    tmpreg = USARTx->CTLR1;
+    tmpreg &= CTLR1_CLEAR_Mask;
+    tmpreg |= (uint32_t)USART_InitStruct->USART_WordLength | USART_InitStruct->USART_Parity |
+              USART_InitStruct->USART_Mode;
+    USARTx->CTLR1 = (uint16_t)tmpreg;
+
+    tmpreg = USARTx->CTLR3;
+    tmpreg &= CTLR3_CLEAR_Mask;
+    tmpreg |= USART_InitStruct->USART_HardwareFlowControl;
+    USARTx->CTLR3 = (uint16_t)tmpreg;
+
+    RCC_GetClocksFreq(&RCC_ClocksStatus);
+
+    if(usartxbase == USART1_BASE)
+    {
+        apbclock = RCC_ClocksStatus.PCLK2_Frequency;
+    }
+    else
+    {
+        apbclock = RCC_ClocksStatus.PCLK1_Frequency;
+    }
+
+    integerdivider = ((25 * apbclock) / (4 * (USART_InitStruct->USART_BaudRate)));
+    tmpreg = (integerdivider / 100) << 4;
+
+    fractionaldivider = integerdivider - (100 * (tmpreg >> 4));
+    tmpreg |= ((((fractionaldivider * 16) + 50) / 100)) & ((uint8_t)0x0F);
+
+    USARTx->BRR = (uint16_t)tmpreg;
+}
+
+/*********************************************************************
+ * @fn      USART_StructInit
+ *
+ * @brief   Fills each USART_InitStruct member with its default value.
+ *
+ * @param   USART_InitStruct: pointer to a USART_InitTypeDef structure
+ *       which will be initialized.
+ *
+ * @return  none
+ */
+void USART_StructInit(USART_InitTypeDef *USART_InitStruct)
+{
+    USART_InitStruct->USART_BaudRate = 9600;
+    USART_InitStruct->USART_WordLength = USART_WordLength_8b;
+    USART_InitStruct->USART_StopBits = USART_StopBits_1;
+    USART_InitStruct->USART_Parity = USART_Parity_No;
+    USART_InitStruct->USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
+    USART_InitStruct->USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+}
+
+/*********************************************************************
+ * @fn      USART_ClockInit
+ *
+ * @brief   Initializes the USARTx peripheral Clock according to the
+ *        specified parameters in the USART_ClockInitStruct .
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_ClockInitStruct - pointer to a USART_ClockInitTypeDef
+ *        structure that contains the configuration information for the specified
+ *        USART peripheral.
+ *
+ * @return  none
+ */
+void USART_ClockInit(USART_TypeDef *USARTx, USART_ClockInitTypeDef *USART_ClockInitStruct)
+{
+    uint32_t tmpreg = 0x00;
+
+    tmpreg = USARTx->CTLR2;
+    tmpreg &= CTLR2_CLOCK_CLEAR_Mask;
+    tmpreg |= (uint32_t)USART_ClockInitStruct->USART_Clock | USART_ClockInitStruct->USART_CPOL |
+              USART_ClockInitStruct->USART_CPHA | USART_ClockInitStruct->USART_LastBit;
+    USARTx->CTLR2 = (uint16_t)tmpreg;
+}
+
+/*********************************************************************
+ * @fn      USART_ClockStructInit
+ *
+ * @brief   Fills each USART_ClockStructInit member with its default value.
+ *
+ * @param   USART_ClockInitStruct - pointer to a USART_ClockInitTypeDef
+ *        structure which will be initialized.
+ *
+ * @return  none
+ */
+void USART_ClockStructInit(USART_ClockInitTypeDef *USART_ClockInitStruct)
+{
+    USART_ClockInitStruct->USART_Clock = USART_Clock_Disable;
+    USART_ClockInitStruct->USART_CPOL = USART_CPOL_Low;
+    USART_ClockInitStruct->USART_CPHA = USART_CPHA_1Edge;
+    USART_ClockInitStruct->USART_LastBit = USART_LastBit_Disable;
+}
+
+/*********************************************************************
+ * @fn      USART_Cmd
+ *
+ * @brief   Enables or disables the specified USART peripheral.
+ *        reset values (Affects also the I2Ss).
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          NewState: ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_Cmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR1 |= CTLR1_UE_Set;
+    }
+    else
+    {
+        USARTx->CTLR1 &= CTLR1_UE_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_ITConfig
+ *
+ * @brief   Enables or disables the specified USART interrupts.
+ *        reset values (Affects also the I2Ss).
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_IT - specifies the USART interrupt sources to be enabled or disabled.
+ *            USART_IT_LBD - LIN Break detection interrupt.
+ *            USART_IT_TXE - Transmit Data Register empty interrupt.
+ *            USART_IT_TC - Transmission complete interrupt.
+ *            USART_IT_RXNE - Receive Data register not empty interrupt.
+ *            USART_IT_IDLE - Idle line detection interrupt.
+ *            USART_IT_PE - Parity Error interrupt.
+ *            USART_IT_ERR - Error interrupt.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_ITConfig(USART_TypeDef *USARTx, uint16_t USART_IT, FunctionalState NewState)
+{
+    uint32_t usartreg = 0x00, itpos = 0x00, itmask = 0x00;
+    uint32_t usartxbase = 0x00;
+
+
+    usartxbase = (uint32_t)USARTx;
+    usartreg = (((uint8_t)USART_IT) >> 0x05);
+    itpos = USART_IT & IT_Mask;
+    itmask = (((uint32_t)0x01) << itpos);
+
+    if(usartreg == 0x01)
+    {
+        usartxbase += 0x0C;
+    }
+    else if(usartreg == 0x02)
+    {
+        usartxbase += 0x10;
+    }
+    else
+    {
+        usartxbase += 0x14;
+    }
+
+    if(NewState != DISABLE)
+    {
+        *(__IO uint32_t *)usartxbase |= itmask;
+    }
+    else
+    {
+        *(__IO uint32_t *)usartxbase &= ~itmask;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_DMACmd
+ *
+ * @brief   Enables or disables the USART DMA interface.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_DMAReq - specifies the DMA request.
+ *            USART_DMAReq_Tx - USART DMA transmit request.
+ *            USART_DMAReq_Rx - USART DMA receive request.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_DMACmd(USART_TypeDef *USARTx, uint16_t USART_DMAReq, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= USART_DMAReq;
+    }
+    else
+    {
+        USARTx->CTLR3 &= (uint16_t)~USART_DMAReq;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_SetAddress
+ *
+ * @brief   Sets the address of the USART node.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_Address - Indicates the address of the USART node.
+ *
+ * @return  none
+ */
+void USART_SetAddress(USART_TypeDef *USARTx, uint8_t USART_Address)
+{
+    USARTx->CTLR2 &= CTLR2_Address_Mask;
+    USARTx->CTLR2 |= USART_Address;
+}
+
+/*********************************************************************
+ * @fn      USART_WakeUpConfig
+ *
+ * @brief   Selects the USART WakeUp method.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_WakeUp - specifies the USART wakeup method.
+ *            USART_WakeUp_IdleLine - WakeUp by an idle line detection.
+ *            USART_WakeUp_AddressMark - WakeUp by an address mark.
+ *
+ * @return  none
+ */
+void USART_WakeUpConfig(USART_TypeDef *USARTx, uint16_t USART_WakeUp)
+{
+    USARTx->CTLR1 &= CTLR1_WAKE_Mask;
+    USARTx->CTLR1 |= USART_WakeUp;
+}
+
+/*********************************************************************
+ * @fn      USART_ReceiverWakeUpCmd
+ *
+ * @brief   Determines if the USART is in mute mode or not.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_ReceiverWakeUpCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR1 |= CTLR1_RWU_Set;
+    }
+    else
+    {
+        USARTx->CTLR1 &= CTLR1_RWU_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_LINBreakDetectLengthConfig
+ *
+ * @brief   Sets the USART LIN Break detection length.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_LINBreakDetectLength - specifies the LIN break detection length.
+ *            USART_LINBreakDetectLength_10b - 10-bit break detection.
+ *            USART_LINBreakDetectLength_11b - 11-bit break detection.
+ *
+ * @return  none
+ */
+void USART_LINBreakDetectLengthConfig(USART_TypeDef *USARTx, uint16_t USART_LINBreakDetectLength)
+{
+    USARTx->CTLR2 &= CTLR2_LBDL_Mask;
+    USARTx->CTLR2 |= USART_LINBreakDetectLength;
+}
+
+/*********************************************************************
+ * @fn      USART_LINCmd
+ *
+ * @brief   Enables or disables the USART LIN mode.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_LINCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR2 |= CTLR2_LINEN_Set;
+    }
+    else
+    {
+        USARTx->CTLR2 &= CTLR2_LINEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_SendData
+ *
+ * @brief   Transmits single data through the USARTx peripheral.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          Data - the data to transmit.
+ *
+ * @return  none
+ */
+void USART_SendData(USART_TypeDef *USARTx, uint16_t Data)
+{
+    USARTx->DATAR = (Data & (uint16_t)0x01FF);
+}
+
+/*********************************************************************
+ * @fn      USART_ReceiveData
+ *
+ * @brief   Returns the most recent received data by the USARTx peripheral.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *
+ * @return  The received data.
+ */
+uint16_t USART_ReceiveData(USART_TypeDef *USARTx)
+{
+    return (uint16_t)(USARTx->DATAR & (uint16_t)0x01FF);
+}
+
+/*********************************************************************
+ * @fn      USART_SendBreak
+ *
+ * @brief   Transmits break characters.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *
+ * @return  none
+ */
+void USART_SendBreak(USART_TypeDef *USARTx)
+{
+    USARTx->CTLR1 |= CTLR1_SBK_Set;
+}
+
+/*********************************************************************
+ * @fn      USART_SetGuardTime
+ *
+ * @brief   Sets the specified USART guard time.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_GuardTime - specifies the guard time.
+ *
+ * @return  none
+ */
+void USART_SetGuardTime(USART_TypeDef *USARTx, uint8_t USART_GuardTime)
+{
+    USARTx->GPR &= GPR_LSB_Mask;
+    USARTx->GPR |= (uint16_t)((uint16_t)USART_GuardTime << 0x08);
+}
+
+/*********************************************************************
+ * @fn      USART_SetPrescaler
+ *
+ * @brief   Sets the system clock prescaler.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_Prescaler - specifies the prescaler clock.
+ *
+ * @return  none
+ */
+void USART_SetPrescaler(USART_TypeDef *USARTx, uint8_t USART_Prescaler)
+{
+    USARTx->GPR &= GPR_MSB_Mask;
+    USARTx->GPR |= USART_Prescaler;
+}
+
+/*********************************************************************
+ * @fn      USART_SmartCardCmd
+ *
+ * @brief   Enables or disables the USART Smart Card mode.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_SmartCardCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_SCEN_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_SCEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_SmartCardNACKCmd
+ *
+ * @brief   Enables or disables NACK transmission.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_SmartCardNACKCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_NACK_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_NACK_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_HalfDuplexCmd
+ *
+ * @brief   Enables or disables the USART Half Duplex communication.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *                  NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_HalfDuplexCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_HDSEL_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_HDSEL_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_IrDAConfig
+ *
+ * @brief   Configures the USART's IrDA interface.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_IrDAMode - specifies the IrDA mode.
+ *            USART_IrDAMode_LowPower.
+ *            USART_IrDAMode_Normal.
+ *
+ * @return  none
+ */
+void USART_IrDAConfig(USART_TypeDef *USARTx, uint16_t USART_IrDAMode)
+{
+    USARTx->CTLR3 &= CTLR3_IRLP_Mask;
+    USARTx->CTLR3 |= USART_IrDAMode;
+}
+
+/*********************************************************************
+ * @fn      USART_IrDACmd
+ *
+ * @brief   Enables or disables the USART's IrDA interface.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_IrDACmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_IREN_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_IREN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_GetFlagStatus
+ *
+ * @brief   Checks whether the specified USART flag is set or not.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_FLAG - specifies the flag to check.
+ *            USART_FLAG_LBD - LIN Break detection flag.
+ *            USART_FLAG_TXE - Transmit data register empty flag.
+ *            USART_FLAG_TC - Transmission Complete flag.
+ *            USART_FLAG_RXNE - Receive data register not empty flag.
+ *            USART_FLAG_IDLE - Idle Line detection flag.
+ *            USART_FLAG_ORE - OverRun Error flag.
+ *            USART_FLAG_NE - Noise Error flag.
+ *            USART_FLAG_FE - Framing Error flag.
+ *            USART_FLAG_PE - Parity Error flag.
+ *
+ * @return  bitstatus: SET or RESET
+ */
+FlagStatus USART_GetFlagStatus(USART_TypeDef *USARTx, uint16_t USART_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+
+    if((USARTx->STATR & USART_FLAG) != (uint16_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      USART_ClearFlag
+ *
+ * @brief   Clears the USARTx's pending flags.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_FLAG - specifies the flag to clear.
+ *            USART_FLAG_LBD - LIN Break detection flag.
+ *            USART_FLAG_TC - Transmission Complete flag.
+ *            USART_FLAG_RXNE - Receive data register not empty flag.
+ *          Note-
+ *            - PE (Parity error), FE (Framing error), NE (Noise error), ORE (OverRun 
+ *            error) and IDLE (Idle line detected) flags are cleared by software 
+ *            sequence: a read operation to USART_STATR register (USART_GetFlagStatus()) 
+ *            followed by a read operation to USART_DATAR register (USART_ReceiveData()).
+ *            - RXNE flag can be also cleared by a read to the USART_DATAR register 
+ *            (USART_ReceiveData()).
+ *            - TC flag can be also cleared by software sequence: a read operation to 
+ *            USART_STATR register (USART_GetFlagStatus()) followed by a write operation
+ *            to USART_DATAR register (USART_SendData()).
+ *            - TXE flag is cleared only by a write to the USART_DATAR register 
+ *            (USART_SendData()).
+ * @return  none
+ */
+void USART_ClearFlag(USART_TypeDef *USARTx, uint16_t USART_FLAG)
+{
+
+    USARTx->STATR = (uint16_t)~USART_FLAG;
+}
+
+/*********************************************************************
+ * @fn      USART_GetITStatus
+ *
+ * @brief   Checks whether the specified USART interrupt has occurred or not.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_IT - specifies the USART interrupt source to check.
+ *            USART_IT_LBD - LIN Break detection interrupt.
+ *            USART_IT_TXE - Tansmit Data Register empty interrupt.
+ *            USART_IT_TC - Transmission complete interrupt.
+ *            USART_IT_RXNE - Receive Data register not empty interrupt.
+ *            USART_IT_IDLE - Idle line detection interrupt.
+ *            USART_IT_ORE_RX - OverRun Error interrupt if the RXNEIE bit is set.
+ *            USART_IT_ORE_ER - OverRun Error interrupt if the EIE bit is set.
+ *            USART_IT_NE - Noise Error interrupt.
+ *            USART_IT_FE - Framing Error interrupt.
+ *            USART_IT_PE - Parity Error interrupt.
+ *
+ * @return  bitstatus: SET or RESET.
+ */
+ITStatus USART_GetITStatus(USART_TypeDef *USARTx, uint16_t USART_IT)
+{
+    uint32_t bitpos = 0x00, itmask = 0x00, usartreg = 0x00;
+    ITStatus bitstatus = RESET;
+
+    usartreg = (((uint8_t)USART_IT) >> 0x05);
+    itmask = USART_IT & IT_Mask;
+    itmask = (uint32_t)0x01 << itmask;
+
+    if(usartreg == 0x01)
+    {
+        itmask &= USARTx->CTLR1;
+    }
+    else if(usartreg == 0x02)
+    {
+        itmask &= USARTx->CTLR2;
+    }
+    else
+    {
+        itmask &= USARTx->CTLR3;
+    }
+
+    bitpos = USART_IT >> 0x08;
+    bitpos = (uint32_t)0x01 << bitpos;
+    bitpos &= USARTx->STATR;
+
+    if((itmask != (uint16_t)RESET) && (bitpos != (uint16_t)RESET))
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      USART_ClearITPendingBit
+ *
+ * @brief   Clears the USARTx's interrupt pending bits.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 or 4 to select the USART peripheral.
+ *          USART_IT - specifies the interrupt pending bit to clear.
+ *            USART_IT_LBD - LIN Break detection interrupt.
+ *            USART_IT_TC - Transmission complete interrupt.
+ *            USART_IT_RXNE - Receive Data register not empty interrupt.
+ *         Note-
+ *            - PE (Parity error), FE (Framing error), NE (Noise error), ORE (OverRun 
+ *            error) and IDLE (Idle line detected) pending bits are cleared by 
+ *            software sequence: a read operation to USART_STATR register 
+ *            (USART_GetITStatus()) followed by a read operation to USART_DATAR register 
+ *            (USART_ReceiveData()).
+ *            - RXNE pending bit can be also cleared by a read to the USART_DATAR register 
+ *            (USART_ReceiveData()).
+ *            - TC pending bit can be also cleared by software sequence: a read 
+ *            operation to USART_STATR register (USART_GetITStatus()) followed by a write 
+ *            operation to USART_DATAR register (USART_SendData()).
+ *            - TXE pending bit is cleared only by a write to the USART_DATAR register 
+ *            (USART_SendData()).
+ * @return  none
+ */
+void USART_ClearITPendingBit(USART_TypeDef *USARTx, uint16_t USART_IT)
+{
+    uint16_t bitpos = 0x00, itmask = 0x00;
+
+    bitpos = USART_IT >> 0x08;
+    itmask = ((uint16_t)0x01 << (uint16_t)bitpos);
+    USARTx->STATR = (uint16_t)~itmask;
+}

--- a/Peripheral/ch32x035/src/ch32x035_wwdg.c
+++ b/Peripheral/ch32x035/src/ch32x035_wwdg.c
@@ -1,0 +1,141 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32x035_wwdg.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : This file provides all the WWDG firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035_wwdg.h"
+#include "ch32x035_rcc.h"
+
+/* CTLR register bit mask */
+#define CTLR_WDGA_Set      ((uint32_t)0x00000080)
+
+/* CFGR register bit mask */
+#define CFGR_WDGTB_Mask    ((uint32_t)0xFFFFFE7F)
+#define CFGR_W_Mask        ((uint32_t)0xFFFFFF80)
+#define BIT_Mask           ((uint8_t)0x7F)
+
+/*********************************************************************
+ * @fn      WWDG_DeInit
+ *
+ * @brief   Deinitializes the WWDG peripheral registers to their default reset values
+ *
+ * @return  none
+ */
+void WWDG_DeInit(void)
+{
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_WWDG, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_WWDG, DISABLE);
+}
+
+/*********************************************************************
+ * @fn      WWDG_SetPrescaler
+ *
+ * @brief   Sets the WWDG Prescaler
+ *
+ * @param   WWDG_Prescaler - specifies the WWDG Prescaler
+ *            WWDG_Prescaler_1 - WWDG counter clock = (PCLK1/4096)/1
+ *            WWDG_Prescaler_2 - WWDG counter clock = (PCLK1/4096)/2
+ *            WWDG_Prescaler_4 - WWDG counter clock = (PCLK1/4096)/4
+ *            WWDG_Prescaler_8 - WWDG counter clock = (PCLK1/4096)/8
+ *
+ * @return  none
+ */
+void WWDG_SetPrescaler(uint32_t WWDG_Prescaler)
+{
+    uint32_t tmpreg = 0;
+    tmpreg = WWDG->CFGR & CFGR_WDGTB_Mask;
+    tmpreg |= WWDG_Prescaler;
+    WWDG->CFGR = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      WWDG_SetWindowValue
+ *
+ * @brief   Sets the WWDG window value
+ *
+ * @param   WindowValue - specifies the window value to be compared to the
+ *        downcounter,which must be lower than 0x80
+ *
+ * @return  none
+ */
+void WWDG_SetWindowValue(uint8_t WindowValue)
+{
+    __IO uint32_t tmpreg = 0;
+
+    tmpreg = WWDG->CFGR & CFGR_W_Mask;
+
+    tmpreg |= WindowValue & (uint32_t)BIT_Mask;
+
+    WWDG->CFGR = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      WWDG_EnableIT
+ *
+ * @brief   Enables the WWDG Early Wakeup interrupt(EWI)
+ *
+ * @return  none
+ */
+void WWDG_EnableIT(void)
+{
+    WWDG->CFGR |= (1 << 9);
+}
+
+/*********************************************************************
+ * @fn      WWDG_SetCounter
+ *
+ * @brief   Sets the WWDG counter value
+ *
+ * @param   Counter - specifies the watchdog counter value,which must be a
+ *        number between 0x40 and 0x7F
+ *
+ * @return  none
+ */
+void WWDG_SetCounter(uint8_t Counter)
+{
+    WWDG->CTLR = Counter & BIT_Mask;
+}
+
+/*********************************************************************
+ * @fn      WWDG_Enable
+ *
+ * @brief   Enables WWDG and load the counter value
+ *
+ * @param   Counter - specifies the watchdog counter value,which must be a
+ *        number between 0x40 and 0x7F
+ * @return  none
+ */
+void WWDG_Enable(uint8_t Counter)
+{
+    WWDG->CTLR = CTLR_WDGA_Set | Counter;
+}
+
+/*********************************************************************
+ * @fn      WWDG_GetFlagStatus
+ *
+ * @brief   Checks whether the Early Wakeup interrupt flag is set or not
+ *
+ * @return  The new state of the Early Wakeup interrupt flag (SET or RESET)
+ */
+FlagStatus WWDG_GetFlagStatus(void)
+{
+    return (FlagStatus)(WWDG->STATR);
+}
+
+/*********************************************************************
+ * @fn      WWDG_ClearFlag
+ *
+ * @brief   Clears Early Wakeup interrupt flag
+ *
+ * @return  none
+ */
+void WWDG_ClearFlag(void)
+{
+    WWDG->STATR = (uint32_t)RESET;
+}

--- a/Startup/startup_ch32x035.S
+++ b/Startup/startup_ch32x035.S
@@ -1,0 +1,226 @@
+;/********************************** (C) COPYRIGHT *******************************
+;* File Name          : startup_ch32x035.s
+;* Author             : WCH
+;* Version            : V1.0.0
+;* Date               : 2023/04/06
+;* Description        : vector table for eclipse toolchain.
+;*********************************************************************************
+;* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+;* Attention: This software (modified or not) and binary are used for 
+;* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+;*******************************************************************************/
+
+	.section	.init,"ax",@progbits
+	.global	_start
+	.align	1
+_start:
+	j	handle_reset
+    .section    .vector,"ax",@progbits
+    .align  1
+_vector_base:
+    .option norvc;
+    .word   _start
+    .word   0
+    .word   NMI_Handler                /* NMI */
+    .word   HardFault_Handler          /* Hard Fault */
+    .word   0
+    .word   Ecall_M_Mode_Handler       /* Ecall M Mode */
+    .word   0
+    .word   0
+    .word   Ecall_U_Mode_Handler       /* Ecall U Mode */
+    .word   Break_Point_Handler        /* Break Point */
+    .word   0
+    .word   0
+    .word   SysTick_Handler            /* SysTick */
+    .word   0
+    .word   SW_Handler                 /* SW */
+    .word   0
+    /* External Interrupts */
+    .word   WWDG_IRQHandler            /* Window Watchdog */
+    .word   PVD_IRQHandler             /* PVD through EXTI Line detect */
+    .word   FLASH_IRQHandler           /* Flash */
+    .word   0
+    .word   EXTI7_0_IRQHandler         /* EXTI Line 7..0 */
+    .word   AWU_IRQHandler             /* Auto Wake up */
+    .word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */
+    .word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */
+    .word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */
+    .word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */
+    .word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */
+    .word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */
+    .word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */
+    .word   ADC1_IRQHandler            /* ADC1 */
+    .word   I2C1_EV_IRQHandler         /* I2C1 Event */
+    .word   I2C1_ER_IRQHandler         /* I2C1 Error */
+    .word   USART1_IRQHandler          /* USART1 */
+    .word   SPI1_IRQHandler            /* SPI1 */
+    .word   TIM1_BRK_IRQHandler        /* TIM1 Break */
+    .word   TIM1_UP_IRQHandler         /* TIM1 Update */
+    .word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */
+    .word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */
+    .word   TIM2_UP_IRQHandler         /* TIM2 Update */
+    .word   USART2_IRQHandler          /* USART2 */
+    .word   EXTI15_8_IRQHandler        /* EXTI Line 15..8 */
+    .word   EXTI25_16_IRQHandler       /* EXTI Line 25..16 */
+    .word   USART3_IRQHandler          /* USART3 */
+    .word   USART4_IRQHandler          /* USART4 */
+    .word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */
+    .word   USBFS_IRQHandler           /* USBFS Break */
+    .word   USBFSWakeUp_IRQHandler     /* USBFS Wake up from suspend */
+    .word   PIOC_IRQHandler            /* PIOC */
+    .word   OPA_IRQHandler             /* OPA */
+    .word   USBPD_IRQHandler           /* USBPD */
+    .word   USBPDWakeUp_IRQHandler     /* USBPD Wake up */
+    .word   TIM2_CC_IRQHandler         /* TIM2 Capture Compare */
+    .word   TIM2_TRG_COM_IRQHandler    /* TIM2 Trigger and Commutation */
+    .word   TIM2_BRK_IRQHandler        /* TIM2 Break */
+    .word   TIM3_IRQHandler            /* TIM3 */
+
+    .option rvc;
+
+    .section    .text.vector_handler, "ax", @progbits
+    .weak   NMI_Handler                /* NMI */
+    .weak   HardFault_Handler          /* Hard Fault */
+    .weak   Ecall_M_Mode_Handler       /* Ecall M Mode */
+    .weak   Ecall_U_Mode_Handler       /* Ecall U Mode */
+    .weak   Break_Point_Handler        /* Break Point */
+    .weak   SysTick_Handler            /* SysTick */
+    .weak   SW_Handler                 /* SW */
+    .weak   WWDG_IRQHandler            /* Window Watchdog */
+    .weak   PVD_IRQHandler             /* PVD through EXTI Line detect */
+    .weak   FLASH_IRQHandler           /* Flash */
+    .weak   EXTI7_0_IRQHandler         /* EXTI Line 7..0 */
+    .weak   AWU_IRQHandler             /* Auto Wake up */
+    .weak   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */
+    .weak   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */
+    .weak   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */
+    .weak   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */
+    .weak   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */
+    .weak   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */
+    .weak   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */
+    .weak   ADC1_IRQHandler            /* ADC1 */
+    .weak   I2C1_EV_IRQHandler         /* I2C1 Event */
+    .weak   I2C1_ER_IRQHandler         /* I2C1 Error */
+    .weak   USART1_IRQHandler          /* USART1 */
+    .weak   SPI1_IRQHandler            /* SPI1 */
+    .weak   TIM1_BRK_IRQHandler        /* TIM1 Break */
+    .weak   TIM1_UP_IRQHandler         /* TIM1 Update */
+    .weak   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */
+    .weak   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */
+    .weak   TIM2_UP_IRQHandler         /* TIM2 Update */
+    .weak   USART2_IRQHandler          /* USART2 */
+    .weak   EXTI15_8_IRQHandler        /* EXTI Line 15..8 */
+    .weak   EXTI25_16_IRQHandler       /* EXTI Line 25..16 */
+    .weak   USART3_IRQHandler          /* USART3 */
+    .weak   USART4_IRQHandler          /* USART4 */
+    .weak   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */
+    .weak   USBFS_IRQHandler           /* USBFS Break */
+    .weak   USBFSWakeUp_IRQHandler     /* USBFS Wake up from suspend */
+    .weak   PIOC_IRQHandler            /* PIOC */
+    .weak   OPA_IRQHandler             /* OPA */
+    .weak   USBPD_IRQHandler           /* USBPD */
+    .weak   USBPDWakeUp_IRQHandler     /* USBPD Wake up */
+    .weak   TIM2_CC_IRQHandler         /* TIM2 Capture Compare */
+    .weak   TIM2_TRG_COM_IRQHandler    /* TIM2 Trigger and Commutation */
+    .weak   TIM2_BRK_IRQHandler        /* TIM2 Break */
+    .weak   TIM3_IRQHandler            /* TIM3 */
+
+NMI_Handler:  1:  j 1b
+HardFault_Handler:  1:  j 1b
+Ecall_M_Mode_Handler:  1:  j 1b
+Ecall_U_Mode_Handler:  1:  j 1b
+Break_Point_Handler:  1:  j 1b
+SysTick_Handler:  1:  j 1b
+SW_Handler:  1:  j 1b
+WWDG_IRQHandler:  1:  j 1b
+PVD_IRQHandler:  1:  j 1b
+FLASH_IRQHandler:  1:  j 1b
+EXTI7_0_IRQHandler:  1:  j 1b
+AWU_IRQHandler:  1:  j 1b
+DMA1_Channel1_IRQHandler:  1:  j 1b
+DMA1_Channel2_IRQHandler:  1:  j 1b
+DMA1_Channel3_IRQHandler:  1:  j 1b
+DMA1_Channel4_IRQHandler:  1:  j 1b
+DMA1_Channel5_IRQHandler:  1:  j 1b
+DMA1_Channel6_IRQHandler:  1:  j 1b
+DMA1_Channel7_IRQHandler:  1:  j 1b
+ADC1_IRQHandler:  1:  j 1b
+I2C1_EV_IRQHandler:  1:  j 1b
+I2C1_ER_IRQHandler:  1:  j 1b
+USART1_IRQHandler:  1:  j 1b
+SPI1_IRQHandler:  1:  j 1b
+TIM1_BRK_IRQHandler:  1:  j 1b
+TIM1_UP_IRQHandler:  1:  j 1b
+TIM1_TRG_COM_IRQHandler:  1:  j 1b
+TIM1_CC_IRQHandler:  1:  j 1b
+TIM2_UP_IRQHandler:  1:  j 1b
+USART2_IRQHandler:  1:  j 1b
+EXTI15_8_IRQHandler:  1:  j 1b
+EXTI25_16_IRQHandler:  1:  j 1b
+USART3_IRQHandler:  1:  j 1b
+USART4_IRQHandler:  1:  j 1b
+DMA1_Channel8_IRQHandler:  1:  j 1b
+USBFS_IRQHandler:  1:  j 1b
+USBFSWakeUp_IRQHandler:  1:  j 1b
+PIOC_IRQHandler:  1:  j 1b
+OPA_IRQHandler:  1:  j 1b
+USBPD_IRQHandler:  1:  j 1b
+USBPDWakeUp_IRQHandler:  1:  j 1b
+TIM2_CC_IRQHandler:  1:  j 1b
+TIM2_TRG_COM_IRQHandler:  1:  j 1b
+TIM2_BRK_IRQHandler:  1:  j 1b
+TIM3_IRQHandler:  1:  j 1b
+
+	.section	.text.handle_reset,"ax",@progbits
+	.weak	handle_reset
+	.align	1
+handle_reset:
+.option push 
+.option	norelax 
+	la gp, __global_pointer$
+.option	pop 
+1:
+	la sp, _eusrstack 
+2:
+	/* Load data section from flash to RAM */
+	la a0, _data_lma
+	la a1, _data_vma
+	la a2, _edata
+	bgeu a1, a2, 2f
+1:
+	lw t0, (a0)
+	sw t0, (a1)
+	addi a0, a0, 4
+	addi a1, a1, 4
+	bltu a1, a2, 1b
+2:
+	/* Clear bss section */
+	la a0, _sbss
+	la a1, _ebss
+	bgeu a0, a1, 2f
+1:
+	sw zero, (a0)
+	addi a0, a0, 4
+	bltu a0, a1, 1b
+2:
+    li t0, 0x1f
+    csrw 0xbc0, t0
+
+    /* Enable nested and hardware stack */
+	li t0, 0x3
+	csrw 0x804, t0
+
+    /* Enable interrupt */
+   	li t0, 0x88           
+   	csrs mstatus, t0
+
+ 	la t0, _vector_base
+    ori t0, t0, 3           
+	csrw mtvec, t0
+
+    jal  SystemInit
+	la t0, main
+	csrw mepc, t0
+	mret
+
+

--- a/System/ch32x035/system_ch32x035.c
+++ b/System/ch32x035/system_ch32x035.c
@@ -1,0 +1,241 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : system_ch32x035.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : CH32X035 Device Peripheral Access Layer System Source File.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32x035.h"
+
+/* 
+* Uncomment the line corresponding to the desired System clock (SYSCLK) frequency (after 
+* reset the HSI is used as SYSCLK source).
+*/
+
+//#define SYSCLK_FREQ_8MHz_HSI   8000000
+//#define SYSCLK_FREQ_12MHz_HSI  12000000
+//#define SYSCLK_FREQ_16MHz_HSI  16000000
+//#define SYSCLK_FREQ_24MHz_HSI  24000000
+#define SYSCLK_FREQ_48MHz_HSI  HSI_VALUE
+
+/* Clock Definitions */
+#ifdef SYSCLK_FREQ_8MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_8MHz_HSI;              /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_12MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_12MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_16MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_16MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_24MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_24MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#else
+uint32_t SystemCoreClock         = HSI_VALUE;                    /* System Clock Frequency (Core Clock) */
+
+#endif
+
+__I uint8_t AHBPrescTable[16] = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+
+
+/* system_private_function_proto_types */
+static void SetSysClock(void);
+
+#ifdef SYSCLK_FREQ_8MHz_HSI
+static void SetSysClockTo8_HSI( void );
+#elif defined SYSCLK_FREQ_12MHz_HSI
+static void SetSysClockTo12_HSI( void );
+#elif defined SYSCLK_FREQ_16MHz_HSI
+static void SetSysClockTo16_HSI( void );
+#elif defined SYSCLK_FREQ_24MHz_HSI
+static void SetSysClockTo24_HSI( void );
+#elif defined SYSCLK_FREQ_48MHz_HSI
+static void SetSysClockTo48_HSI( void );
+
+#endif
+
+/*********************************************************************
+ * @fn      SystemInit
+ *
+ * @brief   Setup the microcontroller system Initialize the Embedded Flash Interface,
+ *        update the SystemCoreClock variable.
+ *
+ * @return  none
+ */
+void SystemInit (void)
+{
+  RCC->CTLR |= (uint32_t)0x00000001;
+  RCC->CFGR0 |= (uint32_t)0x00000050;
+  RCC->CFGR0 &= (uint32_t)0xF8FFFF5F;
+  SetSysClock();
+}
+
+/*********************************************************************
+ * @fn      SystemCoreClockUpdate
+ *
+ * @brief   Update SystemCoreClock variable according to Clock Register Values.
+ *
+ * @return  none
+ */
+void SystemCoreClockUpdate (void)
+{
+    uint32_t tmp = 0;
+
+    SystemCoreClock = HSI_VALUE;
+    tmp = AHBPrescTable[((RCC->CFGR0 & RCC_HPRE) >> 4)];
+
+    if(((RCC->CFGR0 & RCC_HPRE) >> 4) < 8)
+    {
+        SystemCoreClock /= tmp;
+    }
+    else
+    {
+        SystemCoreClock >>= tmp;
+    }
+}
+
+/*********************************************************************
+ * @fn      SetSysClock
+ *
+ * @brief   Configures the System clock frequency, HCLK prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClock(void)
+{
+//    GPIO_IPD_Unused();
+
+#ifdef SYSCLK_FREQ_8MHz_HSI
+    SetSysClockTo8_HSI();
+#elif defined SYSCLK_FREQ_12MHz_HSI
+    SetSysClockTo12_HSI();
+#elif defined SYSCLK_FREQ_16MHz_HSI
+    SetSysClockTo16_HSI();
+#elif defined SYSCLK_FREQ_24MHz_HSI
+    SetSysClockTo24_HSI();
+#elif defined SYSCLK_FREQ_48MHz_HSI
+    SetSysClockTo48_HSI();
+
+#endif
+}
+
+
+#ifdef SYSCLK_FREQ_8MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo8_HSI
+ *
+ * @brief   Sets HSE as System clock source and configure HCLK prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo8_HSI(void)
+{
+    /* Flash 2 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_2;
+
+    /* HCLK = SYSCLK = APB1 */
+    RCC->CFGR0 &= (uint32_t)0xFFFFFF0F;
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV6;
+
+    /* Flash 0 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_0;
+}
+
+#elif defined SYSCLK_FREQ_12MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo12_HSI
+ *
+ * @brief   Sets System clock frequency to 12MHz and configure HCLK prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo12_HSI(void)
+{
+    /* Flash 2 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_2;
+
+    /* HCLK = SYSCLK = APB1 */
+    RCC->CFGR0 &= (uint32_t)0xFFFFFF0F;
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV4;
+
+    /* Flash 0 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_0;
+}
+
+#elif defined SYSCLK_FREQ_16MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo16_HSI
+ *
+ * @brief   Sets System clock frequency to 16MHz and configure HCLK prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo16_HSI(void)
+{
+    /* Flash 2 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_2;
+
+    /* HCLK = SYSCLK = APB1 */
+    RCC->CFGR0 &= (uint32_t)0xFFFFFF0F;
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV3;
+
+    /* Flash 0 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_1;
+}
+
+#elif defined SYSCLK_FREQ_24MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo24_HSI
+ *
+ * @brief   Sets System clock frequency to 24MHz and configure HCLK prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo24_HSI(void)
+{
+    /* Flash 2 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_2;
+
+    /* HCLK = SYSCLK = APB1 */
+    RCC->CFGR0 &= (uint32_t)0xFFFFFF0F;
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV2;
+
+    /* Flash 1 wait state */
+    FLASH->ACTLR = (uint32_t)FLASH_ACTLR_LATENCY_1;
+}
+
+
+#elif defined SYSCLK_FREQ_48MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo48_HSI
+ *
+ * @brief   Sets System clock frequency to 48MHz and configure HCLK prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo48_HSI(void)
+{
+    /* Flash 2 wait state */
+    FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
+    FLASH->ACTLR |= (uint32_t)FLASH_ACTLR_LATENCY_2;
+
+    /* HCLK = SYSCLK = APB1 */
+    RCC->CFGR0 &= (uint32_t)0xFFFFFF0F;
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+}
+
+#endif
+

--- a/System/ch32x035/system_ch32x035.h
+++ b/System/ch32x035/system_ch32x035.h
@@ -1,0 +1,32 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : system_ch32x035.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2023/04/06
+ * Description        : CH32X035 Device Peripheral Access Layer System Header File.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __SYSTEM_CH32X035_H
+#define __SYSTEM_CH32X035_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+extern uint32_t SystemCoreClock;          /* System Clock Frequency (Core Clock) */
+
+/* System_Exported_Functions */  
+extern void SystemInit(void);
+extern void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+
+

--- a/package.json
+++ b/package.json
@@ -3,5 +3,5 @@
     "name": "framework-wch-noneos-sdk",
     "system": "all",
     "url": "https://www.wch.cn/downloads/",
-    "version": "2.10000.0"
+    "version": "2.20000.0"
 }

--- a/platformio/ldscripts/Link_CH32X035.ld
+++ b/platformio/ldscripts/Link_CH32X035.ld
@@ -1,0 +1,164 @@
+ENTRY( _start )
+
+__stack_size = 2048;
+
+PROVIDE( _stack_size = __stack_size );
+
+
+MEMORY
+{
+	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
+	RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 20K
+}
+
+
+SECTIONS
+{
+
+	.init :
+	{
+		_sinit = .;
+		. = ALIGN(4);
+		KEEP(*(SORT_NONE(.init)))
+		. = ALIGN(4);
+		_einit = .;
+	} >FLASH AT>FLASH
+
+  .vector :
+  {
+      *(.vector);
+	  . = ALIGN(64);
+  } >FLASH AT>FLASH
+
+	.text :
+	{
+		. = ALIGN(4);
+		*(.text)
+		*(.text.*)
+		*(.rodata)
+		*(.rodata*)
+		*(.gnu.linkonce.t.*)
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
+
+	.fini :
+	{
+		KEEP(*(SORT_NONE(.fini)))
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
+
+	PROVIDE( _etext = . );
+	PROVIDE( _eitcm = . );
+
+	.preinit_array  :
+	{
+	  PROVIDE_HIDDEN (__preinit_array_start = .);
+	  KEEP (*(.preinit_array))
+	  PROVIDE_HIDDEN (__preinit_array_end = .);
+	} >FLASH AT>FLASH
+
+	.init_array     :
+	{
+	  PROVIDE_HIDDEN (__init_array_start = .);
+	  KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+	  KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+	  PROVIDE_HIDDEN (__init_array_end = .);
+	} >FLASH AT>FLASH
+
+	.fini_array     :
+	{
+	  PROVIDE_HIDDEN (__fini_array_start = .);
+	  KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+	  KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+	  PROVIDE_HIDDEN (__fini_array_end = .);
+	} >FLASH AT>FLASH
+
+	.ctors          :
+	{
+	  /* gcc uses crtbegin.o to find the start of
+	     the constructors, so we make sure it is
+	     first.  Because this is a wildcard, it
+	     doesn't matter if the user does not
+	     actually link against crtbegin.o; the
+	     linker won't look for a file to match a
+	     wildcard.  The wildcard also means that it
+	     doesn't matter which directory crtbegin.o
+	     is in.  */
+	  KEEP (*crtbegin.o(.ctors))
+	  KEEP (*crtbegin?.o(.ctors))
+	  /* We don't want to include the .ctor section from
+	     the crtend.o file until after the sorted ctors.
+	     The .ctor section from the crtend file contains the
+	     end of ctors marker and it must be last */
+	  KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+	  KEEP (*(SORT(.ctors.*)))
+	  KEEP (*(.ctors))
+	} >FLASH AT>FLASH
+
+	.dtors          :
+	{
+	  KEEP (*crtbegin.o(.dtors))
+	  KEEP (*crtbegin?.o(.dtors))
+	  KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+	  KEEP (*(SORT(.dtors.*)))
+	  KEEP (*(.dtors))
+	} >FLASH AT>FLASH
+
+	.dalign :
+	{
+		. = ALIGN(4);
+		PROVIDE(_data_vma = .);
+	} >RAM AT>FLASH
+
+	.dlalign :
+	{
+		. = ALIGN(4);
+		PROVIDE(_data_lma = .);
+	} >FLASH AT>FLASH
+
+	.data :
+	{
+    	*(.gnu.linkonce.r.*)
+    	*(.data .data.*)
+    	*(.gnu.linkonce.d.*)
+		. = ALIGN(8);
+    	PROVIDE( __global_pointer$ = . + 0x800 );
+    	*(.sdata .sdata.*)
+		*(.sdata2.*)
+    	*(.gnu.linkonce.s.*)
+    	. = ALIGN(8);
+    	*(.srodata.cst16)
+    	*(.srodata.cst8)
+    	*(.srodata.cst4)
+    	*(.srodata.cst2)
+    	*(.srodata .srodata.*)
+    	. = ALIGN(4);
+		PROVIDE( _edata = .);
+	} >RAM AT>FLASH
+
+	.bss :
+	{
+		. = ALIGN(4);
+		PROVIDE( _sbss = .);
+  	    *(.sbss*)
+        *(.gnu.linkonce.sb.*)
+		*(.bss*)
+     	*(.gnu.linkonce.b.*)
+		*(COMMON*)
+		. = ALIGN(4);
+		PROVIDE( _ebss = .);
+	} >RAM AT>FLASH
+
+	PROVIDE( _end = _ebss);
+	PROVIDE( end = . );
+
+    .stack ORIGIN(RAM) + LENGTH(RAM) - __stack_size :
+    {
+        PROVIDE( _heap_end = . );
+        . = ALIGN(4);
+        PROVIDE(_susrstack = . );
+        . = . + __stack_size;
+        PROVIDE( _eusrstack = .);
+    } >RAM
+
+}


### PR DESCRIPTION
Could you please add support for CH32X035?

These codes were copied from MounRiver_Studio_Community_V150.
http://www.mounriver.com/download
http://file.mounriver.com/upgrade/MounRiver_Studio_Community_Linux_x64_V150.tar.xz
template/wizard/WCH/RISC-V/CH32X035

GitHub https://github.com/openwch/ch32x035/tree/main/C%2B%2B/Use%20MRS%20Create%20C%2B%2B%20project-example/CH32V203C8T6%2B%2B has an incorrect The code was committed.
This is expected to be fixed eventually.

The following edits are made.

- Added User/ch32x035_conf.h to Peripheral/ch32x035
- Removed the line `#include "ch32x035_it.h"` from Peripheral/ch32x035/inc/ch32x035_conf.h

Directory names such as ch32v20x were being used without the "x" as ch32x035.

We have confirmed that it actually builds and works on the CH32X035 development board.
https://github.com/74th/ch32x035-testing/tree/main/blink-pio