### PR TITLE
Add dbgmcu functions for UID and FlashSize registers

### DIFF
--- a/Peripheral/ch32v00x/inc/ch32v00x_dbgmcu.h
+++ b/Peripheral/ch32v00x/inc/ch32v00x_dbgmcu.h
@@ -27,6 +27,10 @@ extern "C" {
 
 uint32_t DBGMCU_GetREVID(void);
 uint32_t DBGMCU_GetDEVID(void);
+uint32_t DBGMCU_GetMCUUID1(void);
+uint32_t DBGMCU_GetMCUUID2(void);
+uint32_t DBGMCU_GetMCUUID3(void);
+uint16_t DBGMCU_GetMCUFlashSize(void);
 uint32_t __get_DEBUG_CR(void);
 void __set_DEBUG_CR(uint32_t value);
 void DBGMCU_Config(uint32_t DBGMCU_Periph, FunctionalState NewState);

--- a/Peripheral/ch32v00x/src/ch32v00x_dbgmcu.c
+++ b/Peripheral/ch32v00x/src/ch32v00x_dbgmcu.c
@@ -39,6 +39,54 @@ uint32_t DBGMCU_GetDEVID(void)
 }
 
 /*********************************************************************
+ * @fn      DBGMCU_GetMCUUID1
+ *
+ * @brief   Returns the 0-31 digits of UID.
+ *
+ * @return  Device unique ID.
+ */
+uint32_t DBGMCU_GetMCUUID1(void)
+{
+    return(*(uint32_t *)0x1FFFF7E8);
+}
+
+/*********************************************************************
+ * @fn      DBGMCU_GetMCUUID2
+ *
+ * @brief   Returns the 32-63 digits of UID.
+ *
+ * @return  Device unique ID.
+ */
+uint32_t DBGMCU_GetMCUUID2(void)
+{
+    return(*(uint32_t *)0x1FFFF7EC);
+}
+
+/*********************************************************************
+ * @fn      DBGMCU_GetMCUUID3
+ *
+ * @brief   Returns the 64-95 digits of UID.
+ *
+ * @return  Device unique ID.
+ */
+uint32_t DBGMCU_GetMCUUID3(void)
+{
+    return(*(uint32_t *)0x1FFFF7F0);
+}
+
+/*********************************************************************
+ * @fn      DBGMCU_GetMCUFlashSize
+ *
+ * @brief   Returns flash capacity in Kbyte (Example: 0x0080 = 128 Kb)
+ *
+ * @return  Device flash capacity.
+ */
+uint16_t DBGMCU_GetMCUFlashSize(void)
+{
+    return(*(uint16_t *)0x1FFFF7E0);
+}
+
+/*********************************************************************
  * @fn      __get_DEBUG_CR
  *
  * @brief   Return the DEBUGE Control Register


### PR DESCRIPTION
Hello, 

A little PR to add functions for UID and FlashSize registers.
Tested on CH32V003F4P6 official board.
For the UID, the datasheet adverts a 64bit unique ID, but there's 3 UID registers (it's 96 bits not 64).
After testing all of them, only the first and second have data (the third is full of '1').
 