### PR TITLE
add fix rtthread entry point for ch32v4x7

### DIFF
--- a/Startup/startup_ch32v4x7.S
+++ b/Startup/startup_ch32v4x7.S
@@ -382,7 +382,12 @@ handle_reset:
 	csrw mtvec, t0
 
     jal  SystemInit
+	#if defined(__PIO_BUILD_RT_THREAD__)
+	/* RT-Thread has special entry point, it will call our main() later */
+	la t0, entry
+	#else
 	la t0, main
+	#endif
 	csrw mepc, t0
 	mret
 


### PR DESCRIPTION
tested on the CH32V407VET-R0 board.

>  \ | /
> - RT -     Thread Operating System
>  / | \     3.1.3 build Jun 28 2026
>  2006 - 2019 Copyright by rt-thread team
> 
>  MCU: CH32V307
> SystemClk:200000000
> DeviceID: 00004670
>  www.wch.cn